### PR TITLE
[Minor] Fix an error in a Markdown formatted character in the document.

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -311,7 +311,7 @@ LargeFireDistances=0.4375           ; list of floating point values, distance in
 ```
 
 ```{note}
-Save for the change that `Flamer? does not spawn animations if the parent animation is in air, the default settings should provide identical results to similar feature from Ares.
+Save for the change that `Flamer` does not spawn animations if the parent animation is in air, the default settings should provide identical results to similar feature from Ares.
 ```
 
 ### Layer on animations attached to objects


### PR DESCRIPTION
&grave;Flamer? -> `Flamer`
A very minor error that affects users' reading and comprehension.
It made me wait for two months without seeing anyone fix it.
So, I decided to take care of it myself.
That's all.