### PR TITLE
重新组织文档的全局部分

### DIFF
--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -86,7 +86,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed railgun particles being drawn to wrong coordinate against buildings with non-default `TargetCoordOffset` or when force-firing on bridges.
 - Fixed building `TargetCoordOffset` not being taken into accord for several things like fire angle calculations and target lines.
 - In singleplayer missions, the player can now see cloaked objects owned by allied houses.
-- IvanBomb images can now display and the bombs detonate at center of buildings instead of in top-leftmost cell of the building foundation if `[CombatDamage] -> IvanBombAttachToCenter` is set to true.
 - Fixed BibShape drawing for a couple of frames during buildup for buildings with long buildup animations.
 - Animation with `Tiled=yes` now supports `CustomPalette`.
 - Attempted to avoid units from retaining previous orders (attack,grind,garrison,etc) after changing ownership (mind-control,abduction,etc).
@@ -120,7 +119,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Fixed `DeployToFire` not recalculating firer's position on land if it cannot currently deploy.
 - `Arcing=true` projectile elevation inaccuracy can now be fixed by setting `Arcing.AllowElevationInaccuracy=false`.
 - Wall overlays are now drawn with the custom palette defined in `Palette` in `artmd.ini` if possible.
-- If `[CombatDamage] -> AllowWeaponSelectAgainstWalls` is set to true, `Secondary` will now be used against walls if `Primary` weapon Warhead has `Wall=false`, `Secondary` has `Wall=true` and the firer does not have `NoSecondaryWeaponFallback` set to true.
 - Setting `ReloadInTransport` to true on units with `Ammo` will allow the ammo to be reloaded according to `Reload` or `EmptyReload` timers even while the unit is inside a transport.
 - It is now possible to enable `Verses` and `PercentAtMax` to be applied on negative damage by setting `ApplyModifiersOnNegativeDamage` to true on the Warhead.
 - Attached animations on flying units now have their layer updated immediately after the parent unit, if on same layer they always draw above the parent.
@@ -149,7 +147,6 @@ This page describes all ingame logics that are fixed or improved in Phobos witho
 - Units with `Sensors=true` will no longer reveal ally buildings.
 - Air units are now reliably included by target scan with large range and Warhead detonation by large `CellSpread`.
 - OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini` entry.
-- Setting `[AudioVisual] -> ColorAddUse8BitRGB` to true makes game treat values from `[ColorAdd]` as 8-bit RGB (0-255) instead of RGB565 (0-31 for red & blue, 0-63 for green). This works for `LaserTargetColor`, `IronCurtainColor`, `BerserkColor` and `ForceShieldColor`.
 - Weapons with `AA=true` Projectile can now correctly fire at air units when both firer and target are over a bridge.
 - Fixed disguised units not using the correct palette if target has custom palette.
 - Building upgrades now consistently use building's `PowerUpN` animation settings corresponding to the upgrade's `PowersUpToLevel` where possible.
@@ -318,6 +315,286 @@ The described behavior is a replica of and is compliant with XNA CnCNet Client's
 
 ```{note}
 At the moment this is only useful if you use a version of [YRpp Spawner](https://github.com/CnCNet/yrpp-spawner) with multiplayer saves support (along with [XNA CnCNet Client](https://github.com/CnCNet/xna-cncnet-client)).
+```
+
+## Newly added global settings
+
+```{note}
+This category lists all features that are globally effective without needing to be defined on any specific object.
+```
+
+<!--
+
+It was originally planned to list global features that are exclusively related to specific Types, such as [Voxel light source customization](https://phobos.readthedocs.io/en/latest/Fixed-or-Improved-Logics.html#voxel-light-source-customization) and [Customizing effect of level lighting on air units](https://phobos.readthedocs.io/en/latest/Fixed-or-Improved-Logics.html#customizing-effect-of-level-lighting-on-air-units), under the corresponding Types categories. But later, features like [Veinholes & Weeds](https://phobos.readthedocs.io/en/latest/Fixed-or-Improved-Logics.html#veinholes-weeds) were found to be too difficult to separate, so they were just summarized according to the locations where INI flags are written. After all, the end users are modders.
+
+-->
+
+### Crate improvements
+
+There are some improvements on goodie crate logic:
+- The statistic distribution of the randomly generated crates is now more uniform within the visible map region by using an optimized sampling procedure.
+- You can now limit the crates' spawn region to land only by setting `[CrateRules] -> CreateOnlyOnLand` to true.
+- The limit of vehicles a player can own before unit crates start giving money instead can now be customized by setting `UnitCrateVehicleCap`. Negative numbers disable the cap entirely.
+- `FreeMCV` setting is now actually respected and can be used to disable the forced unit selected from `[General] -> BaseUnit` that is given if player picks a crate and has enough credits but no existing buildings or `BaseUnit` vehicles.
+  - The previously hardcoded credits threshold that must be passed can also now be customized via `FreeMCV.CreditsThreshold`.
+
+In `rulesmd.ini`:
+```ini
+[CrateRules]
+CrateOnlyOnLand=false          ; boolean
+UnitCrateVehicleCap=50         ; integer
+FreeMCV=true                   ; boolean
+FreeMCV.CreditsThreshold=1500  ; integer
+```
+
+### Customizable unit image in art
+
+- `Image` tag in art INI is no longer limited to AnimationTypes and BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, VehicleTypes, AircraftTypes, BuildingTypes).
+- The tag specifies **only** the file name (without extension) of the asset that replaces TechnoType's graphics. If the name in `Image` is also an entry in the art INI, **no tags will be read from it**.
+- **By default this feature is disabled** to remain compatible with YR. To use this feature, enable it in rules with `ArtImageSwap=true`.
+- This feature supports SHP images for InfantryTypes, SHP and VXL images for VehicleTypes and VXL images for AircraftTypes.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ArtImageSwap=false  ; disabled by default
+```
+
+```{warning}
+To use this feature properly, you need to remove or replace the following segments in the YR INI code to avoid compatibility issues between the original Westwood INI code and this feature.
+```
+
+In `artmd.ini`:
+```ini
+[CAML]
+Image=JOSH
+
+[BFRT]
+Image=SREF
+```
+
+```{hint}
+In vanilla, `[CLNT]` does not have its own image. Originally, in `artmd.ini`, it uses another image placeholder via `Image=ARND`, but due to the lack of this feature, it has no effect. Subsequently, it and `[UTNK]` etc. also switch to using `rulesmd.ini` to call image resources; however, unlike other art sections which merely changed the implementation method, it not only changes the implementation method but also switches to using `Image=CIVC` instead of `ARND`. Although this does not directly manifest as a conflict when `[General] -> ArtImageSwap=true`, modders may need to pay attention.
+```
+
+### Customize resource storage
+
+- Now Ares `Storage` feature can set which Tiberium type from `[Tiberiums]` list should be used for storing resources in structures with `Refinery.UseStorage=yes` and `Storage` > 0.
+- This tag can not be used without Ares.
+
+In `rulesmd.ini`:
+```ini
+[General]
+Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index
+```
+
+### Customizing effect of level lighting on air units
+
+- It is now possible to customize how air units are affected by level lighting, separately for AircraftTypes and infantry/vehicles with Jumpjet `Locomotor`.
+  - `AircraftLevelLightMultiplier` & `JumpjetLevelLightMultiplier` are direct multipliers to level lighting applied on the units, for height levels above the cell they are on.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+AircraftLevelLightMultiplier=1.0  ; floating point value, percents or absolute
+JumpjetLevelLightMultiplier=0.0   ; floating point value, percents or absolute
+```
+
+### Customizing default ColorScheme
+
+- In vanilla, an `AltPalette=yes` animation or `Voxel=yes` Projectile image that cannot properly remap will use the first Color Scheme in the `[Colors]` list; now it can be manually specified.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+AnimRemapDefaultColorScheme=      ; ColorScheme name
+```
+
+### Iron Curtain & Force Shield extra tint intensity
+
+- It is now possible to specify additional tint intensity applied to Iron Curtained and Force Shielded units.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+IronCurtain.ExtraTintIntensity=0.0  ; floating point value
+ForceShield.ExtraTintIntensity=0.0  ; floating point value
+```
+
+### Move IvanBomb Position
+
+In vanilla, IvanBomb images display and the bombs detonate at the top-leftmost cell of the building foundation instead of at the center of buildings. This can now be changed.
+
+In `rulesmd.ini`:
+```ini
+[CombatDamage]
+IvanBombAttachToCenter=false  ; boolean
+```
+
+```{warning}
+Due to technical constraints this cannot be customized per WeaponType.
+```
+
+### RadialIndicator visibility
+
+In vanilla game, a structure's radial indicator can be drawn only when it belongs to the player. Now it can also be visible to observer.
+On top of that, you can specify its visibility from other houses.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+RadialIndicatorVisibility=allies  ; List of Affected House Enumeration (owner/self | allies/ally | enemies/enemy | all)
+```
+
+### Re-enable obsolete `[JumpjetControls]`
+
+- Re-enable obsolete `[JumpjetControls]`, the keys in it will be as the default value of jumpjet units.
+  - Moreover, added two tags for missing ones.
+
+In `rulesmd.ini`:
+```ini
+[JumpjetControls]
+Crash=5.0        ; floating point value
+NoWobbles=false  ; boolean
+```
+
+```{note}
+`CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no Jumpjet prefix.
+```
+
+### Skirmish AI behavior dehardcode
+
+- In vanilla, there is a hardcoded behavior that when an skirmish AI player has no factory and has not taken damage for a while, it will sell its buildings and set its units to hunt. This can be customized now.
+  - `[General] -> AIFireSale` and `[General] -> AIAllToHunt` control whether the AI will act selling and hunting respectively.
+  - `[General] -> AIFireSaleDelay` defines a timer, it will only work if `[General] -> AIFireSale` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
+  - You can use these flags to make the AIs "all in" before they are defeated.
+- Another hardcoded behavior is that, when the AI deploys a MCV, it will gather all of its forces to that place. This can be toggle off now.
+  - `[General] -> GatherWhenMCVDeploy` controls this behavior.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AIFireSale=true           ; boolean
+AIFireSaleDelay=0         ; integer, number of frames
+AIAllToHunt=true          ; boolean
+GatherWhenMCVDeploy=true  ; boolean
+```
+
+### Use 8-bit RGB parameters for `[ColorAdd]`
+
+- In vanilla, the values in the `[ColorAdd]` entry are used as RGB565 (0-31 for red & blue, 0-63 for green). Now, with this setting, you can use the more user-friendly 8-bit RGB (0-255) for input.
+- This works for `LaserTargetColor`, `IronCurtainColor`, `BerserkColor` and `ForceShieldColor`.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+ColorAddUse8BitRGB=false  ; boolean
+```
+
+### Veinholes & Weeds
+
+#### Veinholes
+
+- Veinhole monsters now work like they used to in Tiberian Sun.
+- Their core parameters are still loaded from `[General]`.
+- The Warhead used by veins is specified under `[CombatDamage]`. The warhead has to have `Veinhole=yes` set.
+- Veinholes are hardcoded to use several overlay types.
+- The vein attack animation specified under `[AudioVisual]` is what deals the damage. The animation has to be properly listed under `[Animations]` as well.
+- Units can be made immune to veins the same way as in Tiberian Sun.
+- The monster itself is represented by the `VEINTREE` TerrainType, which has `IsVeinhole=true` set. Its strength is what determines the strength of the Veinhole.
+
+```{note}
+Everything listed below functions identically to Tiberian Sun.
+Many of the tags from Tiberian Sun have been re-enabled. The values provided below are identical to those found in TS and YR rules. You can read more about them on ModENC:
+[VeinholeGrowthRate](https://modenc.renegadeprojects.com/VeinholeGrowthRate), [VeinholeShrinkRate](https://modenc.renegadeprojects.com/VeinholeShrinkRate), [MaxVeinholeGrowth](https://modenc.renegadeprojects.com/MaxVeinholeGrowth), [VeinDamage](https://modenc.renegadeprojects.com/VeinDamage), [VeinholeTypeClass](https://modenc.renegadeprojects.com/VeinholeTypeClass),
+[VeinholeWarhead](https://modenc.renegadeprojects.com/VeinholeWarhead), [Veinhole](https://modenc.renegadeprojects.com/Veinhole), [VeinAttack](https://modenc.renegadeprojects.com/VeinAttack), [ImmuneToVeins](https://modenc.renegadeprojects.com/ImmuneToVeins), [IsVeinhole](https://modenc.renegadeprojects.com/IsVeinhole)
+```
+
+In `rulesmd.ini`:
+```ini
+[General]
+VeinholeGrowthRate=300        ; integer
+VeinholeShrinkRate=100        ; integer
+MaxVeinholeGrowth=2000        ; integer
+VeinDamage=5                  ; integer
+VeinholeTypeClass=VEINTREE    ; TerrainType
+
+[CombatDamage]
+VeinholeWarhead=VeinholeWH    ; WarheadType
+
+[VeinholeWH]
+Veinhole=yes
+
+[AudioVisual]
+VeinAttack=VEINATAC           ; AnimationType
+
+[TechnoType]
+EliteAbilities=VEIN_PROOF
+ImmuneToVeins=yes
+
+[VEINTREE]
+IsVeinhole=true
+Strength=1000                 ; integer - the strength of the Veinhole
+```
+
+```{warning}
+The game expects certain overlays related to Veinholes to have certain indices, they are listed below. Please keep in mind that the indices in the OverlayTypes list are 0-based, formed internally by the game, and the identifiers left of "=" don't matter. Vanilla `rulesmd.ini` already has the required overlays listed at the correct indices.
+```
+
+In `rulesmd.ini`:
+```ini
+[OverlayTypes]
+126=VEINS                     ; The veins (weeds)
+167=VEINHOLE                  ; The Veinhole itself
+178=VEINHOLEDUMMY             ; A technical overlay
+```
+
+#### Weeds & Weed Eaters
+
+- Vehicles with `Weeder=yes` can now collect weeds. The weeds can then be deposited into a building with `Weeder=yes`.
+- Weeds are not stored in a building's storage, but rather in a House's storage. The weed capacity is listed under `[General] -> WeedCapacity`.
+- Weeders now show the ore gathering animation. It can be customized the same way as for harvesters.
+- Weeders can use the Teleport locomotor like chrono miners.
+- Total amount of weeds in storage can be displayed on sidebar, see [Weeds counter](User-Interface.md#weeds-counter).
+
+#### Weed-consuming superweapons
+
+- Superweapons can consume weeds to recharge, like the Chemical Missile special in Tiberian Sun.
+
+```{note}
+As the code for the Chemical Missile had been removed, setting `Type=ChemMissile` will not work.
+```
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]                                        ; SuperWeaponType
+UseWeeds=no                                     ; boolean - should the SW use weeds to recharge?
+UseWeeds.Amount=                                ; integer - how many? default is General->WeedCapacity
+UseWeeds.StorageTimer=no                        ; boolean - should the counter on the sidebar display the % of weeds stored?
+UseWeeds.ReadinessAnimationPercentage=0.9       ; double - when this many weeds % are stored, the SW will show it's ready on the building (open nuke/open chrono, etc.)
+```
+
+### Voxel light source customization
+
+![image](_static/images/VoxelLightSourceComparison1.png)
+![image](_static/images/VoxelLightSourceComparison2.png)
+*Voxel by <a class="reference external" href="https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index" target="_blank">C&CrispS</a>*
+
+- It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
+  - Only the direction of the light is accounted, the distance to the voxel is not accounted.
+  - Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly at `VoxelLightSource=0.201,-0.907,-0.362`.
+
+In `rulesmd.ini`:
+```ini
+[AudioVisual]
+UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting
+VoxelLightSource=            ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
+```
+
+```{hint}
+In order to easily preview the light source settings use the [VXL Viewer and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon/vxl-renderer/releases). To use the tool unpack it somewhere, then drag the main VXL file of a voxel that you will use to preview onto it (auxilliary VXL and HVA files must be in the same folder).
+
+Keep in mind that the tool doesn't account for `UseFixedVoxelLighting=true` as of yet, so the values shown in tool need to be offset when putting in the game with with fixed voxel lighting.
 ```
 
 ## Aircraft
@@ -1110,25 +1387,6 @@ ChronoRangeMinimum=     ; integer, can be used to set a small range within which
 ChronoDelay=            ; integer, delay after teleport for chronosphere
 ```
 
-### Customizable unit image in art
-
-- `Image` tag in art INI is no longer limited to AnimationTypes and BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, VehicleTypes, AircraftTypes, BuildingTypes).
-- The tag specifies **only** the file name (without extension) of the asset that replaces TechnoType's graphics. If the name in `Image` is also an entry in the art INI, **no tags will be read from it**.
-- **By default this feature is disabled** to remain compatible with YR. To use this feature, enable it in rules with `ArtImageSwap=true`.
-- This feature supports SHP images for InfantryTypes, SHP and VXL images for VehicleTypes and VXL images for AircraftTypes.
-
-In `rulesmd.ini`:
-```ini
-[General]
-ArtImageSwap=false  ; disabled by default
-```
-
-In `artmd.ini`:
-```ini
-[SOMETECHNO]        ; TechnoType
-Image=              ; name of the file that will be used as image, without extension
-```
-
 ### Customizable veterancy insignias
 
 - You can now customize veterancy insignia of TechnoTypes.
@@ -1224,29 +1482,6 @@ FallingDownDamage=              ; integer / percentage
 FallingDownDamage.Water=        ; integer / percentage
 ```
 
-### Customize resource storage
-
-- Now Ares `Storage` feature can set which Tiberium type from `[Tiberiums]` list should be used for storing resources in structures with `Refinery.UseStorage=yes` and `Storage` > 0.
-- This tag can not be used without Ares.
-
-In `rulesmd.ini`:
-```ini
-[General]
-Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index
-```
-
-### Customizing effect of level lighting on air units
-
-- It is now possible to customize how air units are affected by level lighting, separately for AircraftTypes and infantry/vehicles with Jumpjet `Locomotor`.
-  - `AircraftLevelLightMultiplier` & `JumpjetLevelLightMultiplier` are direct multipliers to level lighting applied on the units, for height levels above the cell they are on.
-
-In `rulesmd.ini`:
-```ini
-[AudioVisual]
-AircraftLevelLightMultiplier=1.0  ; floating point value, percents or absolute
-JumpjetLevelLightMultiplier=0.0   ; floating point value, percents or absolute
-```
-
 ### Damaged speed customization
 
 - In vanilla, units using drive/ship loco will has hardcoded speed multiplier when damaged. Now you can customize it.
@@ -1280,6 +1515,40 @@ How to generate `DebrisTypes` in the game:
 2. Traverse `DebrisTypes` and limit the quantity range through `DebrisMaximums` and `DebrisMinimums`.
 3. When the number of generated debris will exceeds the total number, limit the quantity and end the traversal.
 4. When the number of debris generated after a single traversal is not enough to exceed the total number, it will end if `DebrisTypes.Limit` is enabled, otherwise the traversal will restart like vanilla game do.
+```
+
+## DropPod
+
+- DropPod properties can now be customized on a per-TechnoType (non-building) basis.
+  - If you want to attach the trailer animation to the pod, set `DropPod.Trailer.Attached` to yes.
+  - By default LaserTrails that are attached to the infantry will not be drawn if it's on DropPod.
+    - If you really want to use it, set `DropPodOnly` on the LaserTrail's type entry in art.
+  - If you want `DropPod.Weapon` to be fired only upon hard landing, set `DropPod.Weapon.HitLandOnly` to true.
+  - The landing speed is not smaller than it's current height /10 + 2 for unknown reason. A small `DropPod.Speed` value therefore results in exponential deceleration.
+
+```{note}
+Due to technical constraints `DropPod.AirImage` is only drawn for InfantryTypes (as the DropPod is the infantry itself with its image swapped). This may change in future.
+```
+
+In `rulesmd.ini`:
+```ini
+[SOMETECHNO]                  ; TechnoType
+DropPod.Angle=                ; double, default to [General] -> DropPodAngle, measured in radians
+DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> AtmosphereEntry
+DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod
+DropPod.AirImage=             ; SHP file, the pod's shape, default to POD
+DropPod.Height=               ; int, default to [General] -> DropPodHeight
+DropPod.Puff=                 ; anim, default to [AudioVisual] -> DropPodPuff
+DropPod.Speed=                ; int, default to [General] -> DropPodSpeed
+DropPod.Trailer=              ; anim, default to [General] -> DropPodTrailer, which by default is SMOKEY
+DropPod.Trailer.Attached=     ; boolean, default to no
+DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn of DropPod.Trailer, default to 6
+DropPod.Weapon=               ; weapon, default to [General] -> DropPodWeapon
+DropPod.Weapon.HitLandOnly=   ; boolean, default to no
+```
+
+```{note}
+`[General] -> DropPodTrailer` is [Ares feature](https://ares-developers.github.io/Ares-docs/new/droppod.html).
 ```
 
 ### Exploding object customizations
@@ -1353,17 +1622,6 @@ IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill | invu
 IronCurtain.KillWarhead=           ; WarheadType, default to [CombatDamage] -> IronCurtain.KillOrganicsWarhead
 ForceShield.Effect=                ; IronCurtain effect Enumeration (kill | invulnerable | ignore)
 ForceShield.KillWarhead=           ; WarheadType, default to [CombatDamage] -> ForceShield.KillOrganicsWarhead
-```
-
-### Iron Curtain & Force Shield extra tint intensity
-
-- It is now possible to specify additional tint intensity applied to Iron Curtained and Force Shielded units.
-
-In `rulesmd.ini`:
-```ini
-[AudioVisual]
-IronCurtain.ExtraTintIntensity=0.0  ; floating point value
-ForceShield.ExtraTintIntensity=0.0  ; floating point value
 ```
 
 ### Jumpjet climbing logic enhancement
@@ -1474,40 +1732,6 @@ In `rulesmd.ini`:
 RadarInvisibleToHouse=               ; Affected House Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if RadarInvisible=true, none otherwise
 ```
 
-### Re-enable obsolete [JumpjetControls]
-
-- Re-enable obsolete `[JumpjetControls]`, the keys in it will be as the default value of jumpjet units.
-  - Moreover, added two tags for missing ones.
-
-In `rulesmd.ini`:
-```ini
-[JumpjetControls]
-Crash=5.0        ; floating point value
-NoWobbles=false  ; boolean
-```
-
-```{note}
-`CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for `JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and `Acceleration` is for `JumpjetAccel`. All other corresponding keys just simply have no Jumpjet prefix.
-```
-
-### Skirmish AI behavior dehardcode
-
-- In vanilla, there is a hardcoded behavior that when an skirmish AI player has no factory and has not taken damage for a while, it will sell its buildings and set its units to hunt. This can be customized now.
-  - `[General] -> AIFireSale` and `[General] -> AIAllToHunt` control whether the AI will act selling and hunting respectively.
-  - `[General] -> AIFireSaleDelay` defines a timer, it will only work if `[General] -> AIFireSale` is set to `true`. When the first time the AI reaches the trigger condition of vanilla behavior, the timer starts and prevents the selling behavior from happening until the timer is expired.
-  - You can use these flags to make the AIs "all in" before they are defeated.
-- Another hardcoded behavior is that, when the AI deploys a MCV, it will gather all of its forces to that place. This can be toggle off now.
-  - `[General] -> GatherWhenMCVDeploy` controls this behavior.
-
-In `rulesmd.ini`:
-```ini
-[General]
-AIFireSale=true           ; boolean
-AIFireSaleDelay=0         ; integer, number of frames
-AIAllToHunt=true          ; boolean
-GatherWhenMCVDeploy=true  ; boolean
-```
-
 ### Subterranean unit travel height and speed
 
 - It is now possible to control the height at which units with subterranean (Tunnel) `Locomotor` travel, globally or per TechnoType.
@@ -1567,34 +1791,6 @@ In `artmd.ini`:
 ShadowIndices=        ; List of integers (voxel section indices)
 ShadowIndex.Frame=0   ; integer (HVA animation frame index)
 ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)
-```
-
-### Voxel light source customization
-
-![image](_static/images/VoxelLightSourceComparison1.png)
-![image](_static/images/VoxelLightSourceComparison2.png)
-*Voxel by <a class="reference external" href="https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index" target="_blank">C&CrispS</a>, (Save and unzip the second image to obtain an example file including pal & vpl.)*
-
-- It is now possible to change the position of the light relative to the voxels. This allows for better lighting to be set up.
-  - Only the direction of the light is accounted, the distance to the voxel is not accounted.
-- Vanilla game applies some weird unnecessary math which resulted in the voxel light source being "nudged" up by a bit and light being applied incorrectly on tilted voxels. It is now possible to fix that.
-  - Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly at `VoxelLightSource=0.201,-0.907,-0.362`.
-
-```{note}
-Please note that enabling this will remove the vertical offset vanilla engine applies to the light source position. Assuming vanilla lighting this will make the light shine even more from below the ground than it was before, so it is recommended to turn the Z value up in value of `VoxelLightSource`.
-```
-
-In `rulesmd.ini`:
-```ini
-[AudioVisual]
-UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting
-VoxelLightSource=            ; X,Y,Z - position of the light in the world relative to each voxel, floating point values
-```
-
-```{hint}
-In order to easily preview the light source settings use the [VXL Viewer and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon/vxl-renderer/releases). To use the tool unpack it somewhere, then drag the main VXL file of a voxel that you will use to preview onto it (auxilliary VXL and HVA files must be in the same folder).
-
-Keep in mind that the tool doesn't account for `UseFixedVoxelLighting=true` as of yet, so the values shown in tool need to be offset when putting in the game with with fixed voxel lighting.
 ```
 
 ### Voxel shadow scaling in air
@@ -1747,6 +1943,16 @@ BunkerableAnyway=false     ; boolean
 
 ```{warning}
 Skipping checks with this feature doesn't mean that vehicles and tank bunkers will interact correctly. Following the simple checks performed by the provider of this feature, bunkerability is mainly determined by Locomotor. The details about locomotors' bunkerability can be found on [ModEnc](https://modenc.renegadeprojects.com/Bunkerable).
+```
+
+### Custom Unit Crate Reroll Chance
+
+- It is possible to influence weighting of units given from crates (`CrateGoodie=true`) via `CrateGoodie.RerollChance`, which determines the chance that if this type of unit is rolled, it will reroll again for another type of unit.
+
+In `rulesmd.ini`:
+```ini
+[SOMEVEHICLE]                  ; VehicleType
+CrateGoodie.RerollChance=0.0   ; floating point value, percents or absolute (0.0-1.0)
 ```
 
 ### Customize harvester dump amount
@@ -1956,89 +2162,6 @@ In `artmd.ini`:
 ```ini
 [SOMEVEHICLE]   ; VehicleType
 TurretShadow=   ; boolean
-```
-
-## Veinholes & Weeds
-
-### Veinholes
-
-- Veinhole monsters now work like they used to in Tiberian Sun.
-- Their core parameters are still loaded from `[General]`.
-- The Warhead used by veins is specified under `[CombatDamage]`. The warhead has to have `Veinhole=yes` set.
-- Veinholes are hardcoded to use several overlay types.
-- The vein attack animation specified under `[AudioVisual]` is what deals the damage. The animation has to be properly listed under `[Animations]` as well.
-- Units can be made immune to veins the same way as in Tiberian Sun.
-- The monster itself is represented by the `VEINTREE` TerrainType, which has `IsVeinhole=true` set. Its strength is what determines the strength of the Veinhole.
-
-```{note}
-Everything listed below functions identically to Tiberian Sun.
-Many of the tags from Tiberian Sun have been re-enabled. The values provided below are identical to those found in TS and YR rules. You can read more about them on ModENC:
-[VeinholeGrowthRate](https://modenc.renegadeprojects.com/VeinholeGrowthRate), [VeinholeShrinkRate](https://modenc.renegadeprojects.com/VeinholeShrinkRate), [MaxVeinholeGrowth](https://modenc.renegadeprojects.com/MaxVeinholeGrowth), [VeinDamage](https://modenc.renegadeprojects.com/VeinDamage), [VeinholeTypeClass](https://modenc.renegadeprojects.com/VeinholeTypeClass),
-[VeinholeWarhead](https://modenc.renegadeprojects.com/VeinholeWarhead), [Veinhole](https://modenc.renegadeprojects.com/Veinhole), [VeinAttack](https://modenc.renegadeprojects.com/VeinAttack), [ImmuneToVeins](https://modenc.renegadeprojects.com/ImmuneToVeins), [IsVeinhole](https://modenc.renegadeprojects.com/IsVeinhole)
-```
-
-In `rulesmd.ini`:
-```ini
-[General]
-VeinholeGrowthRate=300        ; integer
-VeinholeShrinkRate=100        ; integer
-MaxVeinholeGrowth=2000        ; integer
-VeinDamage=5                  ; integer
-VeinholeTypeClass=VEINTREE    ; TerrainType
-
-[CombatDamage]
-VeinholeWarhead=VeinholeWH    ; WarheadType
-
-[VeinholeWH]
-Veinhole=yes
-
-[AudioVisual]
-VeinAttack=VEINATAC           ; AnimationType
-
-[TechnoType]
-EliteAbilities=VEIN_PROOF
-ImmuneToVeins=yes
-
-[VEINTREE]
-IsVeinhole=true
-Strength=1000                 ; integer - the strength of the Veinhole
-```
-
-```{warning}
-The game expects certain overlays related to Veinholes to have certain indices, they are listed below. Please keep in mind that the indices in the OverlayTypes list are 0-based, formed internally by the game, and the identifiers left of "=" don't matter. Vanilla `rulesmd.ini` already has the required overlays listed at the correct indices.
-```
-
-In `rulesmd.ini`:
-```ini
-[OverlayTypes]
-126=VEINS                     ; The veins (weeds)
-167=VEINHOLE                  ; The Veinhole itself
-178=VEINHOLEDUMMY             ; A technical overlay
-```
-
-### Weeds & Weed Eaters
-
-- Vehicles with `Weeder=yes` can now collect weeds. The weeds can then be deposited into a building with `Weeder=yes`.
-- Weeds are not stored in a building's storage, but rather in a House's storage. The weed capacity is listed under `[General] -> WeedCapacity`.
-- Weeders now show the ore gathering animation. It can be customized the same way as for harvesters.
-- Weeders can use the Teleport locomotor like chrono miners.
-- Total amount of weeds in storage can be displayed on sidebar, see [Weeds counter](User-Interface.md#weeds-counter).
-
-### Weed-consuming superweapons
-
-- Superweapons can consume weeds to recharge, like the Chemical Missile special in Tiberian Sun.
-
-```{note}
-As the code for the Chemical Missile had been removed, setting `Type=ChemMissile` will not work.
-```
-
-In `rulesmd.ini`:
-```ini
-[SOMESW]                                        ; SuperWeaponType
-UseWeeds=no                                     ; boolean - should the SW use weeds to recharge?
-UseWeeds.Amount=                                ; integer - how many? default is General->WeedCapacity
-UseWeeds.StorageTimer=no                        ; boolean - should the counter on the sidebar display the % of weeds stored?
-UseWeeds.ReadinessAnimationPercentage=0.9       ; double - when this many weeds % are stored, the SW will show it's ready on the building (open nuke/open chrono, etc.)
 ```
 
 ## VoxelAnims
@@ -2381,71 +2504,4 @@ TypeSelectUseIFVMode=false   ; boolean
 
 [SOMEVEHICLE]                ; VehicleType
 WeaponGroupAsN=              ; string, default to N if [General] -> TypeSelectUseIFVMode=true, and 0 if false
-```
-
-## RadialIndicator visibility
-
-In vanilla game, a structure's radial indicator can be drawn only when it belongs to the player. Now it can also be visible to observer.
-On top of that, you can specify its visibility from other houses.
-
-In `rulesmd.ini`:
-```ini
-[AudioVisual]
-RadialIndicatorVisibility=allies  ; List of Affected House Enumeration (owner/self | allies/ally | enemies/enemy | all)
-```
-
-## Crate improvements
-
-There are some improvements on goodie crate logic:
-- The statistic distribution of the randomly generated crates is now more uniform within the visible map region by using an optimized sampling procedure.
-- You can now limit the crates' spawn region to land only by setting `[CrateRules] -> CreateOnlyOnLand` to true.
-- The limit of vehicles a player can own before unit crates start giving money instead can now be customized by setting `UnitCrateVehicleCap`. Negative numbers disable the cap entirely.
-- `FreeMCV` setting is now actually respected and can be used to disable the forced unit selected from `[General] -> BaseUnit` that is given if player picks a crate and has enough credits but no existing buildings or `BaseUnit` vehicles.
-  - The previously hardcoded credits threshold that must be passed can also now be customized via `FreeMCV.CreditsThreshold`.
-- It is possible to influence weighting of units given from crates (`CrateGoodie=true`) via `CrateGoodie.RerollChance`, which determines the chance that if this type of unit is rolled, it will reroll again for another type of unit.
-
-In `rulesmd.ini`:
-```ini
-[CrateRules]
-CrateOnlyOnLand=false          ; boolean
-UnitCrateVehicleCap=50         ; integer
-FreeMCV=true                   ; boolean
-FreeMCV.CreditsThreshold=1500  ; integer
-
-[SOMEVEHICLE]                  ; VehicleType
-CrateGoodie.RerollChance=0.0   ; floating point value, percents or absolute (0.0-1.0)
-```
-
-## DropPod
-
-- DropPod properties can now be customized on a per-TechnoType (non-building) basis.
-  - If you want to attach the trailer animation to the pod, set `DropPod.Trailer.Attached` to yes.
-  - By default LaserTrails that are attached to the infantry will not be drawn if it's on DropPod.
-    - If you really want to use it, set `DropPodOnly` on the LaserTrail's type entry in art.
-  - If you want `DropPod.Weapon` to be fired only upon hard landing, set `DropPod.Weapon.HitLandOnly` to true.
-  - The landing speed is not smaller than it's current height /10 + 2 for unknown reason. A small `DropPod.Speed` value therefore results in exponential deceleration.
-
-```{note}
-Due to technical constraints `DropPod.AirImage` is only drawn for InfantryTypes (as the DropPod is the infantry itself with its image swapped). This may change in future.
-```
-
-In `rulesmd.ini`:
-```ini
-[SOMETECHNO]                  ; TechnoType
-DropPod.Angle=                ; double, default to [General] -> DropPodAngle, measured in radians
-DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> AtmosphereEntry
-DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod
-DropPod.AirImage=             ; SHP file, the pod's shape, default to POD
-DropPod.Height=               ; int, default to [General] -> DropPodHeight
-DropPod.Puff=                 ; anim, default to [AudioVisual] -> DropPodPuff
-DropPod.Speed=                ; int, default to [General] -> DropPodSpeed
-DropPod.Trailer=              ; anim, default to [General] -> DropPodTrailer, which by default is SMOKEY
-DropPod.Trailer.Attached=     ; boolean, default to no
-DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn of DropPod.Trailer, default to 6
-DropPod.Weapon=               ; weapon, default to [General] -> DropPodWeapon
-DropPod.Weapon.HitLandOnly=   ; boolean, default to no
-```
-
-```{note}
-`[General] -> DropPodTrailer` is [Ares feature](https://ares-developers.github.io/Ares-docs/new/droppod.html).
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -329,6 +329,31 @@ It was originally planned to list global features that are exclusively related t
 
 -->
 
+### Allow deploy controlled MCV
+
+In vanilla, you cannot deploy a controlled vehicle to `ConstructionYard=true` building. Now you can customize it.
+
+In `rulesmd.ini`:
+```ini
+[General]
+AllowDeployControlledMCV=false   ; boolean
+```
+
+### Chrono sparkle animation customization & improvements
+
+- It is now possible to customize the frame delay between instances of `[General] -> ChronoSparkle1` animations created on objects being warped by setting `[General] -> ChronoSparkleDisplayDelay`.
+- By default on buildings with `MaxNumberOccupants` higher than 0, chrono sparkle animation would be shown at each of the `MuzzleFlashX` coordinates. This behaviour is now customizable, and supports `MuzzleFlashX` indices higher than 10.
+  - `[General] -> ChronoSparkleBuildingDisplayPositions` can be set to show the sparkle animation on the building (`building`), muzzle flash coordinates of current occupants (`occupants`), muzzle flash coordinates of all occupant slots (`occupantslots`) or any combination of these.
+    - If `occupants` or `occupantslots` is listed without `building`, a single chrono sparkle animation is still displayed on building if it doesn't have any occupants or it has `MaxNumberOccupants` value less than 1, respectively.
+- The chrono sparkle animation that is displayed on building itself is also now displayed at the center of it rather than at center of its topmost cell.
+
+In `rulesmd.ini`:
+```ini
+[General]
+ChronoSparkleDisplayDelay=24                         ; integer, game frames
+ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono sparkle position enum (building | occupants | occupantslots | all)
+```
+
 ### Crate improvements
 
 There are some improvements on goodie crate logic:
@@ -388,6 +413,17 @@ In `rulesmd.ini`:
 Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index
 ```
 
+### Customize the chained damage of the wall
+
+- In vanilla, when the wall is damaged, it will deal 200 damage to the walls in the 4 nearby cells. This makes connected walls more vulnerable to damage compared to single walls.
+- Now you can customize that damage by using the following flag.
+
+In `rulesmd.ini`:
+```ini
+[CombatDamage]
+AdjacentWallDamage=200  ; integer
+```
+
 ### Customizing effect of level lighting on air units
 
 - It is now possible to customize how air units are affected by level lighting, separately for AircraftTypes and infantry/vehicles with Jumpjet `Locomotor`.
@@ -419,6 +455,19 @@ In `rulesmd.ini`:
 [AudioVisual]
 IronCurtain.ExtraTintIntensity=0.0  ; floating point value
 ForceShield.ExtraTintIntensity=0.0  ; floating point value
+```
+
+### Jumpjet climbing logic enhancement
+
+- You can now let the jumpjets increase their height earlier by set `JumpjetClimbPredictHeight` to true. The jumpjet will raise its height 5 cells in advance, instead of only raising its height when encountering cliffs or buildings in front of it.
+- You can also let them simply skip the stop check by set `JumpjetClimbWithoutCutOut` to true. The jumpjet will not stop moving horizontally when encountering cliffs or buildings in front of it, but will continue to move forward while raising its altitude.
+  - When `JumpjetClimbPredictHeight` is enabled, if the height raised five grids in advance is still not enough to cross cliffs or buildings, it will stop and move horizontally as before, unless `JumpjetClimbWithoutCutOut` is also enabled.
+
+In `rulesmd.ini`:
+```ini
+[General]
+JumpjetClimbPredictHeight=false  ; boolean
+JumpjetClimbWithoutCutOut=false  ; boolean
 ```
 
 ### Move IvanBomb Position
@@ -595,6 +644,16 @@ VoxelLightSource=            ; X,Y,Z - position of the light in the world relati
 In order to easily preview the light source settings use the [VXL Viewer and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon/vxl-renderer/releases). To use the tool unpack it somewhere, then drag the main VXL file of a voxel that you will use to preview onto it (auxilliary VXL and HVA files must be in the same folder).
 
 Keep in mind that the tool doesn't account for `UseFixedVoxelLighting=true` as of yet, so the values shown in tool need to be offset when putting in the game with with fixed voxel lighting.
+```
+
+### Waypoints for buildings
+
+- In vanilla, buildings are forbidden to use waypoints. Now you can allow that using the following flag.
+
+In `rulesmd.ini`:
+```ini
+[General]
+BuildingWaypoints=false  ; boolean
 ```
 
 ## Aircraft
@@ -1031,16 +1090,6 @@ Units.RepairPercent=  ; floating point value, percents or absolute, default to [
 Units.UseRepairCost=  ; boolean
 ```
 
-### Waypoints for buildings
-
-- In vanilla, buildings are forbidden to use waypoints. Now you can allow that using the following flag.
-
-In `rulesmd.ini`:
-```ini
-[General]
-BuildingWaypoints=false  ; boolean
-```
-
 ### Customize if cloning need power
 
 - In vanilla, cloning vats can work fine even low power. Starting from Ares 2.0, they need power to work. Now you can specific it.
@@ -1081,17 +1130,6 @@ ProneSpeed=                   ; floating point value, multiplier, by default, us
 ```
 
 ## Overlays
-
-### Customize the chained damage of the wall
-
-- In vanilla, when the wall is damaged, it will deal 200 damage to the walls in the 4 nearby cells. This makes connected walls more vulnerable to damage compared to single walls.
-- Now you can customize that damage by using the following flag.
-
-In `rulesmd.ini`:
-```ini
-[CombatDamage]
-AdjacentWallDamage=200  ; integer
-```
 
 ## Particle systems
 
@@ -1300,21 +1338,6 @@ Pips.SelfHeal.Buildings.Offset=15,10    ; X,Y, pixels relative to default
 
 [SOMETECHNO]                            ; TechnoType
 SelfHealGainType=                       ; Self-Heal Gain Type Enumeration (noheal|infantry|units)
-```
-
-### Chrono sparkle animation customization & improvements
-
-- It is now possible to customize the frame delay between instances of `[General] -> ChronoSparkle1` animations created on objects being warped by setting `[General] -> ChronoSparkleDisplayDelay`.
-- By default on buildings with `MaxNumberOccupants` higher than 0, chrono sparkle animation would be shown at each of the `MuzzleFlashX` coordinates. This behaviour is now customizable, and supports `MuzzleFlashX` indices higher than 10.
-  - `[General] -> ChronoSparkleBuildingDisplayPositions` can be set to show the sparkle animation on the building (`building`), muzzle flash coordinates of current occupants (`occupants`), muzzle flash coordinates of all occupant slots (`occupantslots`) or any combination of these.
-    - If `occupants` or `occupantslots` is listed without `building`, a single chrono sparkle animation is still displayed on building if it doesn't have any occupants or it has `MaxNumberOccupants` value less than 1, respectively.
-- The chrono sparkle animation that is displayed on building itself is also now displayed at the center of it rather than at center of its topmost cell.
-
-In `rulesmd.ini`:
-```ini
-[General]
-ChronoSparkleDisplayDelay=24                         ; integer, game frames
-ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono sparkle position enum (building | occupants | occupantslots | all)
 ```
 
 ### Customizable ChronoSphere teleport delays for units
@@ -1622,19 +1645,6 @@ IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill | invu
 IronCurtain.KillWarhead=           ; WarheadType, default to [CombatDamage] -> IronCurtain.KillOrganicsWarhead
 ForceShield.Effect=                ; IronCurtain effect Enumeration (kill | invulnerable | ignore)
 ForceShield.KillWarhead=           ; WarheadType, default to [CombatDamage] -> ForceShield.KillOrganicsWarhead
-```
-
-### Jumpjet climbing logic enhancement
-
-- You can now let the jumpjets increase their height earlier by set `JumpjetClimbPredictHeight` to true. The jumpjet will raise its height 5 cells in advance, instead of only raising its height when encountering cliffs or buildings in front of it.
-- You can also let them simply skip the stop check by set `JumpjetClimbWithoutCutOut` to true. The jumpjet will not stop moving horizontally when encountering cliffs or buildings in front of it, but will continue to move forward while raising its altitude.
-  - When `JumpjetClimbPredictHeight` is enabled, if the height raised five grids in advance is still not enough to cross cliffs or buildings, it will stop and move horizontally as before, unless `JumpjetClimbWithoutCutOut` is also enabled.
-
-In `rulesmd.ini`:
-```ini
-[General]
-JumpjetClimbPredictHeight=false  ; boolean
-JumpjetClimbWithoutCutOut=false  ; boolean
 ```
 
 ### Jumpjet rotating on crashing toggle
@@ -2494,31 +2504,4 @@ In `rulesmd.ini`:
 ```ini
 [SOMEWEAPON]         ; WeaponType
 IsSingleColor=false  ; boolean
-```
-
-## Allow deploy controlled MCV
-
-In vanilla, you cannot deploy a controlled vehicle to `ConstructionYard=true` building. Now you can customize it.
-
-In `rulesmd.ini`:
-```ini
-[General]
-AllowDeployControlledMCV=false   ; boolean
-```
-
-## Customize type selection for IFV
-
-In vanilla game, when using type selection command on IFVs, all of them will be selected regardless of their current modes, which is allowed to customize now.
-- `WeaponGroupAsN` determines which group the IFV is in when enabling `WeaponN`, where N stands for 1-based weapon mode index. IFVs in the same group will be selected together during type a selection, while not included those in different groups.
-- `TypeSelectUseIFVMode` determines whether all IFV modes will be considered as its own group by default during a type selection.
-  - If it's set to true, `WeaponGroupAsN` will be default to N for each `WeaponN`, which makes each of them become a standalone type during a type selection.
-  - If it's set to false, `WeaponGroupAsN` will be default to 0 for all weapons, which makes type selection on IFVs work the same as before.
-
-In `rulesmd.ini`:
-```ini
-[General]
-TypeSelectUseIFVMode=false   ; boolean
-
-[SOMEVEHICLE]                ; VehicleType
-WeaponGroupAsN=              ; string, default to N if [General] -> TypeSelectUseIFVMode=true, and 0 if false
 ```

--- a/docs/Fixed-or-Improved-Logics.md
+++ b/docs/Fixed-or-Improved-Logics.md
@@ -1969,6 +1969,23 @@ HarvesterDumpAmount=0.0               ; float point value
 HarvesterDumpAmount=                  ; float point value
 ```
 
+### Customize type selection for IFV
+
+In vanilla game, when using type selection command on IFVs, all of them will be selected regardless of their current modes, which is allowed to customize now.
+- `WeaponGroupAsN` determines which group the IFV is in when enabling `WeaponN`, where N stands for 1-based weapon mode index. IFVs in the same group will be selected together during type a selection, while not included those in different groups.
+- `TypeSelectUseIFVMode` determines whether all IFV modes will be considered as its own group by default during a type selection.
+  - If it's set to true, `WeaponGroupAsN` will be default to N for each `WeaponN`, which makes each of them become a standalone type during a type selection.
+  - If it's set to false, `WeaponGroupAsN` will be default to 0 for all weapons, which makes type selection on IFVs work the same as before.
+
+In `rulesmd.ini`:
+```ini
+[General]
+TypeSelectUseIFVMode=false   ; boolean
+
+[SOMEVEHICLE]                ; VehicleType
+WeaponGroupAsN=              ; string, default to N if [General] -> TypeSelectUseIFVMode=true, and 0 if false
+```
+
 ### Customizing crushing tilt and slowdown
 
 - Vehicles with `Crusher=true` and `OmniCrusher=true` / `MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles / walls respectively. This now obeys `TiltsWhenCrushes` but can be customized individually for these two scenarios using `TiltsWhenCrusher.Vehicles` and `TiltsWhenCrusher.Overlays`, which both default to `TiltsWhenCrushes`.

--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1575,9 +1575,13 @@ Vanilla game played vehicles' `SellSound` globally. This has been changed in con
   - Weapons with `ElectricAssault=true` set on `Warhead` against `Overpowerable=true` buildings belonging to owner or allies.
   - `Overpowerable=true` buildings that are currently overpowered.
   - Any system using `(Elite)WeaponX`, f.ex `Gunner=true` or `IsGattling=true` is also wholly exempt.
+- If `[CombatDamage] -> AllowWeaponSelectAgainstWalls` is set to true, `Secondary` will now be used against walls if `Primary` weapon Warhead has `Wall=false`, `Secondary` has `Wall=true` and the firer does not have `NoSecondaryWeaponFallback` set to true.
 
 In `rulesmd.ini`:
 ```ini
+[CombatDamage]
+AllowWeaponSelectAgainstWalls=false      ; boolean
+
 [SOMETECHNO]                             ; TechnoType
 NoSecondaryWeaponFallback=false          ; boolean
 NoSecondaryWeaponFallback.AllowAA=false  ; boolean

--- a/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/Fixed-or-Improved-Logics.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-30 01:57+0800\n"
+"POT-Creation-Date: 2025-12-06 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -173,17 +173,17 @@ msgstr ""
 
 #: ../../Fixed-or-Improved-Logics.md:30 ../../Fixed-or-Improved-Logics.md:40
 #: ../../Fixed-or-Improved-Logics.md:50 ../../Fixed-or-Improved-Logics.md:79
-#: ../../Fixed-or-Improved-Logics.md:648 ../../Fixed-or-Improved-Logics.md:936
-#: ../../Fixed-or-Improved-Logics.md:1064
-#: ../../Fixed-or-Improved-Logics.md:1089
-#: ../../Fixed-or-Improved-Logics.md:1212
-#: ../../Fixed-or-Improved-Logics.md:1558
-#: ../../Fixed-or-Improved-Logics.md:1574
-#: ../../Fixed-or-Improved-Logics.md:1648
-#: ../../Fixed-or-Improved-Logics.md:1846
-#: ../../Fixed-or-Improved-Logics.md:2278
-#: ../../Fixed-or-Improved-Logics.md:2323
-#: ../../Fixed-or-Improved-Logics.md:2348
+#: ../../Fixed-or-Improved-Logics.md:579 ../../Fixed-or-Improved-Logics.md:925
+#: ../../Fixed-or-Improved-Logics.md:1213
+#: ../../Fixed-or-Improved-Logics.md:1341
+#: ../../Fixed-or-Improved-Logics.md:1366
+#: ../../Fixed-or-Improved-Logics.md:1470
+#: ../../Fixed-or-Improved-Logics.md:1782
+#: ../../Fixed-or-Improved-Logics.md:1844
+#: ../../Fixed-or-Improved-Logics.md:2052
+#: ../../Fixed-or-Improved-Logics.md:2484
+#: ../../Fixed-or-Improved-Logics.md:2529
+#: ../../Fixed-or-Improved-Logics.md:2554
 msgid "image"
 msgstr "图像"
 
@@ -505,53 +505,44 @@ msgstr "在单人任务中，玩家现在可以看到盟友所属方的隐形对
 
 #: ../../Fixed-or-Improved-Logics.md:89
 msgid ""
-"IvanBomb images can now display and the bombs detonate at center of "
-"buildings instead of in top-leftmost cell of the building foundation if "
-"`[CombatDamage] -> IvanBombAttachToCenter` is set to true."
-msgstr ""
-"现在伊文炸弹的图像显示位置和炸弹引爆位置可以通过设置 `[CombatDamage] -> "
-"IvanBombAttachToCenter=true` 来改为建筑中心而不再是建筑占地左上角的单元格。"
-
-#: ../../Fixed-or-Improved-Logics.md:90
-msgid ""
 "Fixed BibShape drawing for a couple of frames during buildup for "
 "buildings with long buildup animations."
 msgstr "修复了具有较长建造动画的建筑在建造过程中会绘制几帧 BibShape 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:91
+#: ../../Fixed-or-Improved-Logics.md:90
 msgid "Animation with `Tiled=yes` now supports `CustomPalette`."
 msgstr "现在带有 `Tiled=yes` 的动画也支持 `CustomPalette` 了。"
 
-#: ../../Fixed-or-Improved-Logics.md:92
+#: ../../Fixed-or-Improved-Logics.md:91
 msgid ""
 "Attempted to avoid units from retaining previous orders "
 "(attack,grind,garrison,etc) after changing ownership (mind-"
 "control,abduction,etc)."
 msgstr "尝试避免单位在更改所属方（心灵控制、超时空监狱等）后保留之前的命令（攻击，回收，进驻等）。"
 
-#: ../../Fixed-or-Improved-Logics.md:93
+#: ../../Fixed-or-Improved-Logics.md:92
 msgid ""
 "Fixed buildings' `NaturalParticleSystem` being created for in-map pre-"
 "placed structures."
 msgstr "修复了地图中预先放置的建筑也会创建建筑 `NaturalParticleSystem` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:94
+#: ../../Fixed-or-Improved-Logics.md:93
 msgid ""
 "Fixed jumpjet units being unable to visually tilt or be flipped if "
 "`TiltCrashJumpjet=no`."
 msgstr "修复了 `TiltCrashJumpjet=no` 时 Jumpjet 单位无法视觉上倾斜或翻转的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:95
+#: ../../Fixed-or-Improved-Logics.md:94
 msgid "Unlimited (more than 5) `AlternateFLH` entries for units."
 msgstr "单位的 `AlternateFLH` 条目数量不再被限制（可以超过 5 个）。"
 
-#: ../../Fixed-or-Improved-Logics.md:96
+#: ../../Fixed-or-Improved-Logics.md:95
 msgid ""
 "Warheads spawning debris now use `MaxDebris` as an actual cap for number "
 "of debris to spawn instead of `MaxDebris` - 1."
 msgstr "现在生成碎片的弹头使用 `MaxDebris` 作为实际的碎片数量上限而不再是 `MaxDebris` - 1。"
 
-#: ../../Fixed-or-Improved-Logics.md:97
+#: ../../Fixed-or-Improved-Logics.md:96
 msgid ""
 "If both `Primary` and `Secondary` weapons can fire at air targets "
 "(projectile has `AA=true`), `Primary` can now be picked instead of always"
@@ -563,7 +554,7 @@ msgstr ""
 "而不再总是强制使用 `Secondary`。这也适用于 `IsGattling=true`，奇数与偶数的 `WeaponX` 分别对应 "
 "`Primary` 与 `Secondary`。"
 
-#: ../../Fixed-or-Improved-Logics.md:98
+#: ../../Fixed-or-Improved-Logics.md:97
 msgid ""
 "`IsGattling=true` can now fall back to secondary weapon slot (even-"
 "numbered `WeaponX` slots) if primary one (odd-numbered) cannot fire at "
@@ -572,19 +563,19 @@ msgstr ""
 "现在 `IsGattling=true` 在主要武器（奇数 `WeaponX` 序列）无法对当前目标开火（受制于 "
 "Armor、`CanTarget(Houses)`、护盾等）时可以更换到次要武器（偶数 `WeaponX` 序列）。"
 
-#: ../../Fixed-or-Improved-Logics.md:99
+#: ../../Fixed-or-Improved-Logics.md:98
 msgid ""
 "Fixed `LandTargeting=1` not preventing from targeting TerrainTypes (trees"
 " etc.) on land."
 msgstr "修复了 `LandTargeting=1` 未能阻止瞄准陆地上的地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:100
+#: ../../Fixed-or-Improved-Logics.md:99
 msgid ""
 "Fixed `NavalTargeting=6` not preventing from targeting empty water cells "
 "or TerrainTypes (trees etc.) on water."
 msgstr "修复了 `NavalTargeting=6` 未能阻止瞄准水上空置单元格或水上地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:101
+#: ../../Fixed-or-Improved-Logics.md:100
 msgid ""
 "Fixed `NavalTargeting=7` and/or `LandTargeting=2` resulting in still "
 "targeting TerrainTypes (trees etc.) on land with `Primary` weapon."
@@ -592,19 +583,19 @@ msgstr ""
 "修复了 `NavalTargeting=7` 和 `LandTargeting=2` 导致在陆地上仍然使用 `Primary` "
 "武器来瞄准地形对象（树木等）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:102
+#: ../../Fixed-or-Improved-Logics.md:101
 msgid ""
 "Fixed infantry without `C4=true` being killed in water if paradropped, "
 "chronoshifted etc. even if they can normally enter water."
 msgstr "修复了没有 `C4=true` 的步兵即便可以正常进入水中但当被空投、超时空传送等情况下在水中会死亡的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:103
+#: ../../Fixed-or-Improved-Logics.md:102
 msgid ""
 "Allowed MCV to redeploy in campaigns using a new toggle different from "
 "`[MultiplayerDialogSettings] -> MCVRedeploys`."
 msgstr "允许在战役中使用一个与 `[MultiplayerDialogSettings] -> MCVRedeploys` 不同的新开关设置重部署 MCV。"
 
-#: ../../Fixed-or-Improved-Logics.md:104
+#: ../../Fixed-or-Improved-Logics.md:103
 msgid ""
 "Fixed buildings with `UndeploysInto` but `Unsellable=no` & "
 "`ConstructionYard=no` unable to be sold normally, by using "
@@ -615,13 +606,13 @@ msgstr ""
 "的建筑无法正常出售的问题，需要设置 `UndeploysInto.Sellable=true`。并且复原了在 `UndeploysInto` "
 "的建筑被出售时应有的 `EVA_StructureSold` 播报语音。"
 
-#: ../../Fixed-or-Improved-Logics.md:105
+#: ../../Fixed-or-Improved-Logics.md:104
 msgid ""
 "Fixed `WaterBound=true` buildings with `UndeploysInto` not correctly "
 "setting the location for the vehicle to move into when undeployed."
 msgstr "修复了 `WaterBound=true` 且拥有 `UndeploysInto` 的建筑在反部署时无法正常设置载具移动位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:106
+#: ../../Fixed-or-Improved-Logics.md:105
 msgid ""
 "`CanC4=false` on building makes building take atleast 1 point of damage "
 "**if** the raw damage is non-zero but is lowered to below 1 by `Verses` "
@@ -633,13 +624,13 @@ msgstr ""
 "点。`CanC4.AllowZeroDamage=true` 可以禁用这一行为。（经 `Verses` "
 "等机制修正计算完的）负伤害将完全绕过此检查，无需额外启用。"
 
-#: ../../Fixed-or-Improved-Logics.md:107
+#: ../../Fixed-or-Improved-Logics.md:106
 msgid ""
 "Buildings with primary weapon that has `AG=false` projectile now have "
 "attack cursor when selected."
 msgstr "主武器使用 `AG=false` 抛射体的的建筑现在在选中时将正常显示攻击光标"
 
-#: ../../Fixed-or-Improved-Logics.md:108
+#: ../../Fixed-or-Improved-Logics.md:107
 msgid ""
 "Weapons with `AA=true` projectiles can now be set to fire exclusively at "
 "air targets by setting `AAOnly=true`, regardless of other conditions. "
@@ -650,20 +641,20 @@ msgstr ""
 "现在拥有 `AA=true ` 抛射体的武器可以通过设置 `AAOnly=true` 来使其仅可对空中目标进行攻击。这很有用：毕竟 "
 "`AG=false` 只能防止瞄准地面单元格（并且无法在不破坏现有行为的情况下更改）而且它适用于无法使用 `LandTargeting` 的情况。"
 
-#: ../../Fixed-or-Improved-Logics.md:109
+#: ../../Fixed-or-Improved-Logics.md:108
 msgid ""
 "Transports with `OpenTopped=true` and weapon that has `Burst` above 1 and"
 " passengers firing out no longer have the passenger firing offset shift "
 "lateral position based on burst index."
 msgstr "现在 `OpenTopped=true` 且拥有大于 1 的 `Burst` 的武器的运输工具其载员开火不再由于连发的序数而改变侧向偏移位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:110
+#: ../../Fixed-or-Improved-Logics.md:109
 msgid ""
 "Fixed disguised infantry not using custom palette for drawing the "
 "disguise when needed."
 msgstr "修复了伪装的步兵在必要时没有使用自定义色盘来绘制伪装图像的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:111
+#: ../../Fixed-or-Improved-Logics.md:110
 msgid ""
 "Disguised infantry now show appropriate insignia when disguise is "
 "visible, based on the disguise type and house. Original unit's insignia "
@@ -673,30 +664,30 @@ msgstr ""
 "现在当伪装闪烁时伪装的步兵将会根据伪装的类型和所属方显示对应的军衔。原始单位的军衔始终显示给观察者和 `[General] -> "
 "DisguiseBlinkingVisibility` 设置所支持可见伪装闪烁的当前玩家。"
 
-#: ../../Fixed-or-Improved-Logics.md:112
+#: ../../Fixed-or-Improved-Logics.md:111
 msgid ""
 "Buildings with superweapons no longer display `SuperAnimThree` at "
 "beginning of match if pre-placed on the map."
 msgstr "地图上预先放置的超级武器类建筑在游戏开始时不再显示 `SuperAnimThree`。"
 
-#: ../../Fixed-or-Improved-Logics.md:113
+#: ../../Fixed-or-Improved-Logics.md:112
 msgid "`SpySat=yes` can now be applied using building upgrades."
 msgstr "现在 `SpySat=yes` 可以通过建筑加载物获得。"
 
-#: ../../Fixed-or-Improved-Logics.md:114
+#: ../../Fixed-or-Improved-Logics.md:113
 msgid ""
 "AI players can now build `Naval=true` and `Naval=false` vehicles "
 "concurrently like human players do."
 msgstr "现在 AI 玩家可以像人类玩家一样同时建造 `Naval=true` 与 `Naval=false` 的载具。"
 
-#: ../../Fixed-or-Improved-Logics.md:115
+#: ../../Fixed-or-Improved-Logics.md:114
 msgid ""
 "Fixed the bug when jumpjets were snapping into facing bottom-right when "
 "starting movement (observable when the starting unit is a jumpjet and is "
 "ordered to move)."
 msgstr "修复了 Jumpjet 单位在开始移动时（当初始部队是 Jumpjet 单位并命令去移动时可以观察到）会突然面向右下方向的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:116
+#: ../../Fixed-or-Improved-Logics.md:115
 msgid ""
 "Objects with `Palette` set now have their color tint adjusted accordingly"
 " by superweapons, map retint actions etc. if they belong to a house using"
@@ -706,7 +697,7 @@ msgstr ""
 "现在拥有 `Palette` 设置的对象可以正常根据超级武器、地图重绘光照行为等调整其色调。只要它们属于使用了任何配色方案的所属方而不仅限于 "
 "`[Colors]` 列表前半部分那些。"
 
-#: ../../Fixed-or-Improved-Logics.md:117
+#: ../../Fixed-or-Improved-Logics.md:116
 msgid ""
 "Animations using `AltPalette` are now remapped to their owner's color "
 "scheme instead of first listed color scheme and no longer draw over "
@@ -719,13 +710,13 @@ msgstr ""
 "`[AudioVisual] -> AnimRemapDefaultColorScheme` 指定的配色方案，它同样默认为 `[Colors]` "
 "中被列出的第一个配色方案。"
 
-#: ../../Fixed-or-Improved-Logics.md:118
+#: ../../Fixed-or-Improved-Logics.md:117
 msgid ""
 "They can also have map lighting apply on them if "
 "`AltPalette.ApplyLighting` is set to true."
 msgstr "如果将 `AltPalette.ApplyLighting` 设置为 true 那么地图光照同样可以对它们生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:119
+#: ../../Fixed-or-Improved-Logics.md:118
 msgid ""
 "Fixed `DeployToFire` not considering building placement rules for "
 "`DeploysInto` buildings and as a result not working properly with "
@@ -734,13 +725,13 @@ msgstr ""
 "修复了 `DeployToFire` 未考虑 `DeploysInto` 建筑的摆放规则并导致该功能无法与 `WaterBound` "
 "建筑一起正常工作的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:120
+#: ../../Fixed-or-Improved-Logics.md:119
 msgid ""
 "Fixed `DeployToFire` not recalculating firer's position on land if it "
 "cannot currently deploy."
 msgstr "修复了 `DeployToFire` 在当前无法部署时未能重新计算开火者在陆地上所处位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:121
+#: ../../Fixed-or-Improved-Logics.md:120
 msgid ""
 "`Arcing=true` projectile elevation inaccuracy can now be fixed by setting"
 " `Arcing.AllowElevationInaccuracy=false`."
@@ -748,24 +739,13 @@ msgstr ""
 "现在可以通过设置 `Arcing.AllowElevationInaccuracy=false` 来修复 `Arcing=true` "
 "抛射体在有高程影响下的精度问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:122
+#: ../../Fixed-or-Improved-Logics.md:121
 msgid ""
 "Wall overlays are now drawn with the custom palette defined in `Palette` "
 "in `artmd.ini` if possible."
 msgstr "现在如果可能的话墙类覆盖物将会使用 `artmd.ini` 中使用 `Palette` 指定的自定义色盘进行绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:123
-msgid ""
-"If `[CombatDamage] -> AllowWeaponSelectAgainstWalls` is set to true, "
-"`Secondary` will now be used against walls if `Primary` weapon Warhead "
-"has `Wall=false`, `Secondary` has `Wall=true` and the firer does not have"
-" `NoSecondaryWeaponFallback` set to true."
-msgstr ""
-"现在如果 `[CombatDamage] -> AllowWeaponSelectAgainstWalls` 设置为 true，假设 "
-"`Primary` 武器的弹头拥有 `Wall=false`，而 `Secondary` 武器拥有 `Wall=true` 且开火者没有将 "
-"`NoSecondaryWeaponFallback` 设为 true 那么 `Secondary` 将在应对墙时被使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:124
+#: ../../Fixed-or-Improved-Logics.md:122
 msgid ""
 "Setting `ReloadInTransport` to true on units with `Ammo` will allow the "
 "ammo to be reloaded according to `Reload` or `EmptyReload` timers even "
@@ -774,7 +754,7 @@ msgstr ""
 "在拥有 `Ammo` 的单位上设置 `ReloadInTransport` 为 true 将允许在运输工具内的单位也根据 `Reload` 或 "
 "`EmptyReload` 计时器进行重新装填。"
 
-#: ../../Fixed-or-Improved-Logics.md:125
+#: ../../Fixed-or-Improved-Logics.md:123
 msgid ""
 "It is now possible to enable `Verses` and `PercentAtMax` to be applied on"
 " negative damage by setting `ApplyModifiersOnNegativeDamage` to true on "
@@ -783,24 +763,24 @@ msgstr ""
 "现在可以通过在弹头上将 `ApplyModifiersOnNegativeDamage` 设置为 true 来为负伤害启用 `Verses` 和 "
 "`PercentAtMax`。"
 
-#: ../../Fixed-or-Improved-Logics.md:126
+#: ../../Fixed-or-Improved-Logics.md:124
 msgid ""
 "Attached animations on flying units now have their layer updated "
 "immediately after the parent unit, if on same layer they always draw "
 "above the parent."
 msgstr "现在飞行单位上所附加的动画会紧随其父单位之后立即更新其图层，如果在同一图层上它们将始终绘制在父单位之上。"
 
-#: ../../Fixed-or-Improved-Logics.md:127
+#: ../../Fixed-or-Improved-Logics.md:125
 msgid ""
 "Fixed an issue where the powered anims of `Powered` / `PoweredSpecial` "
 "buildings cease to update when being captured by enemies."
 msgstr "修复了 `Powered`／`PoweredSpecial` 的建筑在被敌人占领时其受电力影响的动画不再更新的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:128
+#: ../../Fixed-or-Improved-Logics.md:126
 msgid "Fixed a glitch related to incorrect target setting for missiles."
 msgstr "修复了有关于导弹目标设置不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:129
+#: ../../Fixed-or-Improved-Logics.md:127
 msgid ""
 "Fixed [EIP "
 "00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14)"
@@ -810,153 +790,141 @@ msgstr ""
 "00529A14](https://modenc.renegadeprojects.com/Internal_Error/YR#eip_00529A14)"
 " 问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:130
+#: ../../Fixed-or-Improved-Logics.md:128
 msgid "Units will no longer rotate its turret under EMP."
 msgstr "单位在 EMP 状态下不再会旋转炮塔。"
 
-#: ../../Fixed-or-Improved-Logics.md:131
+#: ../../Fixed-or-Improved-Logics.md:129
 msgid "Jumpjets will no longer wobble under EMP."
 msgstr "Jumpjet 单位在 EMP 状态下不再会浮动。"
 
-#: ../../Fixed-or-Improved-Logics.md:132
+#: ../../Fixed-or-Improved-Logics.md:130
 msgid "Removed jumpjet units' deceleration when crashing onto buildings."
 msgstr "移除了 Jumpjet 单位坠毁到建筑上时的减速效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:133
+#: ../../Fixed-or-Improved-Logics.md:131
 msgid ""
 "Fixed `AmbientDamage` when used with `IsRailgun=yes` being cut off by "
 "elevation changes."
 msgstr "修复了 `AmbientDamage` 在与 `IsRailgun=yes` 共用时会被高度变化切断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:134
+#: ../../Fixed-or-Improved-Logics.md:132
 msgid "Fixed railgun and fire particles being cut off by elevation changes."
 msgstr "修复了轨道炮和火焰粒子被高度变化切断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:135
+#: ../../Fixed-or-Improved-Logics.md:133
 msgid ""
 "Fixed teleport units' (for example `[CLEG]`) frozen-still timer being "
 "cleared after load game."
 msgstr "修复了超时空单位（例如 `[CLEG]`）的僵直计时器在载入游戏后被清空的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:136
+#: ../../Fixed-or-Improved-Logics.md:134
 msgid "Fixed teleport units being unable to visually tilt on slopes."
 msgstr "修复了超时空运动模式的单位无法在斜坡上视觉性倾斜的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:137
+#: ../../Fixed-or-Improved-Logics.md:135
 msgid "Fixed rockets' shadow location."
 msgstr "修复了火箭的影子位置问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:138
+#: ../../Fixed-or-Improved-Logics.md:136
 msgid ""
 "Fixed units with Teleport, Tunnel or Fly locomotor being unable to be "
 "visually flipped like other locomotors do."
 msgstr "修复了使用 Teleport、Tunnel 或 Fly 运动模式的单位无法像其他运动模式那样视觉翻转的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:139
+#: ../../Fixed-or-Improved-Logics.md:137
 msgid ""
 "Aircraft docking on buildings now respect `[AudioVisual] -> PoseDir` as "
 "the default setting and do not always land facing north or in case of "
 "pre-placed buildings, the building's direction."
 msgstr "现在战机在建筑上停靠时尊重 `[AudioVisual] -> PoseDir` 作为默认设置而不总是朝向北方，或者在地图预置建筑上面向建筑的方向。"
 
-#: ../../Fixed-or-Improved-Logics.md:140
+#: ../../Fixed-or-Improved-Logics.md:138
 msgid "Spawned aircraft now align with the spawner's facing when landing."
 msgstr "现在生成的子机在降落时会与其母舰的朝向对正。"
 
-#: ../../Fixed-or-Improved-Logics.md:141
+#: ../../Fixed-or-Improved-Logics.md:139
 msgid ""
 "Fixed the bug that waypointing unarmed infantry with "
 "agent/engineer/occupier to a spyable/capturable/occupiable building "
 "triggers `EnteredBy` event by executing capture mission."
 msgstr "修复了在路径点中为间谍／工程师／可驻军步兵设置目标为可渗透／占领／驻军的建筑执行行为时会触发 `被...进入` 条件的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:142
+#: ../../Fixed-or-Improved-Logics.md:140
 msgid ""
 "`PowerUpN` building animations can now use `Powered` & "
 "`PoweredLight/Effect/Special` keys."
 msgstr "`PowerUpN` 建筑动画现在可以使用 `Powered` 和 `PoweredLight/Effect/Special` 类的标签。"
 
-#: ../../Fixed-or-Improved-Logics.md:143
+#: ../../Fixed-or-Improved-Logics.md:141
 msgid ""
 "Fixed a desync potentially caused by displaying of cursor over selected "
 "`DeploysInto` units."
 msgstr "修复了在选中 `DeploysInto` 单位上显示光标时可能引起的不同步问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:144
+#: ../../Fixed-or-Improved-Logics.md:142
 msgid "Skipped drawing rally point line when undeploying a factory."
 msgstr "跳过工厂类建筑反部署时的集结线绘制。"
 
-#: ../../Fixed-or-Improved-Logics.md:145
+#: ../../Fixed-or-Improved-Logics.md:143
 msgid ""
 "Tint effects are now correctly applied to SHP vehicles and all types of "
 "aircraft as well as building animations regardless of their position."
 msgstr "现在染色效果无论对象位置如何都会正确对 Shape 载具、所有类型的战机以及建筑动画生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:146
+#: ../../Fixed-or-Improved-Logics.md:144
 msgid ""
 "Iron Curtained / Force Shielded objects now always use the correct tint "
 "color."
 msgstr "现在被铁幕或力场护盾保护的对象将始终使用正确的染色效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:147
+#: ../../Fixed-or-Improved-Logics.md:145
 msgid ""
 "Objects in invalid map coordinates are no longer used for starting view "
 "and AI base center calculations."
 msgstr "位于无效地图坐标中的对象不再用于初始视图和 AI 基地中心计算。"
 
-#: ../../Fixed-or-Improved-Logics.md:148
+#: ../../Fixed-or-Improved-Logics.md:146
 msgid ""
 "Units & buildings with `DecloakToFire=false` weapons now cloak while "
 "targeting & reloading."
 msgstr "现在拥有 `DecloakToFire=false` 武器的单位和建筑在瞄准和装填时会隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:149
+#: ../../Fixed-or-Improved-Logics.md:147
 msgid "Units with `Sensors=true` will no longer reveal ally buildings."
 msgstr "拥有 `Sensors=true` 的单位将不再解除友军建筑的隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:150
+#: ../../Fixed-or-Improved-Logics.md:148
 msgid ""
 "Air units are now reliably included by target scan with large range and "
 "Warhead detonation by large `CellSpread`."
 msgstr "现在具有大范围的目标检索和大 `CellSpread` 的弹头爆炸范围可靠的包含了空中单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:151
+#: ../../Fixed-or-Improved-Logics.md:149
 msgid ""
 "OverlayTypes now read and use `ZAdjust` if specified in their `artmd.ini`"
 " entry."
 msgstr "现在如果被指定那么覆盖物可以正常读取并使用它们在 `artmd.ini` 条目中的 `ZAdjust`。"
 
-#: ../../Fixed-or-Improved-Logics.md:152
-msgid ""
-"Setting `[AudioVisual] -> ColorAddUse8BitRGB` to true makes game treat "
-"values from `[ColorAdd]` as 8-bit RGB (0-255) instead of RGB565 (0-31 for"
-" red & blue, 0-63 for green). This works for `LaserTargetColor`, "
-"`IronCurtainColor`, `BerserkColor` and `ForceShieldColor`."
-msgstr ""
-"设置 `[AudioVisual] -> ColorAddUse8BitRGB` 为 true 时游戏会将 `[ColorAdd]` 中的值视为 "
-"8 位 RGB(0-255)而不是 RGB565（红色和蓝色为 0-31，绿色为 0-63）。这适用于 "
-"`LaserTargetColor`、`IronCurtainColor`、`BerserkColor` 和 "
-"`ForceShieldColor`。（已知 KratosPP v0.1.15会抵消该逻辑）"
-
-#: ../../Fixed-or-Improved-Logics.md:153
+#: ../../Fixed-or-Improved-Logics.md:150
 msgid ""
 "Weapons with `AA=true` Projectile can now correctly fire at air units "
 "when both firer and target are over a bridge."
 msgstr "现在当开火者和目标都在桥上时拥有 `AA=true` 抛射体的武器可以正确的对空中单位射击。"
 
-#: ../../Fixed-or-Improved-Logics.md:154
+#: ../../Fixed-or-Improved-Logics.md:151
 msgid ""
 "Fixed disguised units not using the correct palette if target has custom "
 "palette."
 msgstr "修复了伪装单位在目标具有自定义调色盘时未使用正确调色盘的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:155
+#: ../../Fixed-or-Improved-Logics.md:152
 msgid ""
 "Building upgrades now consistently use building's `PowerUpN` animation "
 "settings corresponding to the upgrade's `PowersUpToLevel` where possible."
 msgstr "现在建筑加载物将尽可能一致地使用与加载物 `PowersUpToLevel` 相对应的建筑 `PowerUpN` 动画设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:156
+#: ../../Fixed-or-Improved-Logics.md:153
 msgid ""
 "Subterranean units are no longer allowed to perform deploy functions like"
 " firing weapons or `IsSimpleDeployer` while burrowed or burrowing, they "
@@ -965,7 +933,7 @@ msgstr ""
 "现在潜地单位在下潜或正在潜地移动时不再允许执行例如发射武器或 `IsSimpleDeployer` "
 "那样的部署功能，现在它们会先像运输工具释放乘客那样先钻出地面。"
 
-#: ../../Fixed-or-Improved-Logics.md:157
+#: ../../Fixed-or-Improved-Logics.md:154
 msgid ""
 "The otherwise unused setting `[AI] -> PowerSurplus` (defaults to 50) "
 "which determines how much surplus power AI players will strive to have "
@@ -974,7 +942,7 @@ msgstr ""
 "可以通过将 `[AI] -> EnablePowerSurplus` 设置为 true 来复原 `[AI] -> "
 "PowerSurplus`（默认为 50）以决定 AI 玩家将尽力保持的富余电力值。"
 
-#: ../../Fixed-or-Improved-Logics.md:158
+#: ../../Fixed-or-Improved-Logics.md:155
 msgid ""
 "Planning paths are now shown for all units under player control or when "
 "`[GlobalControls] -> DebugPlanningPaths=yes` in singleplayer game modes."
@@ -982,49 +950,49 @@ msgstr ""
 "现在当 `[GlobalControls] -> DebugPlanningPaths=yes` "
 "时在单人游戏模式中所有受玩家操作的单位都会显示路径点规划的路径。"
 
-#: ../../Fixed-or-Improved-Logics.md:159
+#: ../../Fixed-or-Improved-Logics.md:156
 msgid ""
 "Fixed `Temporal=true` Warheads potentially crashing game if used to "
 "attack `Slaved=true` infantry."
 msgstr "修复了 `Temporal=true` 弹头在攻击 `Slaved=true` 步兵时可能崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:160
+#: ../../Fixed-or-Improved-Logics.md:157
 msgid ""
 "Fixed some locomotors (Tunnel, Walk, Mech) getting stuck when moving too "
 "fast."
 msgstr "修复了一些运动模式（Tunnel、Walk、Mech）在移动过快时卡住的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:161
+#: ../../Fixed-or-Improved-Logics.md:158
 msgid ""
 "Animations with `MakeInfantry` and `UseNormalLight=false` that are drawn "
 "in unit palette will now have cell lighting changes applied on them."
 msgstr "现在使用 `MakeInfantry` 和 `UseNormalLight=false` 并使用单位色盘绘制的动画将正常应用单元格的亮度变化。"
 
-#: ../../Fixed-or-Improved-Logics.md:162
+#: ../../Fixed-or-Improved-Logics.md:159
 msgid "Removed 0 damage effect on jumpjet infantry from `InfDeath=9` warhead."
 msgstr "移除了 `InfDeath=9` 的弹头对 Jumpjet 步兵只能造成 0 伤害的效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:163
+#: ../../Fixed-or-Improved-Logics.md:160
 msgid "Fixed Nuke & Dominator Level lighting not applying to AircraftTypes."
 msgstr "修复了核弹和心灵支配的光照等级未应用于战机类别的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:164
+#: ../../Fixed-or-Improved-Logics.md:161
 msgid "Skip target scanning function calling for unarmed technos."
 msgstr "禁用了无武器单位的索敌。"
 
-#: ../../Fixed-or-Improved-Logics.md:165
+#: ../../Fixed-or-Improved-Logics.md:162
 msgid ""
 "Projectiles created from `AirburstWeapon` now remember the WeaponType and"
 " can apply radiation etc."
 msgstr "现在由 `AirburstWeapon` 创建的抛射体会保留完整 WeaponType 并且可以应用辐射等效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:166
+#: ../../Fixed-or-Improved-Logics.md:163
 msgid ""
 "Fixed damaged aircraft not repairing on `UnitReload=true` docks unless "
 "they land on the dock first."
 msgstr "修复了受损的战机除非先降落于 `UnitReload=true` 的停靠点上否则不能修复的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:167
+#: ../../Fixed-or-Improved-Logics.md:164
 msgid ""
 "Certain global tileset indices (`ShorePieces`, `WaterSet`, `CliffSet`, "
 "`WaterCliffs`, `WaterBridge`, `BridgeSet` and `WoodBridgeSet`) can now be"
@@ -1038,25 +1006,25 @@ msgstr ""
 " 和 `WoodBridgeSet`）以解析月球场景。注意如果不修复例如 `WoodBridgeTileSet` 指向 "
 "`TilesInSet=0` 的地块这样的隐患就启用本功能将在游戏中引发问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:168
+#: ../../Fixed-or-Improved-Logics.md:165
 msgid ""
 "Fixed infantry `SecondaryFire` / `SecondaryProne` sequences being "
 "displayed in water instead of `WetAttack`."
 msgstr "修复了步兵在水中显示 `SecondaryFire`／`SecondaryProne` 序列而不是 `WetAttack` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:169
+#: ../../Fixed-or-Improved-Logics.md:166
 msgid ""
 "Fixed objects with ally target and `AttackFriendlies=true` having their "
 "target reset every frame, particularly AI-owned buildings."
 msgstr "修复了目标为友军单位且 `AttackFriendlies=true` 的对象每帧重置目标的问题，尤其是 AI 拥有的建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:170
+#: ../../Fixed-or-Improved-Logics.md:167
 msgid ""
 "`<Player @ X>` can now be used as owner for pre-placed objects on "
 "skirmish and multiplayer maps."
 msgstr "现在 `<Player @ X>` 可以直接用于遭遇战和多人地图上预先放置对象的所有者。"
 
-#: ../../Fixed-or-Improved-Logics.md:171
+#: ../../Fixed-or-Improved-Logics.md:168
 msgid ""
 "Follower vehicle index for preplaced vehicles in maps is now explicitly "
 "constrained to `[Units]` list in map files and is no longer thrown off by"
@@ -1064,51 +1032,51 @@ msgid ""
 "vehicles as initial passengers."
 msgstr "现在地图预置载具的跟随索引已被明确限制在地图 `[Units]` 列表中并且不再受到无法创建的载具或创建的载具具有其他载具作为初始乘客的情况所干扰。"
 
-#: ../../Fixed-or-Improved-Logics.md:172
+#: ../../Fixed-or-Improved-Logics.md:169
 msgid ""
 "Drive/Jumpjet/Ship/Teleport locomotor did not power on when it is un-"
 "piggybacked bugfix"
 msgstr "修复了 Drive/Jumpjet/Ship/Teleport 运动方式在退出 piggybacked 接口时无法激活的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:173
+#: ../../Fixed-or-Improved-Logics.md:170
 msgid "Stop command (`[S]` by default) behavior is now more correct:"
 msgstr "停止命令（默认为 `[S]`）的行为现在更加正确："
 
-#: ../../Fixed-or-Improved-Logics.md:174
+#: ../../Fixed-or-Improved-Logics.md:171
 msgid "Jumpjets no longer fall into a state of standing by idly."
 msgstr "Jumpjet 单位不再进入空闲站立状态。"
 
-#: ../../Fixed-or-Improved-Logics.md:175
+#: ../../Fixed-or-Improved-Logics.md:172
 msgid "Technos are no longer unable to stop the attack move mission."
 msgstr "科技类型现在可以停止移动攻击任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:176
+#: ../../Fixed-or-Improved-Logics.md:173
 msgid "Technos are no longer unable to stop the area guard mission."
 msgstr "科技类型现在可以停止区域警戒任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:177
+#: ../../Fixed-or-Improved-Logics.md:174
 msgid "Aircraft no longer find airport twice and overlap."
 msgstr "战机不再两次寻找机场并重叠。"
 
-#: ../../Fixed-or-Improved-Logics.md:178
+#: ../../Fixed-or-Improved-Logics.md:175
 msgid "Aircraft no longer briefly pause in the air before returning."
 msgstr "战机在返回前不再在空中端在停留"
 
-#: ../../Fixed-or-Improved-Logics.md:179
+#: ../../Fixed-or-Improved-Logics.md:176
 msgid "Aircraft with `AirportBound=no` no longer continue moving forward."
 msgstr "拥有 `AirportBound=no` 的战机不再会继续向前移动"
 
-#: ../../Fixed-or-Improved-Logics.md:180
+#: ../../Fixed-or-Improved-Logics.md:177
 msgid "Technos are no longer unable to stop when it is above the elevated bridge."
 msgstr "科技类型在桥上时不再无法停止。"
 
-#: ../../Fixed-or-Improved-Logics.md:181
+#: ../../Fixed-or-Improved-Logics.md:178
 msgid ""
 "Technos are still not allowed to stop moving under the elevated bridge, "
 "but can stop other missions."
 msgstr "科技类型在桥下时仍然无法停止移动，但可以停止其他任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:182
+#: ../../Fixed-or-Improved-Logics.md:179
 msgid ""
 "Now in air team members will use the 2D distance instead of the 3D "
 "distance to judge whether have reached the mission destination, so as to "
@@ -1118,7 +1086,7 @@ msgstr ""
 "现在作为小队成员的空中单位将使用 2D 距离而不是 3D 距离来判断是否达到任务目的地，以防止任务卡住且无法继续的问题（例如 Jumpjet "
 "单位停在建筑上时）。"
 
-#: ../../Fixed-or-Improved-Logics.md:183
+#: ../../Fixed-or-Improved-Logics.md:180
 msgid ""
 "Unit `Speed` setting now accepts floating-point values. Internally parsed"
 " values are clamped down to maximum of 100, multiplied by 256 and divided"
@@ -1129,7 +1097,7 @@ msgstr ""
 "现在单位的 `Speed` 设置接受小数。内部解析的值被限制为最大 100，乘以 256 并除以 100，结果（此时转换为整数）被限制为最大 "
 "255，从而获得有效内部速度值范围 0 到 255，例如以 leptons 为单位每帧移动的距离。"
 
-#: ../../Fixed-or-Improved-Logics.md:184
+#: ../../Fixed-or-Improved-Logics.md:181
 msgid ""
 "`AirburstWeapon` now supports `IsLaser`, `IsElectricBolt`, `IsRadBeam`, "
 "and `AttachedParticleSystem`."
@@ -1137,13 +1105,13 @@ msgstr ""
 "现在 `AirburstWeapon` 可以支持绘制 `IsLaser`、`IsElectricBolt`、`IsRadBeam` "
 "等视觉效果并允许粒子武器正常创建 `AttachedParticleSystem` 的粒子系统。"
 
-#: ../../Fixed-or-Improved-Logics.md:185
+#: ../../Fixed-or-Improved-Logics.md:182
 msgid ""
 "Subterranean movement now benefits from speed multipliers from all "
 "sources such as veterancy, AttachEffect etc."
 msgstr "现在潜地运动方式享受来自升级、AttachEffect 等所有来源的速度加成。"
 
-#: ../../Fixed-or-Improved-Logics.md:186
+#: ../../Fixed-or-Improved-Logics.md:183
 msgid ""
 "Aircraft will now behave as expected according to it's `MovementZone` and"
 " `SpeedType` when moving onto different surfaces. In particular, this "
@@ -1153,38 +1121,38 @@ msgstr ""
 "战机现在会根据其 `MovementZone` 和 `SpeedType` "
 "在移动到不同地形上时表现得像预期一样。特别是，这修复了原版中战机被命令移动到水面却将移动命令改为附近的岸边这一异常行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:188
+#: ../../Fixed-or-Improved-Logics.md:185
 msgid ""
 "Fixed the bug that parasite will vanish if it missed its target when its "
 "previous cell is occupied."
 msgstr "修复了寄生单位在错过目标且其先前单元格被占用时会直接消失的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:189
+#: ../../Fixed-or-Improved-Logics.md:186
 msgid ""
 "Prevent the units with locomotors that cause problems from entering the "
 "tank bunker."
 msgstr "防止拥有会导致问题的运动方式的单位进入坦克碉堡。"
 
-#: ../../Fixed-or-Improved-Logics.md:190
+#: ../../Fixed-or-Improved-Logics.md:187
 msgid ""
 "Fixed an issue where a unit will leave an impassable invisible barrier in"
 " its original position when it is teleported by ChronoSphere onto an "
 "uncrushable unit and self destruct."
 msgstr "修复了一个单位被超时空传送超武传送到一个不可碾压的单位上并自爆时会在原地留下空气墙的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:191
+#: ../../Fixed-or-Improved-Logics.md:188
 msgid "Fixed the bug that destroyed unit may leaves sensors."
 msgstr "修复了单位被摧毁仍会遗留反隐形探测效果的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:192
+#: ../../Fixed-or-Improved-Logics.md:189
 msgid "`FreeUnit` uses the unit's own `SpeedType` to find the spawn location."
 msgstr "`FreeUnit` 使用单位自己的 `SpeedType` 来寻找生成位置。"
 
-#: ../../Fixed-or-Improved-Logics.md:193
+#: ../../Fixed-or-Improved-Logics.md:190
 msgid "The bug where naval ships as StartUnit might spawn on land has been fixed."
 msgstr "修复初始船只可能生成在陆地上的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:194
+#: ../../Fixed-or-Improved-Logics.md:191
 msgid ""
 "When a building is transformed into a vehicle via `UndeploysInto`, the "
 "`SpeedType` and `MovementZone` of the target VehicleType will determine "
@@ -1193,7 +1161,7 @@ msgstr ""
 "建筑通过 `UndeploysInto` 反部署时使用目标载具的 `SpeedType` 和 `MovementZone` "
 "来决定能否向目标单元格移动。"
 
-#: ../../Fixed-or-Improved-Logics.md:195
+#: ../../Fixed-or-Improved-Logics.md:192
 msgid ""
 "Fixed an issue that harvesters with amphibious movement zone can not "
 "automatically return to refineries with `WaterBound` on water surface. "
@@ -1203,45 +1171,45 @@ msgstr ""
 "修复了两栖矿车无法自动返回水上 `WaterBound` 矿场的问题。拥有 `Teleporter=true` 的单位不受影响，因为它们只要矿场的"
 " `Naval` 为 false 就可以正常工作。"
 
-#: ../../Fixed-or-Improved-Logics.md:196
+#: ../../Fixed-or-Improved-Logics.md:193
 msgid ""
 "Units are now unable to kick out from a factory that is in construction "
 "process, and will not always stuck in the factory."
 msgstr "单位现在不会再从正在建造的工厂中驶出，并且将不再会被卡在工厂内。"
 
-#: ../../Fixed-or-Improved-Logics.md:197
+#: ../../Fixed-or-Improved-Logics.md:194
 msgid ""
 "Fixed issues caused by incorrect reference removal (f.ex. If the unit "
 "cloaks/enters transport, it cannot gain experience from previously "
 "launched spawners/C4/projectiles)."
 msgstr "修复错误脱引用导致的问题（例如，如果单位隐形／进入运输工具则无法自此前发射的子机／安置的 C4 炸弹／发射的抛射体获得经验）。"
 
-#: ../../Fixed-or-Improved-Logics.md:198
+#: ../../Fixed-or-Improved-Logics.md:195
 msgid ""
 "Fixed an issue that caused `IsSonic=true` wave drawing to crash the game "
 "if the wave traveled over a certain distance."
 msgstr "修复了一个如果 `IsSonic=true` 的波绘制超过一定距离会导致游戏崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:199
+#: ../../Fixed-or-Improved-Logics.md:196
 msgid ""
 "Buildings with foundation bigger than 1x1 can now recycle spawner "
 "correctly."
 msgstr "占地面积超过 1x1 的建筑现在可以正常回收子机。"
 
-#: ../../Fixed-or-Improved-Logics.md:200
+#: ../../Fixed-or-Improved-Logics.md:197
 msgid ""
 "Electric bolts that are supposed to update their position based on units "
 "current firing coords (by default, those fired by vehicles) now do so "
 "correctly for more than one concurrent electric bolt."
 msgstr "现在那些本应跟随单位当前开火坐标更新位置的 EBolt 效果（默认指由载具发射的）能够正确的对超过 1 个同时创建的 EBolt 效果生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:201
+#: ../../Fixed-or-Improved-Logics.md:198
 msgid ""
 "Fixed an issue where `FireAngle` would not work properly under certain "
 "circumstances."
 msgstr "修复了 `FireAngle` 在某些情况下未能正常工作的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:202
+#: ../../Fixed-or-Improved-Logics.md:199
 msgid ""
 "Fixed an issue that `MovementZone=AmphibiousDestroyer` and "
 "`MovementZone=AmphibiousCrusher` technos being unable to enter on water "
@@ -1250,59 +1218,59 @@ msgstr ""
 "修复了 `MovementZone=AmphibiousDestroyer` 与 `MovementZone=AmphibiousCrusher`"
 " 的单位无法进入水上建筑的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:203
+#: ../../Fixed-or-Improved-Logics.md:200
 msgid ""
 "Fixed an issue that aircraft carriers can not find suitable locations for"
 " attacks when under elevated bridges on their own."
 msgstr "修复了航空母舰在桥下时无法找到恰当攻击位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:204
+#: ../../Fixed-or-Improved-Logics.md:201
 msgid ""
 "Fixed an issue that in air aircraft carriers being unable to attack when "
 "it is near by elevated bridges."
 msgstr "修复了空天母舰靠近高架桥梁时无法攻击的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:205
+#: ../../Fixed-or-Improved-Logics.md:202
 msgid ""
 "Fixed an issue that aircraft carriers cannot retract its spawned aircraft"
 " when on the bridge."
 msgstr "修复了航空母舰在桥上无法回收子机的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:206
+#: ../../Fixed-or-Improved-Logics.md:203
 msgid ""
 "Fixed an issue where the shadow of jumpjet remained on the ground when it"
 " was above the elevated bridge."
 msgstr "修复了 Jumpjet 在桥梁上方时其影子残留在地面的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:207
+#: ../../Fixed-or-Improved-Logics.md:204
 msgid ""
 "Fixed an issue that laser, electric bolt and rad beam not support "
 "`Inviso=true` projectiles with `FlakScatter=true` to scatter."
 msgstr "修复了激光、EBolt、辐射波在 `FlakScatter=true` 的 `Inviso=true` 抛射体上不不跟随散布的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:208
+#: ../../Fixed-or-Improved-Logics.md:205
 msgid ""
 "Fixed the bug that healing weapons could not automatically acquire aerial"
 " targets."
 msgstr "修复了治疗武器无法自动获取到空中目标的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:209
+#: ../../Fixed-or-Improved-Logics.md:206
 msgid "Allow voxel projectiles to use `AnimPalette` and `FirersPalette`."
 msgstr "允许了 Voxel 抛射体使用 `AnimPalette` 和 `FirersPalette`。"
 
-#: ../../Fixed-or-Improved-Logics.md:210
+#: ../../Fixed-or-Improved-Logics.md:207
 msgid ""
 "Fixed an issue where AI would select unreachable buildings and get stuck "
 "when looking for buildings like tank bunkers, bio reactors, etc."
 msgstr "修复了 AI 会找实际无法抵达的坦克碉堡、生化反应炉等建筑作为目标而导致卡住的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:211
+#: ../../Fixed-or-Improved-Logics.md:208
 msgid ""
 "Fixed an issue that the first passenger who call the transport ship no "
 "longer board the transport ship when the land units call for boarding."
 msgstr "修复了当陆地单位请求登船时第一个呼叫运输船的乘客不会登船的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:212
+#: ../../Fixed-or-Improved-Logics.md:209
 msgid ""
 "Fixed the bug that `EnterBioReactorSound`, `LeaveBioReactorSound`, "
 "`EnterGrinderSound` on technotype does not used."
@@ -1310,169 +1278,169 @@ msgstr ""
 "修复了 `EnterBioReactorSound`、`LeaveBioReactorSound`、`EnterGrinderSound` "
 "在单位上微观设定无效的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:213
+#: ../../Fixed-or-Improved-Logics.md:210
 msgid ""
 "Fixed the bug that harvester dont stop unloading and cannot unload cargos"
 " anymore when lifting by `IsLocomotor=yes` warhead."
 msgstr "修复了矿车被 `IsLocomotor=yes` 的弹头抬起也不会停止倒矿状态且无法继续正常倒矿的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:214
+#: ../../Fixed-or-Improved-Logics.md:211
 msgid "Fixed an issue that units on the slope tilted at an excessive angle."
 msgstr "修复了单位在斜坡上倾斜角度过大的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:215
+#: ../../Fixed-or-Improved-Logics.md:212
 msgid ""
 "Fixed an issue that impassable invisible barrier generated by the "
 "behavior of infantry continuously entering vehicles."
 msgstr "修复了步兵通过路径点连续进入两个载具等行为会产生空气墙的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:216
+#: ../../Fixed-or-Improved-Logics.md:213
 msgid ""
 "Fixed an issue that teleport units board transport vehicles on the bridge"
 " will create an impassable invisible barrier, which may cause the game to"
 " freeze or even crash."
 msgstr "修复了单位超时空进入桥上的运输载具会产生空气墙并可能导致游戏卡死乃至崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:217
+#: ../../Fixed-or-Improved-Logics.md:214
 msgid ""
 "Fixed an issue that moving MCV with Teleport locomotion will cause "
 "reconnection error."
 msgstr "修复了超时空移动的 MCV 会引发 Reconnection Error 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:218
+#: ../../Fixed-or-Improved-Logics.md:215
 msgid ""
 "Fixed wrong shadow when a vehicle has hover locomotor and is being lifted"
 " by `IsLocomotor=yes` warhead."
 msgstr "修复了使用悬浮运动模式的载具被 `IsLocomotor=yes` 弹头抬起时显示的错误阴影。"
 
-#: ../../Fixed-or-Improved-Logics.md:219
+#: ../../Fixed-or-Improved-Logics.md:216
 msgid ""
 "Fixed an issue that game crashes (EIP:7FB178) when infantry are about to "
 "enter an occupiable building that has been removed and is not real dead."
 msgstr "修复了当步兵进入一个已被移除但并未真正死亡的可驻军建筑时导致的游戏崩溃问题（EIP:7FB178）。"
 
-#: ../../Fixed-or-Improved-Logics.md:220
+#: ../../Fixed-or-Improved-Logics.md:217
 msgid ""
 "Fixed an issue that game crashes when spawnee has been removed and is not"
 " real dead."
 msgstr "修复了当子机已被移除但并未真正死亡时导致的游戏崩溃问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:221
+#: ../../Fixed-or-Improved-Logics.md:218
 msgid ""
 "Separated the AirstrikeClass pointer between the attacker/aircraft and "
 "the target to avoid erroneous overwriting issues."
 msgstr "分离了 AirstrikeClass 中攻击者／战机与目标的指针以避免错误覆盖问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:222
+#: ../../Fixed-or-Improved-Logics.md:219
 msgid "Fixed the bug that buildings will always be tinted as airstrike owner."
 msgstr "修复了建筑总是被染色为空袭所属方颜色的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:223
+#: ../../Fixed-or-Improved-Logics.md:220
 msgid ""
 "Fixed the bug that `AllowAirstrike=no` cannot completely prevent air "
 "strikes from being launched against it."
 msgstr "修复了 `AllowAirstrike=no` 未能完全阻止对某个单位进行空袭的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:224
+#: ../../Fixed-or-Improved-Logics.md:221
 msgid ""
 "Fixed an issue where computer players did not search for new enemies "
 "after defeating them or forming alliances with them."
 msgstr "修复了 AI 玩家在消灭一家敌人或敌人结盟后不再搜索新敌人的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:225
+#: ../../Fixed-or-Improved-Logics.md:222
 msgid ""
 "Fixed the bug that infantry ignored `Passengers` and `SizeLimit` when "
 "entering buildings."
 msgstr "修复了步兵进入建筑时忽略 `Passengers` 和 `SizeLimit` 的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:226
+#: ../../Fixed-or-Improved-Logics.md:223
 msgid "Fixed `VoiceDeploy` not played, when deployed through hot-key/command bar."
 msgstr "修复了通过快捷键／底边栏按钮部署时不播放 `VoiceDeploy` 的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:227
+#: ../../Fixed-or-Improved-Logics.md:224
 msgid "Fixed the bug that ships can travel on elevated bridges."
 msgstr "修复了船只可以在高架桥上行驶的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:228
+#: ../../Fixed-or-Improved-Logics.md:225
 msgid "Dehardcoded 255 limit of `OverlayType`."
 msgstr "解除了覆盖物最多 255 个的数量限制。"
 
-#: ../../Fixed-or-Improved-Logics.md:229
+#: ../../Fixed-or-Improved-Logics.md:226
 msgid ""
 "Fixed an issue where airstrike flare line drawn to target at lower "
 "elevation would clip."
 msgstr "修复了空袭引导激光高打低时会截断的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:230
+#: ../../Fixed-or-Improved-Logics.md:227
 msgid ""
 "Fixed the bug that uncontrolled scatter when elite techno attacked by "
 "aircraft or some unit try crush it."
 msgstr "修复精英单位在被战机攻击或一个单位尝试碾压它时强制散开的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:231
+#: ../../Fixed-or-Improved-Logics.md:228
 msgid ""
 "Second weapon with `ElectricAssault=yes` will not unconditionally attack "
 "your building with `Overpowerable=yes`."
 msgstr "有 `ElectricAssault=yes` 的副武不再会无条件地攻击己方 `Overpowerable=yes` 的建筑。"
 
-#: ../../Fixed-or-Improved-Logics.md:232
+#: ../../Fixed-or-Improved-Logics.md:229
 msgid "Infantry support `IsGattling=yes`."
 msgstr "步兵类现已支持使用 `IsGattling=yes` 开启盖特逻辑"
 
-#: ../../Fixed-or-Improved-Logics.md:233
+#: ../../Fixed-or-Improved-Logics.md:230
 msgid ""
 "Fixed an issue that the widespread damage caused by detonation on the "
 "bridge/ground cannot affect objects on the ground/bridge who are in the "
 "opposite case."
 msgstr "修复了范围伤害在桥上／地面引爆时无法影响相对情况即在地面／桥上的对象的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:234
+#: ../../Fixed-or-Improved-Logics.md:231
 msgid ""
 "Fixed the bug that `DamageSelf` and `AllowDamageOnSelf` are ineffective "
 "on airforce."
 msgstr "修复了 `DamageSelf` 和 `AllowDamageOnSelf` 对空军无效的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:235
+#: ../../Fixed-or-Improved-Logics.md:232
 msgid ""
 "Fixed the bug that damaged particle dont disappear after building has "
 "repaired by engineer."
 msgstr "修复了建筑在被工程师修复后受损粒子不会移除的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:236
+#: ../../Fixed-or-Improved-Logics.md:233
 msgid "Fixed an issue of incorrect position of `TrailerAnim` in `VoxelAnim`."
 msgstr "修复了 Voxel 碎片 `TrailerAnim` 生成位置不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:237
+#: ../../Fixed-or-Improved-Logics.md:234
 msgid ""
 "Fixed the bug that `OpenToppedWarpDistance` is calculated incorrectly for"
 " building target."
 msgstr "修复了建筑类目标 `OpenToppedWarpDistance` 计算错误的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:238
+#: ../../Fixed-or-Improved-Logics.md:235
 msgid ""
 "Fixed an issue that `MovementZone=Fly` harvesters can not be able to "
 "enter refinery buildings manually."
 msgstr "修复了 `MovementZone=Fly` 的矿车无法手动进入矿场的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:239
+#: ../../Fixed-or-Improved-Logics.md:236
 msgid ""
 "Fixed an issue that jumpjet harvester cannot automatically go mining when"
 " leaving the weapons factory."
 msgstr "修复了 `Locomotor=Jumpjet` 的矿车出厂后不会自动去采矿的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:240
+#: ../../Fixed-or-Improved-Logics.md:237
 msgid ""
 "Fixed an issue that jumpjet harvester will overlap when manually entering"
 " refinery buildings and cause game crashes."
 msgstr "修复了 `Locomotor=Jumpjet` 的矿车会因为手动进入矿场而交叠并导致游戏崩溃的问题"
 
-#: ../../Fixed-or-Improved-Logics.md:241
+#: ../../Fixed-or-Improved-Logics.md:238
 msgid ""
 "Fixed an issue that `Spawned` aircraft will fly towards the edge of the "
 "map when its `Spawner` is under EMP."
 msgstr "修了拥有 `Spawned` 的战机会在子机发射器单位处于 EMP 状态时飞向地图边界的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:242
+#: ../../Fixed-or-Improved-Logics.md:239
 msgid ""
 "Projectiles with `Vertical=true` now drop straight down if fired off by "
 "AircraftTypes instead of behaving erratically. This behaviour can be "
@@ -1481,85 +1449,85 @@ msgstr ""
 "现在当一个拥有 `Vertical=true` 的抛射体被战机类发射时将会正常下坠。可以通过在抛射体上设置 "
 "`Vertical.AircraftFix=false` 来关闭这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:243
+#: ../../Fixed-or-Improved-Logics.md:240
 msgid ""
 "Engineers can enter buildings normally when they don't need to be "
 "repaired (or you can force it by pressing Alt)."
 msgstr "工程师在建筑无需维修时可以正常进入（也可以通过按住 `[Alt]` 强制进入）。"
 
-#: ../../Fixed-or-Improved-Logics.md:244
+#: ../../Fixed-or-Improved-Logics.md:241
 msgid ""
 "Player-controlled spies are not forced to perform other tasks while "
 "attacking buildings."
 msgstr "人类玩家控制的间谍在攻击建筑时不会强制执行其他任务。"
 
-#: ../../Fixed-or-Improved-Logics.md:245
+#: ../../Fixed-or-Improved-Logics.md:242
 msgid ""
 "If `BombDisarm=yes` is not present for all weapon warheads, then the "
 "engineer will no longer use the appropriate mouse action."
 msgstr "如果所有武器的弹头都没有 `BombDisarm=yes` 则工程师将不再使用相应的鼠标动作。"
 
-#: ../../Fixed-or-Improved-Logics.md:246
+#: ../../Fixed-or-Improved-Logics.md:243
 msgid "Fixed an unusual use of DeployFireWeapon for InfantryType."
 msgstr "修复了步兵使用 `DeployFireWeapon` 时的异常情况。"
 
-#: ../../Fixed-or-Improved-Logics.md:247
+#: ../../Fixed-or-Improved-Logics.md:244
 msgid ""
 "Fixed the bug that passengers' Temporal attacks wouldn't stop when an "
 "OpenTopped vehicle was frozen by a Temporal warhead."
 msgstr "修复了即便 `OpenTopped` 载具被超时空弹头冻结其乘客的超时空武器攻击也不会停止的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:248
+#: ../../Fixed-or-Improved-Logics.md:245
 msgid "Fixed the bug that vehicle owned by computer will scatter when cloaking."
 msgstr "修复了 AI 的载具在隐形时会乱跑的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:249
+#: ../../Fixed-or-Improved-Logics.md:246
 msgid ""
 "Fixed the bug that submarine always turn left after changed owner by map "
 "event."
 msgstr "修复了水下单位在被地图触发修改所属后总会朝向左方的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:250
+#: ../../Fixed-or-Improved-Logics.md:247
 msgid ""
 "Fixed the bug that occupyable structure won't redraw when press deploy "
 "hotkey to release all occupants."
 msgstr "修复了可驻军建筑在按部署键释放全部驻兵后绘图不会刷新的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:251
+#: ../../Fixed-or-Improved-Logics.md:248
 msgid ""
 "Fixed an issue that if the garrison unload occupants when there is no "
 "open space around it would result in the disappearance of the occupants."
 msgstr "修复了周围没有空地时释放驻军会导致它们消失的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:252
+#: ../../Fixed-or-Improved-Logics.md:249
 msgid ""
 "Fixed the bug that Locomotor warhead won't stop working when the attacker"
 " is being affected by `Temporal=yes` warhead."
 msgstr "修复了攻击者被 `Temporal=yes` 弹头作用时运动模式弹头不会停止工作的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:253
+#: ../../Fixed-or-Improved-Logics.md:250
 msgid ""
 "Fixed the bug that `IsLocomotor=yes` warhead rendering hover units "
 "unselectable and undamageable on elevated bridge."
 msgstr "修复了 `IsLocomotor=yes` 弹头会导致高架桥上的悬浮载具无法选中且无法被伤害的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:254
+#: ../../Fixed-or-Improved-Logics.md:251
 msgid ""
 "Fixed the bug that Locomotor warhead won't stop working when firer "
 "(except for vehicle) stop firing."
 msgstr "修复了非载具单位使用运动模式弹头时停止开火也不会停止工作的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:255
+#: ../../Fixed-or-Improved-Logics.md:252
 msgid "Fixed the bug that hover vehicle will sink if destroyed on bridge."
 msgstr "修复了悬浮载具在桥上被摧毁会沉没（而不是爆炸）的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:256
+#: ../../Fixed-or-Improved-Logics.md:253
 msgid ""
 "Fixed the fact that when the selected unit is in a rearmed state, it can "
 "unconditionally use attack mouse on the target."
 msgstr "修复了当被选中的单位武器正在 CD 时可以无条件对目标使用 Attack 光标的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:257
+#: ../../Fixed-or-Improved-Logics.md:254
 msgid ""
 "When `Speed=0` or the TechnoTypes cell cannot move due to "
 "`MovementRestrictedTo`, vehicles cannot attack targets beyond the "
@@ -1569,19 +1537,19 @@ msgstr ""
 "若 `Speed=0` 或单位由于 `MovementRestrictedTo` 导致无法移动，载具不再可以攻击武器射程外的目标。`Area "
 "Guard` 和 `Hunt` 任务将不会生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:258
+#: ../../Fixed-or-Improved-Logics.md:255
 msgid ""
 "Fixed an issue that barrel anim data will be incorrectly overwritten by "
 "turret anim data if the techno's section exists in the map file."
 msgstr "修复了地图文件中内置了某单位时其炮管动画数据会被炮塔动画数据错误覆盖的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:259
+#: ../../Fixed-or-Improved-Logics.md:256
 msgid ""
 "Fixed pathfinding crashes (EIP 0x42A525, 0x42C507, 0x42C554) that "
 "happened on bigger maps due to too small pathfinding node buffer."
 msgstr "修复了在较大的地图中由于寻路节点缓冲区过小而引发的寻路崩溃（EIP 0x42A525、0x42C507、0x42C554）问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:260
+#: ../../Fixed-or-Improved-Logics.md:257
 msgid ""
 "`IsSimpleDeployer` `BalloonHover=true` units with `DeployToLand=false` "
 "are no longer forced to land when hovering."
@@ -1589,13 +1557,13 @@ msgstr ""
 "拥有 `BalloonHover=true` 和 `IsSimpleDeployer=true` 但 `DeployToLand=false` "
 "的单位现在在悬停时不会强制着陆。"
 
-#: ../../Fixed-or-Improved-Logics.md:261
+#: ../../Fixed-or-Improved-Logics.md:258
 msgid ""
 "If `DeployingAnim` with `Shadow=true` is played for unit currently in air"
 " its shadow will now be drawn on ground."
 msgstr "如果当前处于空中的单位通过 `DeployingAnim` 播放带有 `Shadow=true` 的动画则动画的影子现在会绘制在地面上。"
 
-#: ../../Fixed-or-Improved-Logics.md:262
+#: ../../Fixed-or-Improved-Logics.md:259
 msgid ""
 "`DeployingAnim` now supports both `Normalized=true` and `Reverse=true`. "
 "Keep in mind `Reverse` uses `LoopEnd` for frame amount instead of `End` "
@@ -1604,39 +1572,39 @@ msgstr ""
 "`DeployingAnim` 现已支持 `Normalized=true` 与 `Reverse=true`。注意：即便不是 "
 "`LoopCount > 1` 的情况 `Reverse` 也会使用 `LoopEnd` 而不是 `End` 来控制帧数。"
 
-#: ../../Fixed-or-Improved-Logics.md:263
+#: ../../Fixed-or-Improved-Logics.md:260
 msgid "`DeployingAnim` using unit drawer now also tint accordingly with the unit."
 msgstr "`DeployingAnim` 使用单位绘制方式时现可跟随单位一起染色。"
 
-#: ../../Fixed-or-Improved-Logics.md:264
+#: ../../Fixed-or-Improved-Logics.md:261
 msgid "Fixed an issue that jumpjets in air can not correctly spawn missiles."
 msgstr "修复了 Jumpjet 单位在空中时无法生成导弹子机的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:265
+#: ../../Fixed-or-Improved-Logics.md:262
 msgid ""
 "Fixed an issue that the currently hovered planning node not update up-to-"
 "date, such as using hotkeys to select technos."
 msgstr "修复了所谓的高等路径学。"
 
-#: ../../Fixed-or-Improved-Logics.md:266
+#: ../../Fixed-or-Improved-Logics.md:263
 msgid ""
 "Fixed an issue that infantry walking through a cell containing a tree "
 "would cause it to be impassable to other houses."
 msgstr "修复了步兵占据包含树木的单元格会导致该单元格对其他所属方不可通行的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:267
+#: ../../Fixed-or-Improved-Logics.md:264
 msgid ""
 "Fixed the bug that techno unit will draw with ironcurtain and airstrike "
 "color and intensity who disguised as terrain or overlay."
 msgstr "修复了单位在伪装成地形对象或覆盖物时铁幕与空袭染色强度绘制错误的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:268
+#: ../../Fixed-or-Improved-Logics.md:265
 msgid ""
 "Fixed an issue that the AI would enter a combat state when its building "
 "receiving damage from friendly units or damage not greater than 0."
 msgstr "修复了 AI 在建筑受到的伤害即便来自友军单位或不大于 0 点也依然进入防御状态的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:269
+#: ../../Fixed-or-Improved-Logics.md:266
 msgid ""
 "If `[General] -> FallingDownTargetingFix` is set to true, the techno with"
 " weapon with `AA=yes` and `AG=no` will auto targeting units that are "
@@ -1645,71 +1613,71 @@ msgstr ""
 "如果 `[General] -> FallingDownTargetingFix` 设为 true 则所用武器 `AA=yes` 且 "
 "`AG=no` 的单位将会主动攻击坠落中的单位（例如伞兵）。"
 
-#: ../../Fixed-or-Improved-Logics.md:270
+#: ../../Fixed-or-Improved-Logics.md:267
 msgid "Iron Curtain/Custom Tint Support for SHP Turreted Vehicles."
 msgstr "修复了铁幕／自定义染色无法将 SHP 有炮塔载具染色的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:271
+#: ../../Fixed-or-Improved-Logics.md:268
 msgid "Reactivate unused trigger events 2, 53, and 54."
 msgstr "重新激活无效的 2、53 和 54 号触发条件。"
 
-#: ../../Fixed-or-Improved-Logics.md:272
+#: ../../Fixed-or-Improved-Logics.md:269
 msgid ""
 "Fixed the bug that vehicle fall on infantry will make all cell content "
 "has been removed."
 msgstr "修复了载具落到有步兵的单元格上时会将格内所有对象全部移除的 Bug"
 
-#: ../../Fixed-or-Improved-Logics.md:273
+#: ../../Fixed-or-Improved-Logics.md:270
 msgid ""
 "Fixed buildings that have their owner changed during buildup skipping "
 "buildup and sometimes not correctly clearing the state."
 msgstr "修复了建筑拔起过程中发生所属变更会跳过建造阶段且有时无法正确清除状态的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:274
+#: ../../Fixed-or-Improved-Logics.md:271
 msgid ""
 "Fixed preplaced aircraft outside visible map being incorrectly flagged as"
 " crashing under certain conditions."
 msgstr "修复了处于可视地图范围外的预置战机某些情况下被错误标记为坠毁的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:275
+#: ../../Fixed-or-Improved-Logics.md:272
 msgid ""
 "Fixed `MovementZone=Subterannean` harvesters being unable to find docks "
 "if in area enclosed by water, cliffs etc."
 msgstr "修复了 `MovementZone=Subterannean` 的矿车无法跨越封闭的水域、悬崖等区域找到停靠点的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:276
+#: ../../Fixed-or-Improved-Logics.md:273
 msgid ""
 "Fixed an issue where some effects pointing to a unit were not properly "
 "cleared when the unit changed its owner."
 msgstr "修复了指向某个某个单位的部分效果在该单位变更所属时未能正确清除的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:277
+#: ../../Fixed-or-Improved-Logics.md:274
 msgid ""
 "Allow Reveal Crate to take effect when picking up by another player "
 "controlled house in campaign."
 msgstr "允许在战役模式中由其他被玩家控制的所属方拾取到的开全图工具箱效果生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:278
+#: ../../Fixed-or-Improved-Logics.md:275
 msgid ""
 "Fixed an issue where the vanilla script ignores jumpjets. Enable it "
 "through `[General] -> AIAirTargetingFix=true`."
 msgstr "修复了原版脚本会忽略 Jumpjet 单位的问题，需要通过 `[General] -> AIAirTargetingFix=true` 来启用。"
 
-#: ../../Fixed-or-Improved-Logics.md:279
+#: ../../Fixed-or-Improved-Logics.md:276
 msgid "Fixed the bug that naval ship will sink even they destroyed in air."
 msgstr "修复了海军舰船即便在空中被摧毁也会在天上沉没的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:281
+#: ../../Fixed-or-Improved-Logics.md:278
 msgid "Fixes / interactions with other extensions"
 msgstr "修复或与其他扩展的交互"
 
-#: ../../Fixed-or-Improved-Logics.md:283
+#: ../../Fixed-or-Improved-Logics.md:280
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now fully respect "
 "the firing building's FLH."
 msgstr "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器将完全遵照发射建筑的 FLH 设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:284
+#: ../../Fixed-or-Improved-Logics.md:281
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* without "
 "`EMPulse.TargetSelf=true` can now create radiation."
@@ -1717,57 +1685,57 @@ msgstr ""
 "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器在没有 `EMPulse.TargetSelf=true` "
 "的情况下也可以正常产生辐射。"
 
-#: ../../Fixed-or-Improved-Logics.md:285
+#: ../../Fixed-or-Improved-Logics.md:282
 msgid ""
 "Weapons fired by EMPulse superweapons *(Ares feature)* now respect "
 "`Floater` and Phobos-added `Gravity` setting."
 msgstr "现在由 EMPulse 超级武器（*Ares 功能*）发射的武器遵守 `Floater` 与 Phobos 添加的 `Gravity` 设定"
 
-#: ../../Fixed-or-Improved-Logics.md:286
+#: ../../Fixed-or-Improved-Logics.md:283
 msgid ""
 "`IsSimpleDeployer` units with Hover locomotor and `DeployToLand` no "
 "longer get stuck after deploying or play their move sound indefinitely."
 msgstr "拥有 Hover 运动模式的 `IsSimpleDeployer` 且 `DeployToLand` 的单位在部署后不再会卡住或无限播放移动音效。"
 
-#: ../../Fixed-or-Improved-Logics.md:287
+#: ../../Fixed-or-Improved-Logics.md:284
 msgid ""
 "`Convert.Deploy` displays 'NoDeploy' cursor if the new type is not "
 "allowed to move to the cell due to `SpeedType` etc."
 msgstr "当 `Convert.Deploy` 转换的目标单位由于 `SpeedType` 等原因无法移动到目标单元格时将会显示 `NoDeploy` 光标。"
 
-#: ../../Fixed-or-Improved-Logics.md:288
+#: ../../Fixed-or-Improved-Logics.md:285
 msgid ""
 "All forms of type conversion (including Ares') now correctly update the "
 "warp-in delay if unit with teleport `Locomotor` was converted while the "
 "delay was active."
 msgstr "现在所有单位转换形式（包括 Ares 的）在使用超时空 `Locomotor` 的单位处于僵直状态被转换时可以正确的更新传送延迟。"
 
-#: ../../Fixed-or-Improved-Logics.md:289
+#: ../../Fixed-or-Improved-Logics.md:286
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`MoveSound` if a moving unit has their type changed."
 msgstr "现在所有单位转换形式（包括 Ares 的）在移动单位的类型被转换时可以正确更新 `MoveSound`。"
 
-#: ../../Fixed-or-Improved-Logics.md:290
+#: ../../Fixed-or-Improved-Logics.md:287
 msgid ""
 "All forms of type conversion (including Ares') now correctly update "
 "`OpenTopped` state of passengers in transport that is converted."
 msgstr "现在所有单位转换形式（包括 Ares 的）在运输工具被转换时可以正确更新乘客的 `OpenTopped` 状态。"
 
-#: ../../Fixed-or-Improved-Logics.md:291
+#: ../../Fixed-or-Improved-Logics.md:288
 msgid ""
 "Fixed an issue introduced by Ares that caused building `ActiveAnim` to be"
 " incorrectly restored while `SpecialAnim` was playing and the building "
 "was sold, erased or destroyed."
 msgstr "修复了 Ares 引入的一个当 `SpecialAnim` 播放且建筑被出售、删除或摧毁时它的 `ActiveAnim` 会被错误地恢复的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:292
+#: ../../Fixed-or-Improved-Logics.md:289
 msgid ""
 "Fixed Ares' Abductor weapon leaves permanent placement stats when "
 "abducting moving vehicles."
 msgstr "修复了 Ares 的超时空监狱武器在绑架移动载具时会留下永久放置统计（空气墙）的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:293
+#: ../../Fixed-or-Improved-Logics.md:290
 msgid ""
 "Suppressed Ares' swizzle warning when parsing `Tags` and `TaskForces` "
 "(typically begin with `[Developer fatal]Pointer 00000000 declared change "
@@ -1776,48 +1744,48 @@ msgstr ""
 "在解析 `Tags` 和 `TaskForces` 时抑制 Ares 的 swizzle 警告（通常以 `[Developer "
 "fatal]Pointer 00000000 declared change to both` 开头）。"
 
-#: ../../Fixed-or-Improved-Logics.md:294
+#: ../../Fixed-or-Improved-Logics.md:291
 msgid ""
 "Fixed Academy *(Ares feature)* not working on the initial payloads *(Ares"
 " feature)* of vehicles built from a war factory."
 msgstr "修复了训练所（*Ares 功能*）在由战车工厂所生产载具的初始载员（*Ares 功能*）上不起作用的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:295
+#: ../../Fixed-or-Improved-Logics.md:292
 msgid ""
 "Fixed Ares' InitialPayload not being created for vehicles spawned by "
 "trigger actions."
 msgstr "修复了 Ares 的初始荷载未为触发行为生成的载具创建的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:297
+#: ../../Fixed-or-Improved-Logics.md:294
 msgid ""
 "Taking over Ares' AlphaImage respawn logic to make it not recreate in "
 "every frame for buildings, static techno and techno without turret, in "
 "order to reduce lags from it."
 msgstr "接管了 Ares 的 AlphaImage 重绘逻辑，使其用于建筑、静止单位和无炮塔单位时不会每帧重绘，以减少其造成的卡顿。"
 
-#: ../../Fixed-or-Improved-Logics.md:298
+#: ../../Fixed-or-Improved-Logics.md:295
 msgid ""
 "Fixed an issue where a portion of Ares's trigger event 75/77 was "
 "determined unsuccessfully."
 msgstr "修复了 Ares 触发条件 75/77 有时判定不成功的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:299
+#: ../../Fixed-or-Improved-Logics.md:296
 msgid ""
 "Fixed an issue where some units crashed after the deployment "
 "transformation."
 msgstr "修复了某些单位部署变形后崩溃的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:300
+#: ../../Fixed-or-Improved-Logics.md:297
 msgid "Fixed the bug that AlphaImage remained after unit entered tunnel."
 msgstr "修复了 AlphaImage 在单位进入隧道后会遗留在隧道口的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:301
+#: ../../Fixed-or-Improved-Logics.md:298
 msgid ""
 "Fixed an issue where Ares' `Convert.Deploy` triggers repeatedly when the "
 "unit is turning or moving."
 msgstr "修复了 Ares 的 `Convert.Deploy` 会在单位转向或移动中反复触发的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:302
+#: ../../Fixed-or-Improved-Logics.md:299
 msgid ""
 "The game now automatically changes save file name from `SAVEGAME.NET` to "
 "`SVGM_XXX.NET` (where `XXX` is a number) when saving to prevent "
@@ -1827,13 +1795,13 @@ msgstr ""
 "游戏现在在保存时会自动将存档文件名从 `SAVEGAME.NET` 改为 `SVGM_XXX.NET`（此处 `XXX` 为数字）以防止在 "
 "Phobos 与 XNA CNCNet Client 共用且保存过于频繁时偶尔覆盖存档文件。"
 
-#: ../../Fixed-or-Improved-Logics.md:303
+#: ../../Fixed-or-Improved-Logics.md:300
 msgid ""
 "1000 save files are supported, from `SVGM_000.NET` to `SVGM_999.NET`. "
 "When the limit is reached, the game will overwrite the latest save file."
 msgstr "支持从 `SVGM_000.NET` 到 `SVGM_999.NET` 的 1000 个文件。当达到上线后游戏将会覆盖此前最新的存档文件。"
 
-#: ../../Fixed-or-Improved-Logics.md:304
+#: ../../Fixed-or-Improved-Logics.md:301
 msgid ""
 "The previous `SVGM_XXX.NET` files are cleaned up before first copy if "
 "it's a new game, otherwise the highest numbered `SVGM_XXX.NET` file is "
@@ -1842,68 +1810,68 @@ msgstr ""
 "如果是新游戏，在首次保存前会清理先前存在的 `SVGM_XXX.NET` 文件，否则游戏会查找编号最大的 `SVGM_XXX.NET` "
 "文件并在可行的情况下递增编号。"
 
-#: ../../Fixed-or-Improved-Logics.md:305
+#: ../../Fixed-or-Improved-Logics.md:302
 msgid ""
 "The game also automatically copies `spawn.ini` to the save folder as "
 "`spawnSG.ini` when saving a game."
 msgstr "游戏还会在保存时自动将 `spawn.ini` 复制到存档文件夹中的 `spawnSG.ini`。"
 
-#: ../../Fixed-or-Improved-Logics.md:306
+#: ../../Fixed-or-Improved-Logics.md:303
 msgid ""
 "Fixed an issue that Ares' Type Conversion not resetting barrel's "
 "direction by `FireAngle`."
 msgstr "修复了 Ares 的单位转换不会通过 `FireAngle` 重设炮管方向的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:307
+#: ../../Fixed-or-Improved-Logics.md:304
 msgid ""
 "Fixed an issue that jumpjet vehicles can not stop correctly when assigned"
 " a target in range."
 msgstr "修复了 Jumpjet 载具在指定射程内目标时无法正确停止的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:308
+#: ../../Fixed-or-Improved-Logics.md:305
 msgid ""
 "Fixed an issue that jumpjet infantry stop incorrectly when assigned a "
 "target out of range."
 msgstr "修复了 Jumpjet 步兵在指定超出射程的目标时停止不正确的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:309
+#: ../../Fixed-or-Improved-Logics.md:306
 msgid ""
 "Fixed an issue that jumpjet infantry' shadow is always drawn even if they"
 " are cloaked."
 msgstr "修复了 Jumpjet 步兵隐形时依然绘制影子的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:310
+#: ../../Fixed-or-Improved-Logics.md:307
 msgid ""
 "Fixed an issue that technos head to building's dock even they are not "
 "going to dock."
 msgstr "修复了单位不执行停靠命令的情况下也会前往停靠位置的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:311
+#: ../../Fixed-or-Improved-Logics.md:308
 msgid ""
 "Fixed an issue that the jumpjet vehicles cannot stop correctly after "
 "going berserk."
 msgstr "修复了被混乱的 Jumpjet 载具无法正确停止的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:312
+#: ../../Fixed-or-Improved-Logics.md:309
 msgid ""
 "Fixed the issue where Ares' `Flash.Duration` cannot override the weapon's"
 " repair flash effect."
 msgstr "修复了 Ares 的 `[WarheadType] -> Flash.Duration=` 无法覆盖维修武器闪光效果的问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:313
+#: ../../Fixed-or-Improved-Logics.md:310
 msgid ""
 "Fixed the bug that building with `CloningFacility=true` and "
 "`WeaponsFactory=true` may cloning multiple vehicles and then they get "
 "stuck."
 msgstr "修复了拥有 `CloningFacility=true` 和 `WeaponsFactory=true` 的建筑可能克隆多个载具并卡住的 Bug。"
 
-#: ../../Fixed-or-Improved-Logics.md:316
+#: ../../Fixed-or-Improved-Logics.md:313
 msgid ""
 "The described behavior is a replica of and is compliant with XNA CnCNet "
 "Client's multiplayer save game support."
 msgstr "上述行为复刻并兼容了 XNA CNCNet Client 的多人游戏存档功能支持。"
 
-#: ../../Fixed-or-Improved-Logics.md:320
+#: ../../Fixed-or-Improved-Logics.md:317
 msgid ""
 "At the moment this is only useful if you use a version of [YRpp "
 "Spawner](https://github.com/CnCNet/yrpp-spawner) with multiplayer saves "
@@ -1914,2476 +1882,196 @@ msgstr ""
 "spawner) 版本（同时配合 [XNA CnCNet Client](https://github.com/CnCNet/xna-"
 "cncnet-client)） 时才有用。"
 
+#: ../../Fixed-or-Improved-Logics.md:320
+msgid "Newly added global settings"
+msgstr "新增的全局设定"
+
 #: ../../Fixed-or-Improved-Logics.md:323
-msgid "Aircraft"
-msgstr "战机类型"
-
-#: ../../Fixed-or-Improved-Logics.md:325
-msgid "Carryall pickup voice"
-msgstr "吊运拾取音效"
-
-#: ../../Fixed-or-Improved-Logics.md:327
 msgid ""
-"It is now possible to override `VoiceMove` for `Carryall=true` aircraft "
-"for when commanding it to pick up vehicles by setting `VoicePickup`."
-msgstr "现在可以通过设置 `VoicePickup` 来覆盖 `Carryall=true` 战机在命令其拾取载具时的 `VoiceMove` 音效。"
+"This category lists all features that are globally effective without "
+"needing to be defined on any specific object."
+msgstr "这个类别下列出了所有全局生效而无需在任何特定对象上定义的功能。"
 
-#: ../../Fixed-or-Improved-Logics.md:329 ../../Fixed-or-Improved-Logics.md:339
-#: ../../Fixed-or-Improved-Logics.md:359 ../../Fixed-or-Improved-Logics.md:382
-#: ../../Fixed-or-Improved-Logics.md:394 ../../Fixed-or-Improved-Logics.md:461
-#: ../../Fixed-or-Improved-Logics.md:540 ../../Fixed-or-Improved-Logics.md:555
-#: ../../Fixed-or-Improved-Logics.md:576 ../../Fixed-or-Improved-Logics.md:598
-#: ../../Fixed-or-Improved-Logics.md:614 ../../Fixed-or-Improved-Logics.md:625
-#: ../../Fixed-or-Improved-Logics.md:640 ../../Fixed-or-Improved-Logics.md:662
-#: ../../Fixed-or-Improved-Logics.md:679 ../../Fixed-or-Improved-Logics.md:697
-#: ../../Fixed-or-Improved-Logics.md:707 ../../Fixed-or-Improved-Logics.md:718
-#: ../../Fixed-or-Improved-Logics.md:748 ../../Fixed-or-Improved-Logics.md:761
-#: ../../Fixed-or-Improved-Logics.md:771 ../../Fixed-or-Improved-Logics.md:783
-#: ../../Fixed-or-Improved-Logics.md:796 ../../Fixed-or-Improved-Logics.md:813
-#: ../../Fixed-or-Improved-Logics.md:825 ../../Fixed-or-Improved-Logics.md:837
-#: ../../Fixed-or-Improved-Logics.md:866 ../../Fixed-or-Improved-Logics.md:895
-#: ../../Fixed-or-Improved-Logics.md:907 ../../Fixed-or-Improved-Logics.md:917
-#: ../../Fixed-or-Improved-Logics.md:927 ../../Fixed-or-Improved-Logics.md:943
-#: ../../Fixed-or-Improved-Logics.md:959 ../../Fixed-or-Improved-Logics.md:975
-#: ../../Fixed-or-Improved-Logics.md:1007
-#: ../../Fixed-or-Improved-Logics.md:1036
-#: ../../Fixed-or-Improved-Logics.md:1047
-#: ../../Fixed-or-Improved-Logics.md:1069
-#: ../../Fixed-or-Improved-Logics.md:1081
-#: ../../Fixed-or-Improved-Logics.md:1098
-#: ../../Fixed-or-Improved-Logics.md:1120
-#: ../../Fixed-or-Improved-Logics.md:1149
-#: ../../Fixed-or-Improved-Logics.md:1202
-#: ../../Fixed-or-Improved-Logics.md:1220
-#: ../../Fixed-or-Improved-Logics.md:1232
-#: ../../Fixed-or-Improved-Logics.md:1243
-#: ../../Fixed-or-Improved-Logics.md:1255
-#: ../../Fixed-or-Improved-Logics.md:1269
-#: ../../Fixed-or-Improved-Logics.md:1290
-#: ../../Fixed-or-Improved-Logics.md:1305
-#: ../../Fixed-or-Improved-Logics.md:1325
-#: ../../Fixed-or-Improved-Logics.md:1343
-#: ../../Fixed-or-Improved-Logics.md:1362
-#: ../../Fixed-or-Improved-Logics.md:1375
-#: ../../Fixed-or-Improved-Logics.md:1386
-#: ../../Fixed-or-Improved-Logics.md:1401
-#: ../../Fixed-or-Improved-Logics.md:1428
-#: ../../Fixed-or-Improved-Logics.md:1458
-#: ../../Fixed-or-Improved-Logics.md:1471
-#: ../../Fixed-or-Improved-Logics.md:1482
-#: ../../Fixed-or-Improved-Logics.md:1502
-#: ../../Fixed-or-Improved-Logics.md:1516
-#: ../../Fixed-or-Improved-Logics.md:1537
-#: ../../Fixed-or-Improved-Logics.md:1587
-#: ../../Fixed-or-Improved-Logics.md:1605
-#: ../../Fixed-or-Improved-Logics.md:1626
-#: ../../Fixed-or-Improved-Logics.md:1655
-#: ../../Fixed-or-Improved-Logics.md:1673
-#: ../../Fixed-or-Improved-Logics.md:1692
-#: ../../Fixed-or-Improved-Logics.md:1704
-#: ../../Fixed-or-Improved-Logics.md:1717
-#: ../../Fixed-or-Improved-Logics.md:1730
-#: ../../Fixed-or-Improved-Logics.md:1742
-#: ../../Fixed-or-Improved-Logics.md:1757
-#: ../../Fixed-or-Improved-Logics.md:1774
-#: ../../Fixed-or-Improved-Logics.md:1789
-#: ../../Fixed-or-Improved-Logics.md:1801
-#: ../../Fixed-or-Improved-Logics.md:1818
-#: ../../Fixed-or-Improved-Logics.md:1835
-#: ../../Fixed-or-Improved-Logics.md:1853
-#: ../../Fixed-or-Improved-Logics.md:1874
-#: ../../Fixed-or-Improved-Logics.md:1889
-#: ../../Fixed-or-Improved-Logics.md:1907
-#: ../../Fixed-or-Improved-Logics.md:1932
-#: ../../Fixed-or-Improved-Logics.md:1949
-#: ../../Fixed-or-Improved-Logics.md:1980
-#: ../../Fixed-or-Improved-Logics.md:2011
-#: ../../Fixed-or-Improved-Logics.md:2035
-#: ../../Fixed-or-Improved-Logics.md:2054
-#: ../../Fixed-or-Improved-Logics.md:2067
-#: ../../Fixed-or-Improved-Logics.md:2079
-#: ../../Fixed-or-Improved-Logics.md:2095
-#: ../../Fixed-or-Improved-Logics.md:2107
-#: ../../Fixed-or-Improved-Logics.md:2120
-#: ../../Fixed-or-Improved-Logics.md:2138
-#: ../../Fixed-or-Improved-Logics.md:2162
-#: ../../Fixed-or-Improved-Logics.md:2175
-#: ../../Fixed-or-Improved-Logics.md:2186
-#: ../../Fixed-or-Improved-Logics.md:2201
-#: ../../Fixed-or-Improved-Logics.md:2215
-#: ../../Fixed-or-Improved-Logics.md:2232
-#: ../../Fixed-or-Improved-Logics.md:2246
-#: ../../Fixed-or-Improved-Logics.md:2258
-#: ../../Fixed-or-Improved-Logics.md:2270
-#: ../../Fixed-or-Improved-Logics.md:2281
-#: ../../Fixed-or-Improved-Logics.md:2292
-#: ../../Fixed-or-Improved-Logics.md:2305
-#: ../../Fixed-or-Improved-Logics.md:2315
-#: ../../Fixed-or-Improved-Logics.md:2331
-#: ../../Fixed-or-Improved-Logics.md:2353
-#: ../../Fixed-or-Improved-Logics.md:2363
-#: ../../Fixed-or-Improved-Logics.md:2377
-#: ../../Fixed-or-Improved-Logics.md:2391
-#: ../../Fixed-or-Improved-Logics.md:2407
-#: ../../Fixed-or-Improved-Logics.md:2432
-msgid "In `rulesmd.ini`:"
-msgstr "在 `rulesmd.ini`："
+#: ../../Fixed-or-Improved-Logics.md:332
+msgid "Crate improvements"
+msgstr "升级工具箱增强"
 
-#: ../../Fixed-or-Improved-Logics.md:330
-msgid ""
-"[SOMEAIRCRAFT]  ; AircraftType\n"
-"VoicePickup=    ; Sound entry\n"
-msgstr ""
-"[SOMEAIRCRAFT]  ; AircraftType\n"
-"VoicePickup=    ; Sound entry\n"
+#: ../../Fixed-or-Improved-Logics.md:334
+msgid "There are some improvements on goodie crate logic:"
+msgstr "对升级工具箱逻辑提供了以下改进："
 
 #: ../../Fixed-or-Improved-Logics.md:335
-msgid "Customize the scatter caused by aircraft attack mission"
-msgstr "自定义战机攻击任务引发分散"
+msgid ""
+"The statistic distribution of the randomly generated crates is now more "
+"uniform within the visible map region by using an optimized sampling "
+"procedure."
+msgstr "优化了随机算法使得随机生成的升级工具箱在可见地图区域内的统计分布更加均匀。"
+
+#: ../../Fixed-or-Improved-Logics.md:336
+msgid ""
+"You can now limit the crates' spawn region to land only by setting "
+"`[CrateRules] -> CreateOnlyOnLand` to true."
+msgstr "现在你可以通过将 `[CrateRules] -> CreateOnlyOnLand` 设为 true 来让升级工具箱的生成区域仅限陆地。"
 
 #: ../../Fixed-or-Improved-Logics.md:337
 msgid ""
-"In vanilla, when an aircraft attacks, it forces the target's cell to "
-"trigger a scatter. Now you can disable this behavior by setting the "
-"following flag to `false`."
-msgstr "在原版中当一架战机发起攻击它会强制触发目标单元格上的分散效果。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:340
-msgid ""
-"[SOMEAIRCRAFT]            ; AircraftType\n"
-"FiringForceScatter=true   ; boolean\n"
+"The limit of vehicles a player can own before unit crates start giving "
+"money instead can now be customized by setting `UnitCrateVehicleCap`. "
+"Negative numbers disable the cap entirely."
 msgstr ""
-"[SOMEAIRCRAFT]            ; AircraftType\n"
-"FiringForceScatter=true   ; boolean\n"
+"现在可以通过 `UnitCrateVehicleCap` "
+"来设置玩家在单位箱子转为给予金钱之前可以拥有的载具数量上限。负数将禁用上限也就是永久生成载具不会达到一定数目后转为金钱。"
 
-#: ../../Fixed-or-Improved-Logics.md:345
-msgid "Extended Aircraft Missions"
-msgstr "拓展的战机任务"
-
-#: ../../Fixed-or-Improved-Logics.md:347
-msgid "Aircraft will now be able to use waypoints."
-msgstr "战机现在将能够使用路径点。"
-
-#: ../../Fixed-or-Improved-Logics.md:348
+#: ../../Fixed-or-Improved-Logics.md:338
 msgid ""
-"When a `guard` command (`[G]` by default) or a `area guard` command "
-"(`[Ctrl]+[Alt]`) is issued, the aircraft will search for targets around "
-"the position (for `guard` is the current location, for `area guard` is "
-"the target position) and return immediately when ammos are depleted."
+"`FreeMCV` setting is now actually respected and can be used to disable "
+"the forced unit selected from `[General] -> BaseUnit` that is given if "
+"player picks a crate and has enough credits but no existing buildings or "
+"`BaseUnit` vehicles."
 msgstr ""
-"当发出 `guard` 命令（默认为 `[G]`）或 `area guard` "
-"命令（`[Ctrl]+[Alt]`）时战机将根据位置（`guard` 为当前位置，`area guard` "
-"为目标位置）周围搜素目标并在弹药耗尽时立即返回。"
+"现在尊重 `FreeMCV` 设置并且可以用来禁止玩家拾取升级工具箱且拥有足够的资金单然而没有建筑或 `BaseUnit` 载具时强制将内容选择为"
+" `[General] -> BaseUnit` 中的单位。"
 
-#: ../../Fixed-or-Improved-Logics.md:349
+#: ../../Fixed-or-Improved-Logics.md:339
 msgid ""
-"If the target is not found, or if there is still ammo when the target is "
-"destroyed, it will continue to hover over the guarded area."
-msgstr "若未发现目标，或摧毁目标后仍有弹药，则继续在警戒区域上方巡游。"
+"The previously hardcoded credits threshold that must be passed can also "
+"now be customized via `FreeMCV.CreditsThreshold`."
+msgstr "现在可以通过 `FreeMCV.CreditsThreshold` 自定义先前硬编码需要高于的资金阈值。"
+
+#: ../../Fixed-or-Improved-Logics.md:341 ../../Fixed-or-Improved-Logics.md:357
+#: ../../Fixed-or-Improved-Logics.md:385 ../../Fixed-or-Improved-Logics.md:396
+#: ../../Fixed-or-Improved-Logics.md:407 ../../Fixed-or-Improved-Logics.md:417
+#: ../../Fixed-or-Improved-Logics.md:428 ../../Fixed-or-Improved-Logics.md:443
+#: ../../Fixed-or-Improved-Logics.md:454 ../../Fixed-or-Improved-Logics.md:474
+#: ../../Fixed-or-Improved-Logics.md:488 ../../Fixed-or-Improved-Logics.md:513
+#: ../../Fixed-or-Improved-Logics.md:544 ../../Fixed-or-Improved-Logics.md:568
+#: ../../Fixed-or-Improved-Logics.md:587 ../../Fixed-or-Improved-Logics.md:606
+#: ../../Fixed-or-Improved-Logics.md:616 ../../Fixed-or-Improved-Logics.md:636
+#: ../../Fixed-or-Improved-Logics.md:659 ../../Fixed-or-Improved-Logics.md:671
+#: ../../Fixed-or-Improved-Logics.md:738 ../../Fixed-or-Improved-Logics.md:817
+#: ../../Fixed-or-Improved-Logics.md:832 ../../Fixed-or-Improved-Logics.md:853
+#: ../../Fixed-or-Improved-Logics.md:875 ../../Fixed-or-Improved-Logics.md:891
+#: ../../Fixed-or-Improved-Logics.md:902 ../../Fixed-or-Improved-Logics.md:917
+#: ../../Fixed-or-Improved-Logics.md:939 ../../Fixed-or-Improved-Logics.md:956
+#: ../../Fixed-or-Improved-Logics.md:974 ../../Fixed-or-Improved-Logics.md:984
+#: ../../Fixed-or-Improved-Logics.md:995 ../../Fixed-or-Improved-Logics.md:1025
+#: ../../Fixed-or-Improved-Logics.md:1038
+#: ../../Fixed-or-Improved-Logics.md:1048
+#: ../../Fixed-or-Improved-Logics.md:1060
+#: ../../Fixed-or-Improved-Logics.md:1073
+#: ../../Fixed-or-Improved-Logics.md:1090
+#: ../../Fixed-or-Improved-Logics.md:1102
+#: ../../Fixed-or-Improved-Logics.md:1114
+#: ../../Fixed-or-Improved-Logics.md:1143
+#: ../../Fixed-or-Improved-Logics.md:1172
+#: ../../Fixed-or-Improved-Logics.md:1184
+#: ../../Fixed-or-Improved-Logics.md:1194
+#: ../../Fixed-or-Improved-Logics.md:1204
+#: ../../Fixed-or-Improved-Logics.md:1220
+#: ../../Fixed-or-Improved-Logics.md:1236
+#: ../../Fixed-or-Improved-Logics.md:1252
+#: ../../Fixed-or-Improved-Logics.md:1284
+#: ../../Fixed-or-Improved-Logics.md:1313
+#: ../../Fixed-or-Improved-Logics.md:1324
+#: ../../Fixed-or-Improved-Logics.md:1346
+#: ../../Fixed-or-Improved-Logics.md:1358
+#: ../../Fixed-or-Improved-Logics.md:1375
+#: ../../Fixed-or-Improved-Logics.md:1407
+#: ../../Fixed-or-Improved-Logics.md:1460
+#: ../../Fixed-or-Improved-Logics.md:1478
+#: ../../Fixed-or-Improved-Logics.md:1490
+#: ../../Fixed-or-Improved-Logics.md:1504
+#: ../../Fixed-or-Improved-Logics.md:1533
+#: ../../Fixed-or-Improved-Logics.md:1559
+#: ../../Fixed-or-Improved-Logics.md:1574
+#: ../../Fixed-or-Improved-Logics.md:1594
+#: ../../Fixed-or-Improved-Logics.md:1612
+#: ../../Fixed-or-Improved-Logics.md:1633
+#: ../../Fixed-or-Improved-Logics.md:1644
+#: ../../Fixed-or-Improved-Logics.md:1659
+#: ../../Fixed-or-Improved-Logics.md:1686
+#: ../../Fixed-or-Improved-Logics.md:1716
+#: ../../Fixed-or-Improved-Logics.md:1729
+#: ../../Fixed-or-Improved-Logics.md:1740
+#: ../../Fixed-or-Improved-Logics.md:1761
+#: ../../Fixed-or-Improved-Logics.md:1801
+#: ../../Fixed-or-Improved-Logics.md:1822
+#: ../../Fixed-or-Improved-Logics.md:1851
+#: ../../Fixed-or-Improved-Logics.md:1869
+#: ../../Fixed-or-Improved-Logics.md:1888
+#: ../../Fixed-or-Improved-Logics.md:1900
+#: ../../Fixed-or-Improved-Logics.md:1913
+#: ../../Fixed-or-Improved-Logics.md:1926
+#: ../../Fixed-or-Improved-Logics.md:1938
+#: ../../Fixed-or-Improved-Logics.md:1952
+#: ../../Fixed-or-Improved-Logics.md:1963
+#: ../../Fixed-or-Improved-Logics.md:1980
+#: ../../Fixed-or-Improved-Logics.md:1995
+#: ../../Fixed-or-Improved-Logics.md:2007
+#: ../../Fixed-or-Improved-Logics.md:2024
+#: ../../Fixed-or-Improved-Logics.md:2041
+#: ../../Fixed-or-Improved-Logics.md:2059
+#: ../../Fixed-or-Improved-Logics.md:2080
+#: ../../Fixed-or-Improved-Logics.md:2095
+#: ../../Fixed-or-Improved-Logics.md:2113
+#: ../../Fixed-or-Improved-Logics.md:2138
+#: ../../Fixed-or-Improved-Logics.md:2155
+#: ../../Fixed-or-Improved-Logics.md:2186
+#: ../../Fixed-or-Improved-Logics.md:2217
+#: ../../Fixed-or-Improved-Logics.md:2241
+#: ../../Fixed-or-Improved-Logics.md:2260
+#: ../../Fixed-or-Improved-Logics.md:2273
+#: ../../Fixed-or-Improved-Logics.md:2285
+#: ../../Fixed-or-Improved-Logics.md:2301
+#: ../../Fixed-or-Improved-Logics.md:2313
+#: ../../Fixed-or-Improved-Logics.md:2326
+#: ../../Fixed-or-Improved-Logics.md:2344
+#: ../../Fixed-or-Improved-Logics.md:2368
+#: ../../Fixed-or-Improved-Logics.md:2381
+#: ../../Fixed-or-Improved-Logics.md:2392
+#: ../../Fixed-or-Improved-Logics.md:2407
+#: ../../Fixed-or-Improved-Logics.md:2421
+#: ../../Fixed-or-Improved-Logics.md:2438
+#: ../../Fixed-or-Improved-Logics.md:2452
+#: ../../Fixed-or-Improved-Logics.md:2464
+#: ../../Fixed-or-Improved-Logics.md:2476
+#: ../../Fixed-or-Improved-Logics.md:2487
+#: ../../Fixed-or-Improved-Logics.md:2498
+#: ../../Fixed-or-Improved-Logics.md:2511
+#: ../../Fixed-or-Improved-Logics.md:2521
+#: ../../Fixed-or-Improved-Logics.md:2537
+#: ../../Fixed-or-Improved-Logics.md:2559
+#: ../../Fixed-or-Improved-Logics.md:2569
+#: ../../Fixed-or-Improved-Logics.md:2583
+msgid "In `rulesmd.ini`:"
+msgstr "在 `rulesmd.ini`："
+
+#: ../../Fixed-or-Improved-Logics.md:342
+msgid ""
+"[CrateRules]\n"
+"CrateOnlyOnLand=false          ; boolean\n"
+"UnitCrateVehicleCap=50         ; integer\n"
+"FreeMCV=true                   ; boolean\n"
+"FreeMCV.CreditsThreshold=1500  ; integer\n"
+msgstr ""
+"[CrateRules]\n"
+"CrateOnlyOnLand=false          ; boolean\n"
+"UnitCrateVehicleCap=50         ; integer\n"
+"FreeMCV=true                   ; boolean\n"
+"FreeMCV.CreditsThreshold=1500  ; integer\n"
 
 #: ../../Fixed-or-Improved-Logics.md:350
-msgid ""
-"When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft "
-"will move towards the destination and search for nearby targets on the "
-"route for attack. Once ammo is depleted or the destination is reached, it"
-" will return."
-msgstr ""
-"当发出 `attack move` "
-"命令（`[Ctrl]+[Shift]`）时战机将向目的地移动并在路线上搜索附近的目标进行攻击。一旦弹药耗尽或抵达目的地，它将返回。"
-
-#: ../../Fixed-or-Improved-Logics.md:351
-msgid ""
-"If the automatically selected target is destroyed but ammo is not "
-"depleted yet during the process, the aircraft will continue flying to the"
-" destination."
-msgstr "如果在过程中自动选择的目标被摧毁但弹药尚未耗尽，战机将继续飞往目的地。"
-
-#: ../../Fixed-or-Improved-Logics.md:352
-msgid "In addition, the actions of aircraft are also changed."
-msgstr "此外，战机的行为也可以更改。"
-
-#: ../../Fixed-or-Improved-Logics.md:353
-msgid ""
-"`ExtendedAircraftMissions.SmoothMoving` controls whether the aircraft "
-"will return to the airport when the distance to the destination is less "
-"than half of `SlowdownDistance` or its turning radius."
-msgstr ""
-"`ExtendedAircraftMissions.SmoothMoving` 控制战机距离目的地距离小于 `SlowdownDistance` "
-"的一半或其转弯半径时是否会返回机场。"
-
-#: ../../Fixed-or-Improved-Logics.md:354
-msgid ""
-"`ExtendedAircraftMissions.EarlyDescend` controls whether the aircraft not"
-" have to fly directly above the airport before starting to descend when "
-"the distance between the aircraft and the landing point is less than "
-"`SlowdownDistance` (also work for aircraft spawned by aircraft carriers)."
-msgstr ""
-"`ExtendedAircraftMissions.EarlyDescend` 控制战机距离着陆点小于 `SlowdownDistance` "
-"时是否无需飞越机场正上方即可开始下降（对航母舰载机同样有效）。"
-
-#: ../../Fixed-or-Improved-Logics.md:355
-msgid ""
-"`ExtendedAircraftMissions.RearApproach` controls whether the aircraft "
-"should start landing at the airport from the opposite direction of "
-"`LandingDir`."
-msgstr ""
-"`ExtendedAircraftMissions.RearApproach` 控制战机返回机场时是否应从与 `LandingDir` "
-"相反的方向飞入，即下降时向 `LandingDir` 的方向飞行并着陆。"
-
-#: ../../Fixed-or-Improved-Logics.md:356
-msgid ""
-"`ExtendedAircraftMissions.FastScramble` controls whether the aircraft can"
-" scramble when its airport has been destroyed."
-msgstr "`ExtendedAircraftMissions.FastScramble` 控制战机在所属的机场被摧毁后是否仍能紧急升空。"
-
-#: ../../Fixed-or-Improved-Logics.md:357
-msgid ""
-"`ExtendedAircraftMissions.UnlandDamage` controls the damage suffered by "
-"the aircraft every 4 frames when there is no airport for the aircraft to "
-"land. If the value is negative, it will crash immediately. Not "
-"recommended to use when `ExtendedAircraftMissions` is not enabled."
-msgstr ""
-"`ExtendedAircraftMissions.UnlandDamage` 控制战机在无机场可降落时每 4 "
-"帧受到的损伤。若为负则立即坠毁。未启用 `ExtendedAircraftMissions` 时不建议使用此参数。"
-
-#: ../../Fixed-or-Improved-Logics.md:360
-msgid ""
-"[General]\n"
-"ExtendedAircraftMissions=false            ; boolean\n"
-"ExtendedAircraftMissions.UnlandDamage=-1  ; integer\n"
-"\n"
-"[SOMEAIRCRAFT]                            ; AircraftType\n"
-"ExtendedAircraftMissions.SmoothMoving=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.EarlyDescend=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.RearApproach=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.FastScramble=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.UnlandDamage=    ; integer, default to [General]"
-" -> ExtendedAircraftMissions.UnlandDamage\n"
-msgstr ""
-"[General]\n"
-"ExtendedAircraftMissions=false            ; boolean\n"
-"ExtendedAircraftMissions.UnlandDamage=-1  ; integer\n"
-"\n"
-"[SOMEAIRCRAFT]                            ; AircraftType\n"
-"ExtendedAircraftMissions.SmoothMoving=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.EarlyDescend=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.RearApproach=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.FastScramble=    ; boolean, default to [General]"
-" -> ExtendedAircraftMissions\n"
-"ExtendedAircraftMissions.UnlandDamage=    ; integer, default to [General]"
-" -> ExtendedAircraftMissions.UnlandDamage\n"
-
-#: ../../Fixed-or-Improved-Logics.md:374
-msgid ""
-"And now when `ExtendedAircraftMissions` is enabled, aircraft that can "
-"land at the airport will check at any time to see if they have a dock. "
-"Therefore, if there are aircraft in your mission that require dock and "
-"you have not provided enough or not disabled the feature, they will crash"
-" immediately"
-msgstr ""
-"目前当 `ExtendedAircraftMissions` "
-"被启用时，能够降落到机场的战机会始终检查自身是否拥有用于停靠的机位。因此若你的任务中需要存在能够降落到机场的战机但没有提供足够的空余机位也没有禁用该功能，那么这些战机将立即坠毁。"
-
-#: ../../Fixed-or-Improved-Logics.md:377
-msgid "Fixed spawn distance & spawn height for airstrike / SpyPlane aircraft"
-msgstr "空袭战机和侦察机的生成距离和生成高度"
-
-#: ../../Fixed-or-Improved-Logics.md:379
-msgid ""
-"It is now possible to have aircraft spawned from "
-"`(Elite)AirstrikeTeamType` or `Type=SpyPlane` superweapons to be created "
-"at fixed distance from their intended target/destination instead of from "
-"edge of the map by setting `SpawnDistanceFromTarget`."
-msgstr ""
-"现在可以通过设置 `SpawnDistanceFromTarget` 来让由 `(Elite)AirstrikeTeamType` 或 "
-"`Type=SpyPlane` 超级武器生成的战机在与目标／目的地固定距离处生成而不再是地图边界。"
-
-#: ../../Fixed-or-Improved-Logics.md:380
-msgid ""
-"`SpawnHeight` can also be used to override the initial height of the "
-"aircraft, which defaults to `FlightLevel`, or if not set then `[General] "
-"-> FlightLevel`."
-msgstr ""
-"也可以通过 `SpawnHeight` 来覆盖战机的初始高度，默认为 `FlightLevel`，如果没有设置则使用 `[General] -> "
-"FlightLevel`。"
-
-#: ../../Fixed-or-Improved-Logics.md:383
-msgid ""
-"[SOMEAIRCRAFT]            ; AircraftType\n"
-"SpawnDistanceFromTarget=  ; floating point value, distance in cells\n"
-"SpawnHeight=              ; integer, height in leptons\n"
-msgstr ""
-
-#: ../../Fixed-or-Improved-Logics.md:389
-msgid "Landing direction"
-msgstr "降落方向"
-
-#: ../../Fixed-or-Improved-Logics.md:391
-msgid ""
-"By default aircraft land facing the direction specified by `[AudioVisual]"
-" -> PoseDir`. This can now be customized per AircraftType via "
-"`LandingDir`, defaults to `[AudioVisual] -> PoseDir`. If the building the"
-" aircraft is docking to has [aircraft docking direction](#aircraft-"
-"docking-direction) set, that setting takes priority over this."
-msgstr ""
-"默认情况下战机降落时朝向 `[AudioVisual] -> PoseDir` 指定的方向。现在可以通过每个战机类型上的 `LandingDir`"
-" 进行自定义，默认为 `[AudioVisual] -> PoseDir`。如果战机停靠的建筑设置了[战机停靠方向](#aircraft-"
-"docking-direction)，则该设置优先于此设置。"
-
-#: ../../Fixed-or-Improved-Logics.md:392
-msgid ""
-"Negative values are allowed as a special case for `AirportBound=false` "
-"aircraft which makes them land facing their current direction."
-msgstr "对于 `AirportBound=false` 的战机允许使用负值以使其降落时面向当前方向。"
-
-#: ../../Fixed-or-Improved-Logics.md:395
-msgid ""
-"[SOMEAIRCRAFT]  ; AircraftType\n"
-"LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
-"values as a special case.\n"
-msgstr ""
-"[SOMEAIRCRAFT]  ; AircraftType\n"
-"LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
-"values as a special case.\n"
-
-#: ../../Fixed-or-Improved-Logics.md:400
-msgid "Animations"
-msgstr "动画类型"
-
-#: ../../Fixed-or-Improved-Logics.md:402
-msgid "Animation weapon and damage settings"
-msgstr "动画武器和伤害设置"
-
-#: ../../Fixed-or-Improved-Logics.md:404
-msgid ""
-"`Weapon` can be set to a WeaponType, to create a projectile and "
-"immediately detonate it instead of simply dealing `Damage` by `Warhead`. "
-"This allows weapon effects to be applied."
-msgstr ""
-"现在 `Weapon` 可以设置为完整的 WeaponType，以创建一个抛射体并立即引爆，而不是简单地通过 `Warhead` 造成 "
-"`Damage`。这允许武器效果正常使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:405
-msgid ""
-"`Damage.Delay` determines delay between two applications of `Damage`. "
-"Requires `Damage` to be set to 1.0 or above. Value of 0 disables the "
-"delay. Keep in mind that this is measured in animation frames, not game "
-"frames. Depending on `Rate`, animation may or may not advance animation "
-"frames on every game frame."
-msgstr ""
-"`Damage.Delay` 确定两次应用 `Damage` 之间的间隔。需要将 `Damage` 设置为 1.0 或更高。值为 0 "
-"将禁用间隔。请注意这是以动画帧为单位而不是游戏帧。动画会根据 `Rate` 可能在每个游戏帧上推进动画帧也可能不进行推进。"
-
-#: ../../Fixed-or-Improved-Logics.md:406
-msgid ""
-"`Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be "
-"considered as coming from the animation's invoker (f.ex, firer of the "
-"weapon if it is Warhead `AnimList/SplashList` animation, the destroyed "
-"vehicle if it is `DestroyAnim` animation or the object the animation is "
-"attached to). If invoker has died or does not exist, the house the "
-"invoker belonged to is still used to deal damage and apply Phobos-"
-"introduced Warhead effects etc. If not set, the animation's owner house, "
-"or failing that, owning house of object it is attached to or the building"
-" it belongs to is used to deal the damage."
-msgstr ""
-"如果设置 `Damage.DealtByInvoker` 为 true，则任何造成的 `Damage` 都被视为来自动画的调用者（例如弹头的 "
-"`AnimList/SplashList` 动画则为武器发射者；如果是 `DestroyAnim` "
-"动画则为被摧毁的载具；或者动画所附着的对象）。即便调用者已经死亡或不存在也会继续使用调用者的所属方来造成伤害并应用 Phobos "
-"引入的弹头效果。若未设置该参数则默认使用动画所有者的所属方，若动画无所有者则使用动画所附着对象的所属方。"
-
-#: ../../Fixed-or-Improved-Logics.md:407
-msgid ""
-"`Damage.ApplyFirepowerMult` determines whether or not firepower modifiers"
-" from the animation's invoker are applied on the damage dealt from this "
-"animation, if exists."
-msgstr "`Damage.ApplyFirepowerMult` 决定动画存在调用者时是否可以获取其火力加成效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:408
-msgid ""
-"`Damage.ApplyOncePerLoop`, if set to true, makes `Damage` be dealt only "
-"once per animation loop (on single loop animations, only once, period) "
-"instead of on every frame or intervals defined by `Damage.Delay`. The "
-"frame on which it is dealt is determined by `Damage.Delay`, defaulting to"
-" after the first animation frame."
-msgstr ""
-"如果设置 `Damage.ApplyOncePerLoop` 为 true，则动画每次循环只造成一次 "
-"`Damage`（在单次循环的动画中只会造成一次）而不是在每帧或由 `Damage.Delay` 定义的间隔造成。造成伤害的帧由 "
-"`Damage.Delay` 决定，默认为在第一个动画帧之后。"
-
-#: ../../Fixed-or-Improved-Logics.md:410 ../../Fixed-or-Improved-Logics.md:431
-#: ../../Fixed-or-Improved-Logics.md:446 ../../Fixed-or-Improved-Logics.md:467
-#: ../../Fixed-or-Improved-Logics.md:488 ../../Fixed-or-Improved-Logics.md:512
-#: ../../Fixed-or-Improved-Logics.md:522 ../../Fixed-or-Improved-Logics.md:565
-#: ../../Fixed-or-Improved-Logics.md:587 ../../Fixed-or-Improved-Logics.md:729
-#: ../../Fixed-or-Improved-Logics.md:989 ../../Fixed-or-Improved-Logics.md:1126
-#: ../../Fixed-or-Improved-Logics.md:1564
-#: ../../Fixed-or-Improved-Logics.md:1636
-#: ../../Fixed-or-Improved-Logics.md:1955
-msgid "In `artmd.ini`:"
-msgstr "在 `artmd.ini`："
-
-#: ../../Fixed-or-Improved-Logics.md:411
-msgid ""
-"[SOMEANIM]                      ; AnimationType\n"
-"Weapon=                         ; WeaponType\n"
-"Damage.Delay=0                  ; integer, animation frames\n"
-"Damage.DealtByInvoker=false     ; boolean\n"
-"Damage.ApplyOncePerLoop=false   ; boolean\n"
-"Damage.ApplyFirepowerMult=false ; boolean\n"
-msgstr ""
-"[SOMEANIM]                      ; AnimationType\n"
-"Weapon=                         ; WeaponType\n"
-"Damage.Delay=0                  ; integer, animation frames\n"
-"Damage.DealtByInvoker=false     ; boolean\n"
-"Damage.ApplyOncePerLoop=false   ; boolean\n"
-"Damage.ApplyFirepowerMult=false ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:421
-msgid ""
-"`Weapon` and `Damage.Delay`, beyond the other additions, should function "
-"similarly to the equivalent features introduced by Ares and take "
-"precedence over them if Phobos is used together with Ares."
-msgstr ""
-"`Weapon` 和 `Damage.Delay`，除了其他新增功能外应与 Ares 引入的等效功能类似，并且在 Phobos 与 Ares "
-"一起使用时优先于它们。"
-
-#: ../../Fixed-or-Improved-Logics.md:424
-msgid "Attached animation position customization"
-msgstr "自定义附着动画位置"
-
-#: ../../Fixed-or-Improved-Logics.md:426
-msgid ""
-"You can now customize position of attached animations via different "
-"values for `AttachedAnimPosition`."
-msgstr "现在你可以通过为 `AttachedAnimPosition` 设置不同的值来自定义附着动画显示的位置。"
-
-#: ../../Fixed-or-Improved-Logics.md:427
-msgid ""
-"`default`: Animation shows up at the parent object's logical position "
-"(for buildings, this is the top-leftmost cell / cell #0)."
-msgstr "`default`：动画显示在父对象的逻辑中心（对于建筑，这是最上方的 0 号单元格）。"
-
-#: ../../Fixed-or-Improved-Logics.md:428
-msgid "`center`: Animation shows up at the parent object's visual center."
-msgstr "`center`：动画显示在父对象的视觉中心。"
-
-#: ../../Fixed-or-Improved-Logics.md:429
-msgid ""
-"`ground`: Animation shows up at the parent object's visual center but "
-"forced to ground level. Note that the animations is still considered "
-"attached to the object and is likely to be drawn above objects that the "
-"object itself would cover unless other settings are used to compensate."
-msgstr "`ground`：动画显示在父对象视觉中心正下方所对应的地面。注意该动画仍被视为附着于对象，因此如果不通过其他设置进行调整的话该动画的图层可能在该对象本应覆盖的其他对象之上。"
-
-#: ../../Fixed-or-Improved-Logics.md:432
-msgid ""
-"[SOMEANIM]                   ; AnimationType\n"
-"AttachedAnimPosition=default ; Attached animation position enumeration "
-"(default|center|ground)\n"
-msgstr ""
-"[SOMEANIM]                   ; AnimationType\n"
-"AttachedAnimPosition=default ; Attached animation position enumeration "
-"(default|center|ground)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:437 ../../Fixed-or-Improved-Logics.md:2046
-msgid "Customizable debris & meteor impact and warhead detonation behaviour"
-msgstr "自定义碎片 & 流星撞击和弹头引爆行为"
-
-#: ../../Fixed-or-Improved-Logics.md:439
-msgid ""
-"`ExplodeOnWater` can be set to true to make the animation explode on "
-"impact with water. `ExpireAnim` will be played and `Warhead` is detonated"
-" or used to deal damage / generate light flash."
-msgstr ""
-"`Warhead.Detonate` 设置为 true 可以使动画在与水面接触时爆炸。`ExpireAnim` 将被触发，`Warhead` "
-"将被引爆或用于造成伤害／产生闪光。"
-
-#: ../../Fixed-or-Improved-Logics.md:440
-msgid ""
-"`Warhead.Detonate`, if set to true, makes the `Warhead` fully detonate "
-"instead of simply being used to deal damage and generate light flash if "
-"it has `Bright=true`."
-msgstr ""
-"如果将 `Warhead.Detonate` 设置为 true，则 `Warhead` 将完全引爆，而不仅仅是用于造成伤害和产生闪光（如果它拥有 "
-"`Bright=true`）。"
-
-#: ../../Fixed-or-Improved-Logics.md:441
-msgid ""
-"`WakeAnim` contains wake animations to play if `ExplodeOnWater` is not "
-"set and the animation impacts with water. Defaults to `[General] -> Wake`"
-" if `IsMeteor` is not set to true, otherwise no animation. If more than "
-"one animation is listed, a random one is selected."
-msgstr ""
-"`WakeAnim` 包含一组在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水波动画。如果 `IsMeteor` 未设置为"
-" true 则默认为 `[General] -> Wake`，否则无动画。如果列出了多个动画，则将随机选择一个。"
-
-#: ../../Fixed-or-Improved-Logics.md:442
-msgid ""
-"`SplashAnims` contains list of splash animations used if `ExplodeOnWater`"
-" is not set and the animation impacts with water."
-msgstr "`SplashAnims` 包含一组在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水花动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:443
-msgid ""
-"If `SplashAnims.PickRandom` is set to true, picks a random animation from"
-" `SplashAnims` to use on each impact with water. Otherwise last listed "
-"animation from `SplashAnims` is used."
-msgstr ""
-"如果设置 `SplashAnims.PickRandom` 为 true，则从 `SplashAnims` 中随机选择一个动画。否则使用 "
-"`SplashAnims` 中列出的最后一个动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:444
-msgid ""
-"`ExtraShadow` can be set to false to disable the display of shadows on "
-"the ground."
-msgstr "`ExtraShadow` 可以设为 false 以禁用地面上的影子显示。"
-
-#: ../../Fixed-or-Improved-Logics.md:447
-msgid ""
-"[SOMEANIM]                    ; AnimationType\n"
-"ExplodeOnWater=false          ; boolean\n"
-"Warhead.Detonate=false        ; boolean\n"
-"WakeAnim=                     ; List of AnimationTypes\n"
-"SplashAnims=                  ; List of AnimationTypes, default to "
-"[CombatDamage] -> SplashList\n"
-"SplashAnims.PickRandom=false  ; boolean\n"
-"ExtraShadow=true              ; boolean\n"
-msgstr ""
-"[SOMEANIM]                    ; AnimationType\n"
-"ExplodeOnWater=false          ; boolean\n"
-"Warhead.Detonate=false        ; boolean\n"
-"WakeAnim=                     ; List of AnimationTypes\n"
-"SplashAnims=                  ; List of AnimationTypes, default to "
-"[CombatDamage] -> SplashList\n"
-"SplashAnims.PickRandom=false  ; boolean\n"
-"ExtraShadow=true              ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:457
-msgid "Customize whether `Crater=yes` animation would destroy tiberium"
-msgstr "自定义 `Crater=yes` 的动画能否摧毁矿石"
-
-#: ../../Fixed-or-Improved-Logics.md:459
-msgid ""
-"In vanilla, the anim with `Crater=yes` is hardcoded to destroy the "
-"tiberium in its cell. Now you can disable this behavior by setting the "
-"following tags to `false`."
-msgstr "在原版中带有 `Crater=yes` 的动画硬编码会摧毁其所在单元格的矿石。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:462
-msgid ""
-"[General]\n"
-"AnimCraterDestroyTiberium=true  ; boolean\n"
-msgstr ""
-"[General]\n"
-"AnimCraterDestroyTiberium=true  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:468
-msgid ""
-"[SOMEANIM]                      ; AnimationType\n"
-"Crater.DestroyTiberium=         ; boolean, default to [General] -> "
-"AnimCraterDestroyTiberium\n"
-msgstr ""
-"[SOMEANIM]                      ; AnimationType\n"
-"Crater.DestroyTiberium=         ; boolean, default to [General] -> "
-"AnimCraterDestroyTiberium\n"
-
-#: ../../Fixed-or-Improved-Logics.md:473
-msgid "Fire animations spawned by Scorch & Flamer"
-msgstr "由 Scorch 和 Flamer 生成的火焰动画"
-
-#: ../../Fixed-or-Improved-Logics.md:475
-msgid ""
-"Tiberian Sun allowed `Scorch=true` and `Flamer=true` animations to spawn "
-"fire animations from `[AudioVisual] -> SmallFire` & `LargeFire`. This "
-"behaviour has been reimplemented and is fully customizable."
-msgstr ""
-"《泰伯利亚之日》中允许 `Scorch=true` 和 `Flamer=true` 的动画生成 `[AudioVisual] -> "
-"SmallFire` 和 `LargeFire` 指定的火焰动画。此行为已重新实现，并且完全可自定义。"
-
-#: ../../Fixed-or-Improved-Logics.md:476
-msgid ""
-"`ConstrainFireAnimsToCellSpots` controls whether or not spawned "
-"animations are locked to cell spots (e.g the subcell positions infantry "
-"are also constrained to)."
-msgstr "`ConstrainFireAnimsToCellSpots` 控制生成的动画是否锁定到单元格位置（例如步兵也受子单元格位置限制）。"
-
-#: ../../Fixed-or-Improved-Logics.md:477
-msgid ""
-"`FireAnimDisallowedLandTypes` controls which landtypes the fire "
-"animations are not allowed to spawn on. Defaults to "
-"`water,rock,beach,ice` for `Scorch=true`, `none` otherwise."
-msgstr ""
-"`FireAnimDisallowedLandTypes` 控制不允许生成火焰动画的地形类型。对于 `Scorch=true` 默认为 "
-"`water,rock,beach,ice` 否则为 `none`。"
-
-#: ../../Fixed-or-Improved-Logics.md:478
-msgid ""
-"`AttachFireAnimsToParent` controls if the spawned animations are attached"
-" to the owner of the parent animation if it is also attached. Defaults to"
-" true for `Scorch=true`, otherwise false."
-msgstr ""
-"`AttachFireAnimsToParent` 控制生成的动画是否附着于父动画所附着的对象（如果父动画也是附着动画）。对于 "
-"`Scorch=true` 默认为 true，否则为 false。"
-
-#: ../../Fixed-or-Improved-Logics.md:479
-msgid ""
-"`SmallFireCount` determines number of small fire animations to spawn by "
-"both `Scorch=true` and `Flamer=true` animations. Defaults to 2 for "
-"`Flamer=true`, otherwise 1."
-msgstr ""
-"`SmallFireCount` 决定由 `Scorch=true` 和 `Flamer=true` 动画生成小火焰动画的数量。对于 "
-"`Flamer=true` 默认为 2，否则为 1。"
-
-#: ../../Fixed-or-Improved-Logics.md:480
-msgid ""
-"`SmallFireAnims` can be used to set the animation types, defaults to "
-"`[AudioVisual] -> SmallFire` (single animation)."
-msgstr "`SmallFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> SmallFire`（单个动画）。"
-
-#: ../../Fixed-or-Improved-Logics.md:481
-msgid ""
-"`SmallFireChances` is a list of probabilities for the animations to "
-"spawn, up to `SmallFireCount` amount of items are read. Last item listed "
-"is used if count exceeds the number of listed probabilities. Defaults to "
-"`1.0,0.5` for `Flamer=true`, `1.0` otherwise."
-msgstr ""
-"`SmallFireChances` 是一个用于动画生成的概率列表，最多读取前 `SmallFireCount` "
-"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `1.0,0.5`，否则为 "
-"`1.0`。"
-
-#: ../../Fixed-or-Improved-Logics.md:482
-msgid ""
-"`SmallFireDistances` is a list of distances in cells for the animations "
-"to spawn at from the parent animation's coordinates, up to "
-"`SmallFireCount` amount of items are read. Last item listed is used if "
-"count exceeds the number of listed probabilities. Defaults to "
-"`0.25,0.625` for `Flamer=true`, `0.0` otherwise."
-msgstr ""
-"`SmallFireDistances` 是一个用于动画相对父动画坐标生成位置单元格距离的列表，最多读取前 `SmallFireCount` "
-"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `0.25,0.625`，否则为 "
-"`0.0`。"
-
-#: ../../Fixed-or-Improved-Logics.md:483
-msgid ""
-"`LargeFireCount` determines number of large fire animations to spawn by "
-"`Flamer=true` animations only."
-msgstr "`LargeFireCount` 决定仅由 `Flamer=true` 动画生成的大火焰动画的数量。"
-
-#: ../../Fixed-or-Improved-Logics.md:484
-msgid ""
-"`LargeFireAnims` can be used to set the animation types, defaults to "
-"`[AudioVisual] -> LargeFire` (single animation)."
-msgstr "`LargeFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> LargeFire`（单个动画）。"
-
-#: ../../Fixed-or-Improved-Logics.md:485
-msgid ""
-"`LargeFireChances` is a list of probabilities for the animations to "
-"spawn, up to `LargeFireCount` amount of items are read. Last item listed "
-"is used if count exceeds the number of listed probabilities."
-msgstr ""
-"`LargeFireChances` 是一个用于动画生成的概率列表，最多读取前 `LargeFireCount` "
-"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
-
-#: ../../Fixed-or-Improved-Logics.md:486
-msgid ""
-"`LargeFireDistances` is a list of distances in cells for the animations "
-"to spawn at from the parent animation's coordinates, up to "
-"`LargeFireCount` amount of items are read. Last item listed is used if "
-"count exceeds the number of listed probabilities."
-msgstr ""
-"`SmallFireDistances` 是一个用于动画相对父动画坐标生成位置单元格距离的列表，最多读取前 `LargeFireCount` "
-"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
-
-#: ../../Fixed-or-Improved-Logics.md:489
-msgid ""
-"[SOMEANIM]                          ; AnimationType\n"
-"ConstrainFireAnimsToCellSpots=true  ; boolean\n"
-"FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | "
-"road | water | rock | wall | tiberium | beach | rough | ice | railroad | "
-"tunnel | weeds)\n"
-"AttachFireAnimsToParent=            ; boolean\n"
-"SmallFireCount=                     ; integer\n"
-"SmallFireAnims=                     ; List of AnimationTypes\n"
-"SmallFireChances=                   ; List of floating point values "
-"(percent or absolute)\n"
-"SmallFireDistances=                 ; List of floating point values, "
-"distance in cells\n"
-"LargeFireCount=1                    ; integer\n"
-"LargeFireAnims=                     ; List of AnimationTypes\n"
-"LargeFireChances=0.5                ; List of floating point values "
-"(percent or absolute)\n"
-"LargeFireDistances=0.4375           ; List of floating point values, "
-"distance in cells\n"
-msgstr ""
-"[SOMEANIM]                          ; AnimationType\n"
-"ConstrainFireAnimsToCellSpots=true  ; boolean\n"
-"FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | "
-"road | water | rock | wall | tiberium | beach | rough | ice | railroad | "
-"tunnel | weeds)\n"
-"AttachFireAnimsToParent=            ; boolean\n"
-"SmallFireCount=                     ; integer\n"
-"SmallFireAnims=                     ; List of AnimationTypes\n"
-"SmallFireChances=                   ; List of floating point values "
-"(percent or absolute)\n"
-"SmallFireDistances=                 ; List of floating point values, "
-"distance in cells\n"
-"LargeFireCount=1                    ; integer\n"
-"LargeFireAnims=                     ; List of AnimationTypes\n"
-"LargeFireChances=0.5                ; List of floating point values "
-"(percent or absolute)\n"
-"LargeFireDistances=0.4375           ; List of floating point values, "
-"distance in cells\n"
-
-#: ../../Fixed-or-Improved-Logics.md:505
-msgid ""
-"Save for the change that `Flamer` does not spawn animations if the parent"
-" animation is in air, the default settings should provide identical "
-"results to similar feature from Ares."
-msgstr "除了 `Flamer` 在父动画位于空中时不生成这一更改外，默认设置应该与 Ares 中类似功能拥有相同的效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:508
-msgid "Layer on animations attached to objects"
-msgstr "附加动画的图层"
-
-#: ../../Fixed-or-Improved-Logics.md:510
-msgid ""
-"You can now customize whether or not animations attached to objects "
-"follow the object's layer or respect their own `Layer` setting. If this "
-"is unset, attached animations use `ground` layer."
-msgstr "现在你可以自定义让附加于对象的动画跟随对象的图层还是遵循它们自身的 `Layer` 设置。如果不设置，附加的动画会使用 `ground` 图层。"
-
-#: ../../Fixed-or-Improved-Logics.md:513
-msgid ""
-"[SOMEANIM]             ; AnimationType\n"
-"Layer.UseObjectLayer=  ; boolean\n"
-msgstr ""
-"[SOMEANIM]             ; AnimationType\n"
-"Layer.UseObjectLayer=  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:518
-msgid "Ore stage threshold for `HideIfNoOre`"
-msgstr "`HideIfNoOre` 的矿石阶段阈值"
-
-#: ../../Fixed-or-Improved-Logics.md:520
-msgid ""
-"You can now customize which growth stage should an ore/tiberium cell have"
-" to have animation with `HideIfNoOre` displayed. Cells with growth stage "
-"less than specified value won't allow the anim to display."
-msgstr ""
-"现在你可以自定义一个矿石／泰伯利亚所在的单元格至少需要到哪个生长阶段才能显示带有 `HideIfNoOre` "
-"的动画。生长阶段低于指定值的单元格将不允许动画显示。"
-
-#: ../../Fixed-or-Improved-Logics.md:523
-msgid ""
-"[SOMEANIM]               ; AnimationType\n"
-"HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
-msgstr ""
-"[SOMEANIM]               ; AnimationType\n"
-"HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
-
-#: ../../Fixed-or-Improved-Logics.md:528
-msgid "Buildings"
-msgstr "建筑类型"
-
-#: ../../Fixed-or-Improved-Logics.md:530
-msgid "AI base construction modification"
-msgstr "AI 基地建设机制更改"
-
-#: ../../Fixed-or-Improved-Logics.md:532
-msgid "AI can now have some new behaviors."
-msgstr "现在 AI 可以执行一些新的行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:533
-msgid ""
-"`AIAutoDeployMCV` controls whether AI will still automatically deploy the"
-" mcv after owning a construction yard."
-msgstr "`AIAutoDeployMCV` 控制 AI 在拥有建造厂后是否仍然会自动部署 MCV。"
-
-#: ../../Fixed-or-Improved-Logics.md:534
-msgid ""
-"`AISetBaseCenter` controls whether AI will still set the newly deployed "
-"construction yard as the base center after owning a construction yard."
-msgstr "`AISetBaseCenter` 控制 AI 在拥有建造厂后是否仍会将新部署的建造厂设为基地中心。"
-
-#: ../../Fixed-or-Improved-Logics.md:535
-msgid ""
-"`AIBiasSpawnCell` controls whether AI will preferentially select the "
-"construction yard close to the birth point as the base center (useless in"
-" campaign)."
-msgstr "`AIBiasSpawnCell` 控制 AI 是否优先选择靠近出生点的建造厂作为基地中心（战役模式无效）。"
-
-#: ../../Fixed-or-Improved-Logics.md:536
-msgid ""
-"`AIForbidConYard` controls whether AI cannot place buildings with "
-"`ConstructionYard=true`. AI will try to build one after a construction "
-"yard is destroyed but will not put it down. After that, it will continue "
-"to build other buildings. Building a construction yard will still take "
-"some time. You can try to reduce the build time of it."
-msgstr ""
-"`AIForbidConYard` 控制 AI 是否禁止摆放拥有 `ConstructionYard=true` 的建筑。当建造厂被摧毁后 AI "
-"会尝试重建但不会实际摆放。随后它会继续建造其他建筑。建造厂的建造仍会占用时间。你可以尝试缩短它的建造所需时长。"
-
-#: ../../Fixed-or-Improved-Logics.md:537
-msgid ""
-"`AINodeWallsOnly` controls whether AI can only automatically connect "
-"adjacent walls when there are wall base nodes around."
-msgstr "`AINodeWallsOnly` 控制 AI 是否仅在周围存在围墙节点时才自动连接相邻围墙。"
-
-#: ../../Fixed-or-Improved-Logics.md:538
-msgid ""
-"`AICleanWallNode` controls whether AI cannot place walls when there are "
-"no `ProtectWithWall` buildings around. If it cannot be placed, this base "
-"node will also be removed."
-msgstr ""
-"`AICleanWallNode` 控制 AI 是否在周边都是无 `ProtectWithWall` "
-"的建筑时禁止摆放围墙。若无法摆放，该基地节点将被一同移除。"
-
-#: ../../Fixed-or-Improved-Logics.md:541
-msgid ""
-"[AI]\n"
-"AIAutoDeployMCV=true   ; boolean\n"
-"AISetBaseCenter=true   ; boolean\n"
-"AIBiasSpawnCell=false  ; boolean\n"
-"AIForbidConYard=false  ; boolean\n"
-"AINodeWallsOnly=false  ; boolean\n"
-"AICleanWallNode=false  ; boolean\n"
-msgstr ""
-"[AI]\n"
-"AIAutoDeployMCV=true   ; boolean\n"
-"AISetBaseCenter=true   ; boolean\n"
-"AIBiasSpawnCell=false  ; boolean\n"
-"AIForbidConYard=false  ; boolean\n"
-"AINodeWallsOnly=false  ; boolean\n"
-"AICleanWallNode=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:551
-msgid "Aircraft docking direction"
-msgstr "战机停靠方向"
-
-#: ../../Fixed-or-Improved-Logics.md:553
-msgid ""
-"It is now possible to customize the landing direction for docking "
-"aircraft via `AircraftDockingDir(N)` (`N` optionally replaced by 0-based "
-"index for each `DockingOffset` separately, `AircraftDockingDir` and "
-"`AircraftDockingDir0` are synonymous and will be used if direction is not"
-" set for a specific offset) on the dock building. This overrides the "
-"aircraft's own [landing direction](#landing-direction) setting and "
-"defaults to `[AudioVisual] -> PoseDir`."
-msgstr ""
-"现在可以通过在停靠建筑上使用 `AircraftDockingDir(N)` （`N` 可选地分别替换为每个从 0 开始的 "
-"`DockingOffset` 索引，`AircraftDockingDir` 与 `AircraftDockingDir0` "
-"是没有为特定偏移设置方向时将使用的同义词）来设置停靠战机的降落方向。这会覆盖战机自己的 [降落方向](#landing-direction) "
-"设置并默认为 `[AudioVisual] -> PoseDir`。"
-
-#: ../../Fixed-or-Improved-Logics.md:556
-msgid ""
-"[SOMEBUILDING]          ; BuildingType\n"
-"AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
-msgstr ""
-"[SOMEBUILDING]          ; BuildingType\n"
-"AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:561
-msgid "Allows refineries to use multiple ActiveAnim simultaneously"
-msgstr "允许矿场同时播放多个 `ActiveAnim` 动画"
-
-#: ../../Fixed-or-Improved-Logics.md:563
-msgid ""
-"In vanilla, the refinery uses different ActiveAnims depending on the "
-"storage. You can now make it use multiple ActiveAnims simultaneously like"
-" any other building."
-msgstr "在原版中矿场会根据其矿石存储量的不同播放不同的 `ActiveAnim`。现在你可以让它像其他建筑一样同时播放多个 `ActiveAnim`。"
-
-#: ../../Fixed-or-Improved-Logics.md:566
-msgid ""
-"[SOMEBUILDING]                         ; BuildingType\n"
-"Refinery.UseNormalActiveAnim=false     ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]                         ; BuildingType\n"
-"Refinery.UseNormalActiveAnim=false     ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:571
-msgid "Allowed / disallowed types for FactoryPlant"
-msgstr "工业工厂的类型限制"
-
-#: ../../Fixed-or-Improved-Logics.md:573
-msgid ""
-"It is now possible to customize which TechnoTypes benefit from bonuses of"
-" a `FactoryPlant=true` building by listing them on "
-"`FactoryPlant.AllowTypes` and/or `FactoryPlant.DisallowTypes`."
-msgstr ""
-"现在可以通过在 `FactoryPlant.AllowTypes` 和 `FactoryPlant.DisallowTypes` "
-"中列出有哪些科技类型受到 `FactoryPlant=true` 建筑的加成。"
-
-#: ../../Fixed-or-Improved-Logics.md:574
-msgid ""
-"`FactoryPlant.Multiplier` *(Ares feature)* is still applied on the "
-"bonuses if they are in effect."
-msgstr "`FactoryPlant.Multiplier`（*Ares 功能*）仍然会应用于加成。"
-
-#: ../../Fixed-or-Improved-Logics.md:577
-msgid ""
-"[SOMEBUILDING]               ; BuildingType\n"
-"FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
-"FactoryPlant.DisallowTypes=  ; List of TechnoTypes\n"
-msgstr ""
-"[SOMEBUILDING]               ; BuildingType\n"
-"FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
-"FactoryPlant.DisallowTypes=  ; List of TechnoTypes\n"
-
-#: ../../Fixed-or-Improved-Logics.md:583
-msgid "Apply ZShapePointMove during buildups"
-msgstr "在拔起期间应用 ZShapePointMove"
-
-#: ../../Fixed-or-Improved-Logics.md:585
-msgid ""
-"By default buildings do not apply `ZShapePointMove` (which offsets the 'z"
-" shape' applied on buildings which is used to adjust them in depth buffer"
-" and is used to fix issues related to that such as corners of buildings "
-"getting cut off when drawn) when buildup is being displayed. This "
-"behaviour can now be toggled by setting `ZShapePointMove.OnBuildup`."
-msgstr ""
-"默认情况下建筑物在播放建造动画时并不应用 `ZShapePointMove`（这会调整应用于建筑物的 z shape "
-"以在深度缓冲区中调整它们并用于修复与此相关的例如建筑缺角等问题）。现在可以通过设置 `ZShapePointMove.OnBuildup` "
-"来开关此行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:588
-msgid ""
-"[SOMEBUILDING]                   ; BuildingType\n"
-"ZShapePointMove.OnBuildup=false  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]                   ; BuildingType\n"
-"ZShapePointMove.OnBuildup=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:593
-msgid "Buildings considered as vehicles"
-msgstr "被视为载具的建筑"
-
-#: ../../Fixed-or-Improved-Logics.md:595
-msgid ""
-"By default game considers buildings with both `UndeploysInto` set and "
-"`Foundation` equaling `1x1` as vehicles, in a manner of speaking. This "
-"behaviour can now be toggled individually of these conditions by setting "
-"`ConsideredVehicle`. These buildings are counted as vehicles for unit "
-"count tracking, are not considered as base under attack when damaged and "
-"can be mass selected by default, for an example."
-msgstr ""
-"总的来说默认情况下游戏将同时设置了 `UndeploysInto` 且 `Foundation=1x1` 的建筑视为载具。现在可以通过设置 "
-"`ConsideredVehicle` 来开关此行为。这些建筑在单位计数追踪中被视为载具，受损时不会被视为基地受到攻击，并且默认可以进行批量选择。"
-
-#: ../../Fixed-or-Improved-Logics.md:596
-msgid ""
-"When capturing such \"buildings\", the player won't be notified by EVA "
-"capture event."
-msgstr "当占领此类 “建筑” 时，玩家不会收到 EVA 占领事件的播报。"
-
-#: ../../Fixed-or-Improved-Logics.md:599
-msgid ""
-"[SOMEBUILDING]      ; BuildingType\n"
-"ConsideredVehicle=  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]      ; BuildingType\n"
-"ConsideredVehicle=  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:604
-msgid "Custom exit cell for infantry factory"
-msgstr "兵营自定义出口"
-
-#: ../../Fixed-or-Improved-Logics.md:606
-msgid ""
-"By default `Factory=InfantryType` buildings use exit cell for the created"
-" infantry based on hardcoded settings if any of `GDIBarracks`, "
-"`NODBarracks` or `YuriBarracks` are set to true. It is now possible to "
-"define arbitrary exit cell for such building via `BarracksExitCell`. "
-"Below is a reference of the cell offsets for the hardcoded values."
-msgstr ""
-"默认情况下如果 `GDIBarracks`、`NODBarracks` 或 `YuriBarracks` 中的任何一个设置为 true，则 "
-"`Factory=InfantryType` 的建筑将会根据硬编码设置为创建的步兵设置出口单元格。现在可以通过 "
-"`BarracksExitCell` 为这类建筑定义任意单元格为出口。以下是硬编码值的单元格偏移量参考值。"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "Key"
-msgstr "标签"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "Cell Offset"
-msgstr "单元格偏移"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "`GDIBarracks`"
-msgstr "`GDIBarracks`"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "1,2"
-msgstr "1,2"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "`NODBarracks`"
-msgstr "`NODBarracks`"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "2,2"
-msgstr "2,2"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "`YuriBarracks`"
-msgstr "`YuriBarracks`"
-
-#: ../../Fixed-or-Improved-Logics.md:504
-msgid "2,1"
-msgstr "2,1"
-
-#: ../../Fixed-or-Improved-Logics.md:615
-msgid ""
-"[SOMEBUILDING]     ; BuildingType\n"
-"BarracksExitCell=  ; X,Y - cell offset\n"
-msgstr ""
-"[SOMEBUILDING]     ; BuildingType\n"
-"BarracksExitCell=  ; X,Y - cell offset\n"
-
-#: ../../Fixed-or-Improved-Logics.md:620
-msgid "Customizable garrison and bunker properties"
-msgstr "自定义驻军建筑与坦克碉堡属性"
-
-#: ../../Fixed-or-Improved-Logics.md:622
-msgid ""
-"You can now customize damage or ROF multipliers of a garrison or tank "
-"bunker building."
-msgstr "现在可以自定义驻军建筑或坦克堡垒的 Damage 或 ROF 倍率。"
-
-#: ../../Fixed-or-Improved-Logics.md:623
-msgid "You can now customize enter or exit sound of a tank bunker building."
-msgstr "现在可以自定义坦克碉堡建筑进入和离开时的音效。"
-
-#: ../../Fixed-or-Improved-Logics.md:626
-msgid ""
-"[SOMEBUILDING]              ; BuildingType\n"
-"OccupyDamageMultiplier=     ; floating point value, default to "
-"[CombatDamage] -> OccupyDamageMultiplier\n"
-"OccupyROFMultiplier=        ; floating point value, default to "
-"[CombatDamage] -> OccupyROFMultiplier\n"
-"BunkerDamageMultiplier=     ; floating point value, default to "
-"[CombatDamage] -> BunkerDamageMultiplier\n"
-"BunkerROFMultMultiplier=    ; floating point value, default to "
-"[CombatDamage] -> BunkerROFMultMultiplier\n"
-"BunkerWallsUpSound=         ; Sound entry, default to [AudioVisual] -> "
-"BunkerWallsUpSound\n"
-"BunkerWallsDownSound=       ; Sound entry, default to [AudioVisual] -> "
-"BunkerWallsDownSound\n"
-msgstr ""
-"[SOMEBUILDING]              ; BuildingType\n"
-"OccupyDamageMultiplier=     ; floating point value, default to "
-"[CombatDamage] -> OccupyDamageMultiplier\n"
-"OccupyROFMultiplier=        ; floating point value, default to "
-"[CombatDamage] -> OccupyROFMultiplier\n"
-"BunkerDamageMultiplier=     ; floating point value, default to "
-"[CombatDamage] -> BunkerDamageMultiplier\n"
-"BunkerROFMultMultiplier=    ; floating point value, default to "
-"[CombatDamage] -> BunkerROFMultMultiplier\n"
-"BunkerWallsUpSound=         ; Sound entry, default to [AudioVisual] -> "
-"BunkerWallsUpSound\n"
-"BunkerWallsDownSound=       ; Sound entry, default to [AudioVisual] -> "
-"BunkerWallsDownSound\n"
-
-#: ../../Fixed-or-Improved-Logics.md:636
-msgid ""
-"Customizable selling buildup sequence length for buildings that can "
-"undeploy"
-msgstr "自定义可反部署建筑出售序列动画长度"
-
-#: ../../Fixed-or-Improved-Logics.md:638
-msgid ""
-"By default buildings with `UndeploysInto` will only play 23 frames of "
-"their buildup sequence (in reverse starting from last frame) when being "
-"sold as opposed to being undeployed. This can now be customized via "
-"`SellBuildupLength`."
-msgstr ""
-"默认情况下拥有 `UndeploysInto` 的建筑在出售时只会播放其建造动画序列的前 23 帧（从最后一帧开始反向播放）。现在可以通过 "
-"`SellBuildupLength` 自定义。"
-
-#: ../../Fixed-or-Improved-Logics.md:641
-msgid ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"SellBuildupLength=23  ; integer, number of buildup frames to play\n"
-msgstr ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"SellBuildupLength=23  ; integer, number of buildup frames to play\n"
-
-#: ../../Fixed-or-Improved-Logics.md:646
-msgid "Customizable & new grinder properties"
-msgstr "自定义 & 新的部队回收站特性"
-
-#: ../../Fixed-or-Improved-Logics.md:648
-msgid ""
-"![image](_static/images/grinding.gif) *Using ally grinder, restricting to"
-" vehicles only and refund display ([Project "
-"Phantom](https://www.moddb.com/mods/project-phantom))*"
-msgstr ""
-"![image](_static/images/grinding.gif) *[幽灵计划](https://www.moddb.com/mods"
-"/project-phantom) 中使用友军的部队回收站、仅限载具以及显示资金*"
-
-#: ../../Fixed-or-Improved-Logics.md:651
-msgid ""
-"You can now customize which types of objects a building with `Grinding` "
-"set can grind as well as the grinding sound."
-msgstr "现在你可以自定义具有 `Grinding` 设置的建筑可回收的对象类别以及回收使用的音效。"
-
-#: ../../Fixed-or-Improved-Logics.md:652
-msgid ""
-"`Grinding.AllowAllies` changes whether or not to allow units to enter "
-"allies' buildings."
-msgstr "`Grinding.AllowAllies` 决定是否允许单位进入友军的这座建筑。"
-
-#: ../../Fixed-or-Improved-Logics.md:653
-msgid ""
-"`Grinding.AllowOwner` changes whether or not to allow units to enter your"
-" own buildings."
-msgstr "`Grinding.AllowOwner` 决定是否允许单位进入己方的这座建筑。"
-
-#: ../../Fixed-or-Improved-Logics.md:654
-msgid ""
-"`Grinding.AllowTypes` can be used to define InfantryTypes and "
-"VehicleTypes that can be grinded by the building. Listing any will "
-"disable grinding for all types except those listed."
-msgstr "`Grinding.AllowTypes` 可以用于定义可以被这座建筑回收的步兵和载具。只要设置列表就会导致其他不在表中的任何类型无法被回收。"
-
-#: ../../Fixed-or-Improved-Logics.md:655
-msgid ""
-"`Grinding.DisallowTypes` can be used to exclude InfantryTypes or "
-"VehicleTypes from being able to enter the grinder building."
-msgstr "`Grinding.DisallowTypes` 可以定义不可被这座建筑回收的步兵和载具。"
-
-#: ../../Fixed-or-Improved-Logics.md:656
-msgid ""
-"`Grinding.PlayDieSound` controls if the units' `DieSound` and `VoiceDie` "
-"are played when entering the grinder."
-msgstr "`Grinding.PlayDieSound` 控制单位的 `DieSound` 和 `VoiceDie` 是否都会在进入回收站时播放。"
-
-#: ../../Fixed-or-Improved-Logics.md:657
-msgid ""
-"`Grinding.Sound` is a sound played by when object is grinded by the "
-"building."
-msgstr "`Grinding.Sound` 用于定义物体被这座建筑回收时所播放的音效。"
-
-#: ../../Fixed-or-Improved-Logics.md:658
-msgid ""
-"`Grinding.Weapon` is a weapon fired at the building & by the building "
-"when it grinds an object. Will only be fired if at least weapon's `ROF` "
-"amount of frames have passed since it was last fired."
-msgstr ""
-"`Grinding.Weapon` 用于定义当建筑回收物体时由建筑向该建筑发射的武器。只有在其上次开火以来至少经过了武器 `ROF` "
-"设置的帧数后才能被发射。"
-
-#: ../../Fixed-or-Improved-Logics.md:659
-msgid ""
-"`Grinding.Weapon.RequiredCredits` can be set to have the weapon require "
-"accumulated credits from grinding to fire. Accumulated credits for this "
-"purpose are reset every time when the weapon fires."
-msgstr "`Grinding.Weapon.RequiredCredits` 可以设置武器开火所需的资金。为此目的积累的资金会在每次武器开火时重置。"
-
-#: ../../Fixed-or-Improved-Logics.md:660
-msgid ""
-"For money string indication upon grinding, please refer to "
-"[`DisplayIncome`](User-Interface.md#visual-indication-of-income-from-"
-"grinders-and-refineries)."
-msgstr ""
-"关于回收时的资金字符串提示，请参考 [`DisplayIncome`](User-Interface.md#visual-indication-"
-"of-income-from-grinders-and-refineries)。"
-
-#: ../../Fixed-or-Improved-Logics.md:663
-msgid ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"Grinding.AllowAllies=false         ; boolean\n"
-"Grinding.AllowOwner=true           ; boolean\n"
-"Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes"
-"\n"
-"Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes"
-"\n"
-"Grinding.PlayDieSound=true         ; boolean\n"
-"Grinding.Sound=                    ; Sound entry, default to "
-"[AudioVisual] -> EnterGrinderSound\n"
-"Grinding.Weapon=                   ; WeaponType\n"
-"Grinding.Weapon.RequiredCredits=0  ; integer\n"
-msgstr ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"Grinding.AllowAllies=false         ; boolean\n"
-"Grinding.AllowOwner=true           ; boolean\n"
-"Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes"
-"\n"
-"Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes"
-"\n"
-"Grinding.PlayDieSound=true         ; boolean\n"
-"Grinding.Sound=                    ; Sound entry, default to "
-"[AudioVisual] -> EnterGrinderSound\n"
-"Grinding.Weapon=                   ; WeaponType\n"
-"Grinding.Weapon.RequiredCredits=0  ; integer\n"
-
-#: ../../Fixed-or-Improved-Logics.md:675
-msgid "Customize overpower logic"
-msgstr "自定义磁暴线圈充能"
-
-#: ../../Fixed-or-Improved-Logics.md:677
-msgid "Now you can specific how building can be overpowerd."
-msgstr "现在你可以设定建筑什么情形下才会过载。"
-
-#: ../../Fixed-or-Improved-Logics.md:680
-msgid ""
-"[SOMEWARHEAD]             ; WarheadType\n"
-"ElectricAssaultLevel=1    ; integer\n"
-"\n"
-"[SOMEBUILDING]            ; BuildingType\n"
-"Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
-"keep online\n"
-"Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
-"can never be switched\n"
-msgstr ""
-"[SOMEWARHEAD]             ; WarheadType\n"
-"ElectricAssaultLevel=1    ; integer\n"
-"\n"
-"[SOMEBUILDING]            ; BuildingType\n"
-"Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
-"keep online\n"
-"Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
-"can never be switched\n"
-
-#: ../../Fixed-or-Improved-Logics.md:690
-msgid ""
-"Ares' [Battery Super Weapon](https://ares-developers.github.io/Ares-"
-"docs/new/superweapons/types/battery.html) won't be affected by this."
-msgstr ""
-"Ares 的 [电池超武](https://ares-developers.github.io/Ares-"
-"docs/new/superweapons/types/battery.html) 不受此影响。"
-
-#: ../../Fixed-or-Improved-Logics.md:693
-msgid "Disable `DamageSound`"
-msgstr "禁用 `DamageSound`"
-
-#: ../../Fixed-or-Improved-Logics.md:695
-msgid "Now you can disable `DamageSound` of a building."
-msgstr "现在你可以禁用一个建筑的 `DamageSound`。"
-
-#: ../../Fixed-or-Improved-Logics.md:698
-msgid ""
-"[SOMEBUILDING]            ; BuildingType\n"
-"DisableDamageSound=false  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]            ; BuildingType\n"
-"DisableDamageSound=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:703
-msgid "Exclude Factory from providing multiple factory bonus"
-msgstr "排除特定工厂的多工厂加成"
-
-#: ../../Fixed-or-Improved-Logics.md:705
-msgid ""
-"It is now possible to exclude a building with `Factory` from counting "
-"towards `MultipleFactory` bonus."
-msgstr "现在可以将某个具有 `Factory` 的建筑排除在 `MultipleFactory` 之外"
-
-#: ../../Fixed-or-Improved-Logics.md:708
-msgid ""
-"[SOMEBUILDING]                         ; BuildingType\n"
-"ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]                         ; BuildingType\n"
-"ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:713
-msgid "Power plant damage factor"
-msgstr "伤残电厂电量系数"
-
-#: ../../Fixed-or-Improved-Logics.md:715
-msgid ""
-"It is possible to customize the power decrement of a power plant when "
-"it's damaged. The actual power output for this plant will be: `Power` "
-"minuses the product of original power decrement and "
-"`Powerplant.DamageFactor`. Can't reduce power output lower than 0."
-msgstr ""
-"现在可以自定义电厂血量与发电功率的关系。`Power * PowerPlant.DamageFactor` 相当于电厂血量无限接近于 0 "
-"时损失的发电量，即 `损失发电量 = [1 - (当前血量 / 最大血量)] * PowerPlant.DamageFactor * "
-"Power=`；发电功率无法低于 0。"
-
-#: ../../Fixed-or-Improved-Logics.md:716
-msgid ""
-"Specifically, if the factor is set to 0.0, power output won't be "
-"decreased by losing health for this power plant."
-msgstr "具体来说，如果该系数设为 0.0，则电厂的发电功率不受血量影响。"
-
-#: ../../Fixed-or-Improved-Logics.md:719
-msgid ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"PowerPlant.DamageFactor=1.0        ; floating point value\n"
-msgstr ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"PowerPlant.DamageFactor=1.0        ; floating point value\n"
-
-#: ../../Fixed-or-Improved-Logics.md:724
-msgid "Skip anim delay for burst fire"
-msgstr "跳过 `DelayedFireDelay`"
-
-#: ../../Fixed-or-Improved-Logics.md:726
-msgid ""
-"In Red Alert 1, the tesla coil will attack multiple times after charging "
-"animation. This is not possible in Red Alert 2, where the building must "
-"play the charge animation every time it fires."
-msgstr "《红色警戒 1》中的磁暴线圈会在充能后多次攻击。这在《红色警戒 2》中是不可能的，因为建筑必须每次发射时都播放充能动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:727
-msgid "Now you can implement the above logic using the following flag."
-msgstr "现在你可以使用下面的标签实现上述逻辑。"
-
-#: ../../Fixed-or-Improved-Logics.md:730
-msgid ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"IsAnimDelayedBurst=true            ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]                     ; BuildingType\n"
-"IsAnimDelayedBurst=true            ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:736
-msgid ""
-"The prism towers' fire is hardcoded to be delayed. Their fire will ignore"
-" this flag, just as they ignore `IsAnimDelayedFire`."
-msgstr "光棱塔开火硬编码延迟。就像无视 `IsAnimDelayedFire` 那样，它们同样无视该语句。"
-
-#: ../../Fixed-or-Improved-Logics.md:739
-msgid "Unit repair customization"
-msgstr "在建筑上自定义单位维修参数"
-
-#: ../../Fixed-or-Improved-Logics.md:741
-msgid ""
-"It is now possible to customize the repairing of units by "
-"`UnitRepair=true`, `UnitReload=true` and `Hospital=true` buildings."
-msgstr ""
-"现在可以通过 `UnitRepair=true`、`UnitReload=true` 和 `Hospital=true` "
-"的建筑来自定义单位的维修参数。"
-
-#: ../../Fixed-or-Improved-Logics.md:742
-msgid ""
-"`Units.RepairRate` customizes the rate at which the units are repaired. "
-"This defaults to `[General] -> ReloadRate` if `UnitReload=true` and if "
-"overridden per AircraftType *(Ares feature)* can tick at different time "
-"for each docked aircraft. Setting this overrides that behaviour. For "
-"`UnitRepair=true` buildings this defaults to `[General] -> URepairRate`."
-msgstr ""
-"`Units.RepairRate` 自定义单位的维修速度。如果 `UnitReload=true` 那么默认为 `[General] -> "
-"ReloadRate` 并覆盖每个战机类型独立的时间设置（*Ares 功能*）。对于 `UnitRepair=true` 的建筑则默认为 "
-"`[General] -> URepairRate`。"
-
-#: ../../Fixed-or-Improved-Logics.md:743
-msgid ""
-"On `UnitReload=true` building setting this to negative value will fully "
-"disable the repair functionality."
-msgstr "在 `UnitReload=true` 的建筑上将此值设置为负数将完全禁用维修功能。"
-
-#: ../../Fixed-or-Improved-Logics.md:744
-msgid "`Units.RepairStep` how much `Strength` is restored per repair tick."
-msgstr "`Units.RepairStep` 设置每次维修时恢复多少点 `Strength`。"
-
-#: ../../Fixed-or-Improved-Logics.md:745
-msgid ""
-"`Units.RepairPercent` is a multiplier to cost of repairing (cost / "
-"(maximum health / repair step)). Note that the final cost is set to 1 if "
-"it is less than that."
-msgstr ""
-"`Units.RepairPercent` "
-"是维修成本的倍率［`Cost`/(`Strength`/`RepairStep`)］。注意如果最终的成本低于 1 那么会设为 1。"
-
-#: ../../Fixed-or-Improved-Logics.md:746
-msgid ""
-"`Units.UseRepairCost` can be used to customize if repair cost is applied "
-"at all. Defaults to false for infantry, true for everything else."
-msgstr "`Units.UseRepairCost` 可以用于自定义是否使用维修成本。步兵默认为 false，其他默认为 true。"
-
-#: ../../Fixed-or-Improved-Logics.md:749
-msgid ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"Units.RepairRate=     ; floating point value, ingame minutes\n"
-"Units.RepairStep=     ; integer, default to [General] -> RepairStep\n"
-"Units.RepairPercent=  ; floating point value, percents or absolute, "
-"default to [General] -> RepairPercent\n"
-"Units.UseRepairCost=  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"Units.RepairRate=     ; floating point value, ingame minutes\n"
-"Units.RepairStep=     ; integer, default to [General] -> RepairStep\n"
-"Units.RepairPercent=  ; floating point value, percents or absolute, "
-"default to [General] -> RepairPercent\n"
-"Units.UseRepairCost=  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:757
-msgid "Waypoints for buildings"
-msgstr "建筑路径点"
-
-#: ../../Fixed-or-Improved-Logics.md:759
-msgid ""
-"In vanilla, buildings are forbidden to use waypoints. Now you can allow "
-"that using the following flag."
-msgstr "在原版中，建筑被禁止使用路径点。现在你可以使用以下标签来允许使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:762
-msgid ""
-"[General]\n"
-"BuildingWaypoints=false  ; boolean\n"
-msgstr ""
-"[General]\n"
-"BuildingWaypoints=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:767
-msgid "Customize if cloning need power"
-msgstr "自定义克隆耗电"
-
-#: ../../Fixed-or-Improved-Logics.md:769
-msgid ""
-"In vanilla, cloning vats can work fine even low power. Starting from Ares"
-" 2.0, they need power to work. Now you can specific it."
-msgstr "在原版中，克隆缸即便没电也可以工作。从 Ares 2.0 开始，它们需要电力运作。现在你可以指定。"
-
-#: ../../Fixed-or-Improved-Logics.md:772
-msgid ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"Cloning.Powered=true  ; boolean\n"
-msgstr ""
-"[SOMEBUILDING]        ; BuildingType\n"
-"Cloning.Powered=true  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:777
-msgid "Infantry"
-msgstr "步兵"
-
-#: ../../Fixed-or-Improved-Logics.md:779
-msgid "Auto deploy for GI-like infantry"
-msgstr "GI 式步兵自动部署"
-
-#: ../../Fixed-or-Improved-Logics.md:781
-msgid ""
-"In RA2, the GI-like infantry controlled by the AI will automatically "
-"deploy to use their more powerful secondary weapons when engaging the "
-"enemy. This feature was broken in Yuri's Revenge. Now you can use the "
-"following flags to re-enable this feature."
-msgstr ""
-"在《红色警戒2》中，由 AI "
-"控制的美国大兵在与敌人交战时会自动部署以使用火力更强的副武器。此特性在《尤里的复仇》中遭到破坏。现在你可以通过下面的开关语句重启这一特性。"
-
-#: ../../Fixed-or-Improved-Logics.md:784
-msgid ""
-"[General]\n"
-"InfantryAutoDeploy=false      ; boolean\n"
-"\n"
-"[SOMEINFANTRY]                ; InfantryType\n"
-"InfantryAutoDeploy=           ; boolean, default to [General] -> "
-"InfantryAutoDeploy\n"
-msgstr ""
-"[General]\n"
-"InfantryAutoDeploy=false      ; boolean\n"
-"\n"
-"[SOMEINFANTRY]                ; InfantryType\n"
-"InfantryAutoDeploy=           ; boolean, default to [General] -> "
-"InfantryAutoDeploy\n"
-
-#: ../../Fixed-or-Improved-Logics.md:792
-msgid "Prone speed customization"
-msgstr "自定义匍匐速度"
-
-#: ../../Fixed-or-Improved-Logics.md:794
-msgid "In vanilla, infantry has hardcoded prone speed. Now you can customize it."
-msgstr "原版中步兵匍匐前进的速度是硬编码的。现在你可以自由定义了。"
-
-#: ../../Fixed-or-Improved-Logics.md:797
-msgid ""
-"[General]\n"
-"ProneSpeed.Crawls=0.67        ; floating point value, multiplier\n"
-"ProneSpeed.NoCrawls=1.5       ; floating point value, multiplier\n"
-"\n"
-"[SOMEINFANTRY]                ; InfantryType\n"
-"ProneSpeed=                   ; floating point value, multiplier, by "
-"default, use the corresponding global value according to Crawls\n"
-msgstr ""
-"[General]\n"
-"ProneSpeed.Crawls=0.67        ; floating point value, multiplier\n"
-"ProneSpeed.NoCrawls=1.5       ; floating point value, multiplier\n"
-"\n"
-"[SOMEINFANTRY]                ; InfantryType\n"
-"ProneSpeed=                   ; floating point value, multiplier, by "
-"default, use the corresponding global value according to Crawls\n"
-
-#: ../../Fixed-or-Improved-Logics.md:806
-msgid "Overlays"
-msgstr "覆盖物"
-
-#: ../../Fixed-or-Improved-Logics.md:808
-msgid "Customize the chained damage of the wall"
-msgstr "自定义墙的连锁伤害"
-
-#: ../../Fixed-or-Improved-Logics.md:810
-msgid ""
-"In vanilla, when the wall is damaged, it will deal 200 damage to the "
-"walls in the 4 nearby cells. This makes connected walls more vulnerable "
-"to damage compared to single walls."
-msgstr ""
-"原版中当围墙受到伤害时会对周围 4 个单元格内的墙体造成 200 "
-"点伤害。这使得相连的墙体比单独矗立的墙体更容易被损伤（这就是打完剩下的单格墙体更能抗伤的原因）。"
-
-#: ../../Fixed-or-Improved-Logics.md:811
-msgid "Now you can customize that damage by using the following flag."
-msgstr "现在你可以使用下面的标签自定义这个杀伤值。"
-
-#: ../../Fixed-or-Improved-Logics.md:814
-msgid ""
-"[CombatDamage]\n"
-"AdjacentWallDamage=200  ; integer\n"
-msgstr ""
-"[CombatDamage]\n"
-"AdjacentWallDamage=200  ; integer\n"
-
-#: ../../Fixed-or-Improved-Logics.md:819
-msgid "Particle systems"
-msgstr "粒子系统"
-
-#: ../../Fixed-or-Improved-Logics.md:821
-msgid "Fire particle target coordinate adjustment when firer rotates"
-msgstr "开火者旋转时火焰粒子目标坐标调整"
-
-#: ../../Fixed-or-Improved-Logics.md:823
-msgid ""
-"By default particle systems with `BehavesLike=Fire` shift their target "
-"coordinates if the object that created the particle system (e.g firer of "
-"a weapon) is rotating. This behavior can now be disabled per particle "
-"system type."
-msgstr ""
-"默认情况下拥有 `BehavesLike=Fire` "
-"的粒子系统会根据创建粒子系统的对象（例如武器的开火者）是否旋转来调整其坐标。现在可以为每个粒子系统禁用这一行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:826
-msgid ""
-"[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
-"AdjustTargetCoordsOnRotation=true  ; boolean\n"
-msgstr ""
-"[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
-"AdjustTargetCoordsOnRotation=true  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:831
-msgid "Particles"
-msgstr "粒子"
-
-#: ../../Fixed-or-Improved-Logics.md:833
-msgid "Customizable gas particle speed"
-msgstr "自定义 gas 粒子速度"
-
-#: ../../Fixed-or-Improved-Logics.md:835
-msgid "Gas particles can now drift at a custom speed."
-msgstr "Gas 类的粒子现在可以自定义漂浮速度。"
-
-#: ../../Fixed-or-Improved-Logics.md:838
-msgid ""
-"[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
-"Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
-msgstr ""
-"[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
-"Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:843
-msgid "Projectiles"
-msgstr "抛射体"
-
-#: ../../Fixed-or-Improved-Logics.md:845
-msgid "Airburst & Splits"
-msgstr "空爆与分裂"
-
-#: ../../Fixed-or-Improved-Logics.md:847
-msgid ""
-"`AirburstWeapon` logic has been reimplemented and thus there are several "
-"additions & changes to it."
-msgstr "`AirburstWeapon` 逻辑已被重新实现从而对其进行了一些添加和更改。"
-
-#: ../../Fixed-or-Improved-Logics.md:848
-msgid ""
-"`Splits` can be set to true to use projectile splitting logic from "
-"Firestorm, with the number of split projectiles defined by `Cluster`."
-msgstr "`Splits` 可以设置为 true 以使用 《火风暴》 中的抛射体分裂逻辑，分裂抛射体的数量由 `Cluster` 决定。"
-
-#: ../../Fixed-or-Improved-Logics.md:849
-msgid ""
-"`RetargetAccuracy` defines the probability that the splitted projectiles "
-"head to the same target as the original projectile."
-msgstr "`RetargetAccuracy` 决定了分裂抛射体与原抛射体瞄准同一目标的概率。"
-
-#: ../../Fixed-or-Improved-Logics.md:850
-msgid ""
-"`RetargetSelf` determines if it is possible for the splitted projectiles "
-"to aim at the firer of the original projectile."
-msgstr "`RetargetSelf` 决定了分裂抛射体是否可以将原抛射体的发射者视为目标。"
-
-#: ../../Fixed-or-Improved-Logics.md:851
-msgid ""
-"`RetargetSelf.Probability` is the probability that if the original firer "
-"is chosen as a target, it is kept as the target instead of rerolled to "
-"another."
-msgstr "`RetargetSelf.Probability` 是选择了原本的开火者为目标时它将保留其为目标而不是去重新随机另一个目标的概率。"
-
-#: ../../Fixed-or-Improved-Logics.md:852
-msgid ""
-"`Splits.TargetingDistance` is the distance in cells that any potential "
-"target has to be within from the original target coordinates to be "
-"eligible for targeting by the splitted projectiles."
-msgstr "`Splits.TargetingDistance` 是以单元格为单位的距离，任何潜在目标都必须在原始目标坐标的这个范围内才能够被分裂的抛射体瞄准。"
-
-#: ../../Fixed-or-Improved-Logics.md:853
-msgid ""
-"`Splits.TargetCellRange` is the distance in whole cells from the original"
-" target cell from which the splitted projectiles can pick new target "
-"cells if not enough TechnoType targets were found nearby."
-msgstr ""
-"`Splits.TargetCellRange` "
-"是以完整单元格数为单位的距离，用于附近没有发现足够的科技类型目标时分裂的抛射体从该范围选取新的目标单元格。"
-
-#: ../../Fixed-or-Improved-Logics.md:854
-msgid ""
-"`Splits.UseWeaponTargeting`, if set to true, enables weapon targeting "
-"filter for when checking targets for splitted projectiles. Target's "
-"`LegalTarget` setting, Warhead `Verses` against `Armor` as well as "
-"`AirburstWeapon` [weapon targeting filters](New-or-Enhanced-Logics.md"
-"#weapon-targeting-filter) & [AttachEffect filters](New-or-Enhanced-"
-"Logics.md#attached-effects) will be checked."
-msgstr ""
-"`Splits.UseWeaponTargeting` 如果设为 true，则在检查分裂抛射体的目标时启用武器瞄准筛选。目标上的 "
-"`LegalTarget` 设置、弹头的 `Verses` 对 `Armor` 的设置以及 `AirburstWeapon` 所填武器的 "
-"[武器瞄准筛选](New-or-Enhanced-Logics.md#weapon-targeting-filter) 和 "
-"[AttachEffect 筛选](New-or-Enhanced-Logics.md#attached-effects) 都将被检查。"
-
-#: ../../Fixed-or-Improved-Logics.md:855
-msgid ""
-"Do note that this overrides checking Warhead for "
-"`AffectsAllies/Owner/Enemies` for targeting. You can use "
-"`CanTargetHouses` on `AirburstWeapon` to achieve similar behaviour, "
-"however."
-msgstr ""
-"注意这会在瞄准时覆盖弹头对 `AffectsAllies/Owner/Enemies` 的检查。不过，你可以通过在 "
-"`AirburstWeapon` 设置的武器上使用 `CanTargetHouses` 来实现类似的行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:856
-msgid "Behaviour for if `Airburst` is set to true can also be customized."
-msgstr "如果将 `Airburst` 设为 true 其行为也同样可以自定义。"
-
-#: ../../Fixed-or-Improved-Logics.md:857
-msgid ""
-"`AirburstSpread` is the distance in cells that the effect covers, with "
-"each cell in range being targeted by `AirburstWeapon` by default."
-msgstr "`AirburstSpread` 是以单元格为单位的效果所覆盖范围，默认情况下范围内的每个单元格都会被 `AirburstWeapon` 瞄准。"
-
-#: ../../Fixed-or-Improved-Logics.md:858
-msgid ""
-"`Airburst.UseCluster`, if set to true, makes it so that only number of "
-"cells in the affected area dictated by `Cluster` will be affected, "
-"instead of all of them."
-msgstr "`Airburst.UseCluster` 如果设为 true，则只有 `Cluster` 所指定数量的单元格会被影响，而不是所有单元格。"
-
-#: ../../Fixed-or-Improved-Logics.md:859
-msgid ""
-"If `Airburst.RandomClusters` is set to true, the cells affected will be "
-"picked by random. Otherwise they will be evenly spaced (counting from "
-"center to edges of affected area)."
-msgstr "`Airburst.RandomClusters` 如果设为 true，则受影响的单元格将随机选取。否则它们将均匀分布（从受影响区域的中心到边缘）。"
-
-#: ../../Fixed-or-Improved-Logics.md:860
-msgid ""
-"`Airburst.TargetAsSource` can be used to override source or 'firing' "
-"coordinate to match that of the intended target instead of projectile's "
-"current position."
-msgstr ""
-"`Airburst.TargetAsSource` 可用于令空爆中心坐标跟随目标坐标而非使用抛射体当前位置。例如原先会在爆点生成根据 "
-"`[Projectile] -> AroundTarget` 决定飞向原点或目标位置，现在会直接以目标为中心爆开。"
-
-#: ../../Fixed-or-Improved-Logics.md:861
-msgid ""
-"If `Airburst.TargetAsSource.SkipHeight` is also set, then projectile's "
-"current height will be used instead of target's height still."
-msgstr "如果还设置了 `Airburst.TargetAsSource.SkipHeight` 则仍然使用抛射体当前高度而非目标高度。"
-
-#: ../../Fixed-or-Improved-Logics.md:862
-msgid ""
-"`AroundTarget` controls whether or not targets for projectiles created by"
-" `Airburst` or `Splits` are checked for in area around the original "
-"projectile's intended target, or where the original projectile detonated."
-" Defaults to value of `Splits`."
-msgstr ""
-"`AroundTarget` 控制由 `Airburst` 或 `Splits` "
-"创建的抛射体的目标是否在原抛射体目标周围的区域检查获取，否则从原抛射体爆炸的位置。默认为 `Splits` 值。"
-
-#: ../../Fixed-or-Improved-Logics.md:863
-msgid ""
-"`AirburstWeapon.ApplyFirepowerMult` determines whether or not firepower "
-"modifiers from the firer of the original projectile are applied on the "
-"projectiles created from `AirburstWeapon`."
-msgstr ""
-"`AirburstWeapon.ApplyFirepowerMult` 决定是否将原抛射体发射者的火力加成应用于由 "
-"`AirburstWeapon` 创建的抛射体。"
-
-#: ../../Fixed-or-Improved-Logics.md:864
-msgid ""
-"`AirburstWeapon.SourceScatterMin` and `AirburstWeapon.SourceScatterMax` "
-"can be used to scatter the source or 'firing' coordinate around the "
-"original coordinate."
-msgstr ""
-"`AirburstWeapon.SourceScatterMin` 和 `AirburstWeapon.SourceScatterMax` "
-"可用于令空爆中心坐标产生散布。"
-
-#: ../../Fixed-or-Improved-Logics.md:867
-msgid ""
-"[SOMEPROJECTILE]                          ; Projectile\n"
-"Splits=                                   ; boolean\n"
-"RetargetAccuracy=0.0                      ; floating point value, "
-"percents or absolute (0.0-1.0)\n"
-"RetargetSelf=true                         ; boolean\n"
-"RetargetSelf.Probability=0.5              ; floating point value, "
-"percents or absolute (0.0-1.0)\n"
-"Splits.TargetingDistance=5.0              ; floating point value, "
-"distance in cells\n"
-"Splits.TargetCellRange=3                  ; integer, cell offset\n"
-"Splits.UseWeaponTargeting=false           ; boolean\n"
-"AirburstSpread=1.5                        ; floating point value, "
-"distance in cells\n"
-"Airburst.UseCluster=false                 ; boolean\n"
-"Airburst.RandomClusters=false             ; boolean\n"
-"Airburst.TargetAsSource=false             ; boolean\n"
-"Airburst.TargetAsSource.SkipHeight=false  ; boolean\n"
-"AroundTarget=                             ; boolean\n"
-"AirburstWeapon.ApplyFirepowerMult=false   ; boolean\n"
-"AirburstWeapon.SourceScatterMin=0.0       ; floating point value, "
-"distance in cells\n"
-"AirburstWeapon.SourceScatterMax=0.0       ; floating point value, "
-"distance in cells\n"
-msgstr ""
-"[SOMEPROJECTILE]                          ; Projectile\n"
-"Splits=                                   ; boolean\n"
-"RetargetAccuracy=0.0                      ; floating point value, "
-"percents or absolute (0.0-1.0)\n"
-"RetargetSelf=true                         ; boolean\n"
-"RetargetSelf.Probability=0.5              ; floating point value, "
-"percents or absolute (0.0-1.0)\n"
-"Splits.TargetingDistance=5.0              ; floating point value, "
-"distance in cells\n"
-"Splits.TargetCellRange=3                  ; integer, cell offset\n"
-"Splits.UseWeaponTargeting=false           ; boolean\n"
-"AirburstSpread=1.5                        ; floating point value, "
-"distance in cells\n"
-"Airburst.UseCluster=false                 ; boolean\n"
-"Airburst.RandomClusters=false             ; boolean\n"
-"Airburst.TargetAsSource=false             ; boolean\n"
-"Airburst.TargetAsSource.SkipHeight=false  ; boolean\n"
-"AroundTarget=                             ; boolean\n"
-"AirburstWeapon.ApplyFirepowerMult=false   ; boolean\n"
-"AirburstWeapon.SourceScatterMin=0.0       ; floating point value, "
-"distance in cells\n"
-"AirburstWeapon.SourceScatterMax=0.0       ; floating point value, "
-"distance in cells\n"
-
-#: ../../Fixed-or-Improved-Logics.md:888
-msgid ""
-"`Splits`, `AirburstSpread`, `RetargetAccuracy`, `RetargetSelf` and "
-"`AroundTarget`, beyond the other additions, should function similarly to "
-"the equivalent features introduced by Ares and take precedence over them "
-"if Phobos is used together with Ares."
-msgstr ""
-"`Splits`、`AirburstSpread`、`RetargetAccuracy`、`RetargetSelf` 和 "
-"`AroundTarget`，除了其他新增功能外，应该与 Ares 所引入的类似功能拥有相同效果并且如果 Phobos 与 Ares "
-"一起使用则优先于 Ares 的。"
-
-#: ../../Fixed-or-Improved-Logics.md:891
-msgid "Cluster scatter distance customization"
-msgstr "自定义 Cluster 散布距离"
-
-#: ../../Fixed-or-Improved-Logics.md:893
-msgid ""
-"`ClusterScatter.Min` and `ClusterScatter.Max` can be used to set minimum "
-"and maximum distance, respectively, in cells from the original detonation"
-" coordinate any additional detonations if `Cluster` is set to value "
-"higher than 1 can appear at."
-msgstr ""
-"`ClusterScatter.Min` 和 `ClusterScatter.Max` 可各自用于设置最小和最大距离，用于当 `Cluster` "
-"设为一个大于 1 的值时任何额外爆炸可出现的位置相对原爆炸坐标以单元格为单位的距离。"
-
-#: ../../Fixed-or-Improved-Logics.md:896
-msgid ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
-"ClusterScatter.Max=2.0  ; floating point value, distance in cells\n"
-msgstr ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
-"ClusterScatter.Max=2.0  ; floating point value, distance in cells\n"
-
-#: ../../Fixed-or-Improved-Logics.md:902
-msgid "Customizable projectile gravity"
-msgstr "自定义抛射体重力"
-
-#: ../../Fixed-or-Improved-Logics.md:904
-msgid "You can now specify individual projectile gravity."
-msgstr "现在你可以为特定抛射体指定其重力。"
-
-#: ../../Fixed-or-Improved-Logics.md:905
-msgid ""
-"Setting `Gravity=0` is not recommended as it will cause the projectile to"
-" fly backwards and be unable to hit the target which is not at the same "
-"height. We suggest to use `Straight` Trajectory instead. See [here](New-"
-"or-Enhanced-Logics.md#projectile-trajectories)."
-msgstr ""
-"由于 `Gravity=0` 会导致抛射体向后飞行并且无法击中不在相同高度的目标因此不推荐设置 `Gravity=0` 。我们建议使用 [直线弹道"
-"](New-or-Enhanced-Logics.md#projectile-trajectories) 替代。"
-
-#: ../../Fixed-or-Improved-Logics.md:908
-msgid ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"Gravity=6.0             ; floating point value\n"
-msgstr ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"Gravity=6.0             ; floating point value\n"
-
-#: ../../Fixed-or-Improved-Logics.md:913
-msgid "Customizing initial facing behavior"
-msgstr "自定义初始朝向行为"
-
-#: ../../Fixed-or-Improved-Logics.md:915
-msgid ""
-"Previously projectiles that had `Voxel=true` images were hardcoded to "
-"have downwards initial trajectory. This behavior can now be toggled on "
-"for other types of projectiles or disabled for voxel projectiles. In "
-"addition to defaulting to `true` for `Voxel=true` projectiles, it also "
-"now defaults to true for any `Vertical=true` projectile."
-msgstr ""
-"先前拥有 `Voxel=true` 的抛射体被硬编码为初始向下的弹道。现在该行为可以为其他类型抛射体开启或为 Voxel 抛射体关闭。除了对 "
-"`Voxel=true` 的抛射体默认为 `true` 外，现对所有 `Vertical=true` 的抛射体也同样设为 `true`。"
-
-#: ../../Fixed-or-Improved-Logics.md:918
-msgid ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"VerticalInitialFacing=  ; boolean\n"
-msgstr ""
-"[SOMEPROJECTILE]        ; Projectile\n"
-"VerticalInitialFacing=  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:923
-msgid "FlakScatter distance customization"
-msgstr "自定义 FlakScatter 距离"
-
-#: ../../Fixed-or-Improved-Logics.md:925
-msgid ""
-"By default `FlakScatter=true` makes `Inviso=true` projectiles scatter "
-"within a distance range calculated as `[Minimum * 2, Maximum * 2]` in "
-"cells, where the Minimum is 0 and Maximum is `[CombatDamage] -> "
-"BallisticScatter`, resulting in a range of `0` to `2 * BallisticScatter` "
-"cells. This behavior can now be customized using `BallisticScatter.Min` "
-"to set the Minimum value and `BallisticScatter.Max` to set the Maximum "
-"value. If not set, the default values are used. When estimating the "
-"actual scatter range, remember that the original `*2` multiplier "
-"mechanism still applies."
-msgstr ""
-"默认情况下 `FlakScatter=true` 会使 `Inviso=true` 的抛射体在按公式 `[最小值 * 2, 最大值 * "
-"2]`计算出来的单元格距离范围内散布，其中 `最小值` 为 0，`最大值` 为 `[CombatDamage] -> "
-"BallisticScatter`，最终散布范围为 `[0, 2 * BallisticScatter]` 格。此行为现已可以通过 "
-"`BallisticScatter.Min` 设置 `最小值` 和 通过 `BallisticScatter.Max` 设置 `最大值` "
-"来实现自定义。如果没有设置则使用原有的行为作为默认值。注意在估算实际范围时原有算法中的 `*2` 计算仍然存在。"
-
-#: ../../Fixed-or-Improved-Logics.md:928
-msgid ""
-"[SOMEPROJECTILE]      ; Projectile\n"
-"BallisticScatter.Min= ; floating point value, distance in cells\n"
-"BallisticScatter.Max= ; floating point value, distance in cells\n"
-msgstr ""
-"[SOMEPROJECTILE]      ; Projectile\n"
-"BallisticScatter.Min= ; floating point value, distance in cells\n"
-"BallisticScatter.Max= ; floating point value, distance in cells\n"
-
-#: ../../Fixed-or-Improved-Logics.md:934
-msgid "Shrapnel enhancements"
-msgstr "溅射增强"
-
-#: ../../Fixed-or-Improved-Logics.md:936
-msgid ""
-"![image](_static/images/shrapnel.gif) *Shrapnel appearing against ground "
-"& buildings in [Project Phantom](https://www.moddb.com/mods/project-"
-"phantom)*"
-msgstr ""
-"![image](_static/images/shrapnel.gif) *[幽灵计划](https://www.moddb.com/mods"
-"/project-phantom) 中击中地面和建筑的溅射*"
-
-#: ../../Fixed-or-Improved-Logics.md:939
-msgid ""
-"`ShrapnelWeapon` can now be triggered against ground & buildings via "
-"`Shrapnel.AffectsGround` and `Shrapnel.AffectsBuildings`."
-msgstr "现在可以通过 `Shrapnel.AffectsGround` 和 `Shrapnel.AffectsBuildings` 触发对地面和建筑的溅射。"
-
-#: ../../Fixed-or-Improved-Logics.md:940
-msgid ""
-"Setting `Shrapnel.UseWeaponTargeting` now allows weapon target filtering "
-"to be enabled for `ShrapnelWeapon`. Target's `LegalTarget` setting, "
-"Warhead `Verses` against `Armor` as well as `ShrapnelWeapon` [weapon "
-"targeting filters](#weapon-targeting-filter) & [AttachEffect filters"
-"](#attached-effects) will be checked."
-msgstr ""
-"设置 `Shrapnel.UseWeaponTargeting` 现在允许为 `ShrapnelWeapon` 启用武器目标过滤。目标的 "
-"`LegalTarget` 设置、弹头的 `Verses` 对 `Armor` 以及 `ShrapnelWeapon` [武器目标筛选"
-"](#weapon-targeting-filter) 和 [AE 武器过滤](#attached-effects) 将被检查。"
-
-#: ../../Fixed-or-Improved-Logics.md:941
-msgid ""
-"Do note that this overrides the normal check of only allowing shrapnels "
-"to hit non-allied objects. Use `CanTargetHouses=enemies` to manually "
-"enable this behaviour again."
-msgstr "注意这会覆盖允许溅射武器选择非盟友对象的默认检查。使用 `CanTargetHouses=enemies` 可手动重新启用此行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:944
-msgid ""
-"[SOMEPROJECTILE]                   ; Projectile\n"
-"Shrapnel.AffectsGround=false       ; boolean\n"
-"Shrapnel.AffectsBuildings=false    ; boolean\n"
-"Shrapnel.UseWeaponTargeting=false  ; boolean\n"
-msgstr ""
-"[SOMEPROJECTILE]                   ; Projectile\n"
-"Shrapnel.AffectsGround=false       ; boolean\n"
-"Shrapnel.AffectsBuildings=false    ; boolean\n"
-"Shrapnel.UseWeaponTargeting=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:951
-msgid "Technos"
-msgstr "科技类型"
-
-#: ../../Fixed-or-Improved-Logics.md:953
-msgid "Airstrike flare visual customizations"
-msgstr "自定义空袭引导效果"
-
-#: ../../Fixed-or-Improved-Logics.md:955
-msgid ""
-"It is now possible to customize color of airstrike flare tint on target "
-"on the TechnoType calling in the airstrike as well as customize the color"
-" of the line drawn to target."
-msgstr "现在可以在召唤空袭的单位上自定义目标染色效果及引导激光颜色。"
-
-#: ../../Fixed-or-Improved-Logics.md:956
-msgid ""
-"`LaserTargetColor` can be used to set the index of color from "
-"`[ColorAdd]`."
-msgstr "`LaserTargetColor` 用于填写颜色在 `[ColorAdd]` 中的索引序号。"
-
-#: ../../Fixed-or-Improved-Logics.md:957
-msgid ""
-"`AirstrikeLineColor` sets the color of the line and dot drawn from firer "
-"to target."
-msgstr "`AirstrikeLineColor` 用于填写引导激光的颜色。"
-
-#: ../../Fixed-or-Improved-Logics.md:960
-msgid ""
-"[AudioVisual]\n"
-"AirstrikeLineColor=255,0,0  ; integer - Red,Green,Blue\n"
-"\n"
-"[SOMETECHNO]                ; TechnoType\n"
-"LaserTargetColor=           ; integer - [ColorAdd] index, default to "
-"[AudioVisual] -> LaserTargetColor\n"
-"AirstrikeLineColor=         ; integer - Red,Green,Blue, default to "
-"[AudioVisual] -> AirstrikeLineColor\n"
-msgstr ""
-"[AudioVisual]\n"
-"AirstrikeLineColor=255,0,0  ; integer - Red,Green,Blue\n"
-"\n"
-"[SOMETECHNO]                ; TechnoType\n"
-"LaserTargetColor=           ; integer - [ColorAdd] index, default to "
-"[AudioVisual] -> LaserTargetColor\n"
-"AirstrikeLineColor=         ; integer - Red,Green,Blue, default to "
-"[AudioVisual] -> AirstrikeLineColor\n"
-
-#: ../../Fixed-or-Improved-Logics.md:969
-msgid "Airstrike target eligibility"
-msgstr "空袭目标筛选"
-
-#: ../../Fixed-or-Improved-Logics.md:971
-msgid ""
-"By default whether or not a building can be targeted by airstrikes "
-"(`Airstrike=true` Warhead) depends on value of `CanC4`, which also "
-"affects other things. This can now be changed independently by setting "
-"`AllowAirstrike`. If not set, defaults to value of `CanC4`. For non-"
-"building targets, the default value is true."
-msgstr ""
-"默认情况下建筑能否被空袭武器（弹头 `Airstrike=true`）作为目标取决于 `CanC4` 的值，这也会影响其他方面。现在可以通过设置 "
-"`AllowAirstrike` 来独立更改这一点，如果未设置，默认为 `CanC4` 的值。对于非建筑类单位这默认为 true。"
-
-#: ../../Fixed-or-Improved-Logics.md:972
-msgid ""
-"`AirstrikeTargets` determines what types of targets are valid airstrike "
-"targets for this Warhead."
-msgstr "`AirstrikeTargets` 决定了哪些目标是该弹头的有效空袭目标。"
-
-#: ../../Fixed-or-Improved-Logics.md:973
-msgid ""
-"The airstrike aircraft will now aim at the target itself rather than the "
-"cell beneath its feet, therefore it is possible to properly designate air"
-" strikes against non-building targets."
-msgstr "现在空袭的战机会将目标设为单位自身而不再是单位脚下的单元格，因此可以对非建筑类目标正常地进行空袭引导。"
-
-#: ../../Fixed-or-Improved-Logics.md:976
-msgid ""
-"[SOMETECHNO]                ; TechnoType\n"
-"AllowAirstrike=             ; boolean\n"
-"\n"
-"[SOMEWARHEAD]               ; WarheadType\n"
-"AirstrikeTargets=buildings  ; List of Affected Target Enumeration "
-"(none|infantry|units|buildings|all)\n"
-msgstr ""
-"[SOMETECHNO]                ; TechnoType\n"
-"AllowAirstrike=             ; boolean\n"
-"\n"
-"[SOMEWARHEAD]               ; WarheadType\n"
-"AirstrikeTargets=buildings  ; List of Affected Target Enumeration "
-"(none|infantry|units|buildings|all)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:984
-msgid "Alternate FLH customizations"
-msgstr "跟随炮塔旋转的 `AlternateFLH`"
-
-#: ../../Fixed-or-Improved-Logics.md:986
-msgid ""
-"`AlternateFLH.OnTurret` can be used to customize whether or not "
-"`AlternateFLH` used for `OpenTopped` transport firing coordinates, "
-"multiple mind control link offsets etc. is calculated relative to the "
-"unit's turret if available or body."
-msgstr ""
-"`AlternateFLH.OnTurret` 可自定义 `AlternateFLH` 用于 `OpenTopped` "
-"运输工具的开火坐标、多重心控链接偏移等逻辑时其位置是否相对于炮塔而非车体。"
-
-#: ../../Fixed-or-Improved-Logics.md:987
-msgid ""
-"`AlternateFLH.ApplyVehicle` can be used to customize whether or not a "
-"transport applies its `AlternateFLH` to passengers of the VehicleType, "
-"who by default use their own FLH, as opposed to passengers of the "
-"InfantryType who adhere to `AlternateFLH`."
-msgstr ""
-"`AlternateFLH.ApplyVehicle` 可用于自定义运输工具的 `AlternateFLH` "
-"是否作用于载具类载员，它们默认使用自身的 FLH 而不像步兵类载员那样遵照 `AlternateFLH`。"
-
-#: ../../Fixed-or-Improved-Logics.md:990
-msgid ""
-"[SOMETECHNO]                     ; TechnoType\n"
-"AlternateFLH.OnTurret=true       ; boolean\n"
-"AlternateFLH.ApplyVehicle=false  ; boolean\n"
-msgstr ""
-"[SOMETECHNO]                     ; TechnoType\n"
-"AlternateFLH.OnTurret=true       ; boolean\n"
-"AlternateFLH.ApplyVehicle=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:996
-msgid "Building-provided self-healing customization"
-msgstr "自定义建筑提供的自愈"
-
-#: ../../Fixed-or-Improved-Logics.md:998
-msgid ""
-"It is now possible to set a global cap for the effects of "
-"`InfantryGainSelfHeal` and `UnitsGainSelfHeal` by setting "
-"`InfantryGainSelfHealCap` & `UnitsGainSelfHealCap` under `[General]`, "
-"respectively."
-msgstr ""
-"现在可以通过分别在 `[General]` 中设置 `InfantryGainSelfHealCap` 与 "
-"`UnitsGainSelfHealCap` 来为 `InfantryGainSelfHeal` 和 `UnitsGainSelfHeal` "
-"的效果设置全局上限。"
-
-#: ../../Fixed-or-Improved-Logics.md:999
-msgid ""
-"Whether or not `MultiplayPassive=true` houses benefit from these effects "
-"can be controlled via `GainSelfHealAllowMultiplayPassive`."
-msgstr ""
-"`MultiplayPassive=true` 的所属方是否受益于这些效果可以通过 "
-"`GainSelfHealAllowMultiplayPassive` 加以控制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1000
-msgid ""
-"In campaign, whether or not these effects for player can be benefited by "
-"houses with `PlayerControl=true` can be controlled via "
-"`GainSelfHealFromPlayerControl`."
-msgstr ""
-"玩家能否通过带有 `PlayerControl=true` 的所属方获得这些受益可以通过 "
-"`GainSelfHealFromPlayerControl` 控制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1001
-msgid ""
-"Whether or not these effects can be benefited by allied houses can be "
-"controlled via `GainSelfHealFromAllies`."
-msgstr "玩家能否通过盟友所属获得这些受益效果可以由 `GainSelfHealFromAllies` 控制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1002
-msgid ""
-"It is also possible to change the pip frames displayed from `pips.shp` "
-"individually for infantry, units and buildings by setting the frames for "
-"infantry & unit self-healing on "
-"`Pips.SelfHeal.(Infantry/Units/Buildings)` under `[AudioVisual]`, "
-"respectively."
-msgstr ""
-"还可以分别为步兵、载具和建筑在 `[AudioVisual]` 中使用 "
-"`Pips.SelfHeal.(Infantry/Units/Buildings)` 设置各自 `pips.shp` 中用于显示的 pip 帧。"
-
-#: ../../Fixed-or-Improved-Logics.md:1003
-msgid ""
-"`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` can be used to "
-"customize the pixel offsets for the displayed pips, individually for "
-"infantry, units and buildings."
-msgstr ""
-"`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` 可以被用于分别自定义步兵、载具和建筑显示 "
-"pip 使用的像素偏移量。"
-
-#: ../../Fixed-or-Improved-Logics.md:1004
-msgid ""
-"Whether or not a TechnoType benefits from effects of "
-"`InfantryGainSelfHeal` or `UnitsGainSelfHeal` buildings or neither can "
-"now be controlled by setting `SelfHealGainType`."
-msgstr ""
-"通过设置 `SelfHealGainType` 可以控制科技类型是否受到 `InfantryGainSelfHeal` 或 "
-"`UnitsGainSelfHeal` 建筑的增益效果或者对两者都不享有。"
-
-#: ../../Fixed-or-Improved-Logics.md:1005
-msgid ""
-"If `SelfHealGainType` is not set, InfantryTypes and VehicleTypes with "
-"`Organic` set to true gain self-healing from `InfantryGainSelfHeal`, "
-"other VehicleTypes from `UnitsGainSelfHeal` and AircraftTypes & "
-"BuildingTypes never gain self-healing."
-msgstr ""
-"如果未设置 `SelfHealGainType`，那么步兵类型和 `Organic` 设置为 true 载具类型将从 "
-"`InfantryGainSelfHeal` 获得自愈，其他载具类型从 `UnitsGainSelfHeal` "
-"获得以及战机类型和建筑类型永远不会获得自愈。"
-
-#: ../../Fixed-or-Improved-Logics.md:1008
-msgid ""
-"[General]\n"
-"InfantryGainSelfHealCap=                ; integer, maximum amount of "
-"InfantryGainSelfHeal that can be in effect at once, must be 1 or higher\n"
-"UnitsGainSelfHealCap=                   ; integer, maximum amount of "
-"UnitsGainSelfHeal that can be in effect at once, must be 1 or higher\n"
-"GainSelfHealAllowMultiplayPassive=true  ; boolean\n"
-"GainSelfHealFromPlayerControl=false     ; boolean\n"
-"GainSelfHealFromAllies=false            ; boolean\n"
-"\n"
-"[AudioVisual]\n"
-"Pips.SelfHeal.Infantry=13,20            ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Units=13,20               ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Buildings=13,20           ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Infantry.Offset=25,-35    ; X,Y, pixels relative to default"
-"\n"
-"Pips.SelfHeal.Units.Offset=33,-32       ; X,Y, pixels relative to default"
-"\n"
-"Pips.SelfHeal.Buildings.Offset=15,10    ; X,Y, pixels relative to default"
-"\n"
-"\n"
-"[SOMETECHNO]                            ; TechnoType\n"
-"SelfHealGainType=                       ; Self-Heal Gain Type Enumeration"
-" (noheal|infantry|units)\n"
-msgstr ""
-"[General]\n"
-"InfantryGainSelfHealCap=                ; integer, maximum amount of "
-"InfantryGainSelfHeal that can be in effect at once, must be 1 or higher\n"
-"UnitsGainSelfHealCap=                   ; integer, maximum amount of "
-"UnitsGainSelfHeal that can be in effect at once, must be 1 or higher\n"
-"GainSelfHealAllowMultiplayPassive=true  ; boolean\n"
-"GainSelfHealFromPlayerControl=false     ; boolean\n"
-"GainSelfHealFromAllies=false            ; boolean\n"
-"\n"
-"[AudioVisual]\n"
-"Pips.SelfHeal.Infantry=13,20            ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Units=13,20               ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Buildings=13,20           ; integer, frames of pips.shp for"
-" infantry & unit-self healing pips, respectively\n"
-"Pips.SelfHeal.Infantry.Offset=25,-35    ; X,Y, pixels relative to default"
-"\n"
-"Pips.SelfHeal.Units.Offset=33,-32       ; X,Y, pixels relative to default"
-"\n"
-"Pips.SelfHeal.Buildings.Offset=15,10    ; X,Y, pixels relative to default"
-"\n"
-"\n"
-"[SOMETECHNO]                            ; TechnoType\n"
-"SelfHealGainType=                       ; Self-Heal Gain Type Enumeration"
-" (noheal|infantry|units)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1028
-msgid "Chrono sparkle animation customization & improvements"
-msgstr "超时空闪光动画的自定义与改进"
-
-#: ../../Fixed-or-Improved-Logics.md:1030
-msgid ""
-"It is now possible to customize the frame delay between instances of "
-"`[General] -> ChronoSparkle1` animations created on objects being warped "
-"by setting `[General] -> ChronoSparkleDisplayDelay`."
-msgstr ""
-"现在可以通过设置 `[General] -> ChronoSparkleDisplayDelay` 来自定义被冻结的对象上创建 "
-"`[General] -> ChronoSparkle1` 动画之间的帧间隔。"
-
-#: ../../Fixed-or-Improved-Logics.md:1031
-msgid ""
-"By default on buildings with `MaxNumberOccupants` higher than 0, chrono "
-"sparkle animation would be shown at each of the `MuzzleFlashX` "
-"coordinates. This behaviour is now customizable, and supports "
-"`MuzzleFlashX` indices higher than 10."
-msgstr ""
-"默认情况下对于 `MaxNumberOccupants` 大于 0 的建筑，超时空闪烁动画会在每个 `MuzzleFlashX` "
-"坐标处显示。现在这种行为可以自定义，并且支持大于 10 的 `MuzzleFlashX` 索引。"
-
-#: ../../Fixed-or-Improved-Logics.md:1032
-msgid ""
-"`[General] -> ChronoSparkleBuildingDisplayPositions` can be set to show "
-"the sparkle animation on the building (`building`), muzzle flash "
-"coordinates of current occupants (`occupants`), muzzle flash coordinates "
-"of all occupant slots (`occupantslots`) or any combination of these."
-msgstr ""
-"`[General] -> ChronoSparkleBuildingDisplayPositions` 可以设置闪烁动画为在建筑上闪烁 "
-"(`building`)、在当前驻军的枪口坐标闪烁 (`occupants`)、所有驻军的枪口闪烁坐标 (`occupantslots`) "
-"或这些中任意组合的情况下显示。"
-
-#: ../../Fixed-or-Improved-Logics.md:1033
-msgid ""
-"If `occupants` or `occupantslots` is listed without `building`, a single "
-"chrono sparkle animation is still displayed on building if it doesn't "
-"have any occupants or it has `MaxNumberOccupants` value less than 1, "
-"respectively."
-msgstr ""
-"如果列出了 `occupants` 或 `occupantslots` 而没有 `building`，那么在建筑没有任何驻军或其 "
-"`MaxNumberOccupants` 小于 1 的情况下仍会在建筑上显示一个超时空闪烁动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:1034
-msgid ""
-"The chrono sparkle animation that is displayed on building itself is also"
-" now displayed at the center of it rather than at center of its topmost "
-"cell."
-msgstr "现在显示在建筑自身的超时空闪烁动画位于其正中心而不再是其最顶端单元格的中心。"
-
-#: ../../Fixed-or-Improved-Logics.md:1037
-msgid ""
-"[General]\n"
-"ChronoSparkleDisplayDelay=24                         ; integer, game "
-"frames\n"
-"ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono "
-"sparkle position enum (building | occupants | occupantslots | all)\n"
-msgstr ""
-"[General]\n"
-"ChronoSparkleDisplayDelay=24                         ; integer, game "
-"frames\n"
-"ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono "
-"sparkle position enum (building | occupants | occupantslots | all)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1043
-msgid "Customizable ChronoSphere teleport delays for units"
-msgstr "单位自定义 ChronoSphere 传送延迟"
-
-#: ../../Fixed-or-Improved-Logics.md:1045
-msgid ""
-"It is now possible to customize (globally and per TechnoType) the warp-in"
-" delay for units teleporting through `Type=ChronoSphere/Warp` "
-"Superweapon, both before and after the jump."
-msgstr "现在可以自定义（全局和所有科技类型）单位通过 `Type=ChronoSphere/Warp` 超级武器传送前后的延迟。"
-
-#: ../../Fixed-or-Improved-Logics.md:1048
-msgid ""
-"[General]\n"
-"ChronoSphereDelay=0     ; integer, game frames\n"
-"ChronoSpherePreDelay=60 ; integer, game frames\n"
-"\n"
-"[SOMETECHNO]            ; TechnoType\n"
-"ChronoSphereDelay=      ; integer, game frames, default to [General] -> "
-"ChronoSphereDelay\n"
-"ChronoSpherePreDelay=   ; integer, game frames, default to [General] -> "
-"ChronoSpherePreDelay\n"
-msgstr ""
-"[General]\n"
-"ChronoSphereDelay=0     ; integer, game frames\n"
-"ChronoSpherePreDelay=60 ; integer, game frames\n"
-"\n"
-"[SOMETECHNO]            ; TechnoType\n"
-"ChronoSphereDelay=      ; integer, game frames, default to [General] -> "
-"ChronoSphereDelay\n"
-"ChronoSpherePreDelay=   ; integer, game frames, default to [General] -> "
-"ChronoSpherePreDelay\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1059
-msgid ""
-"Due to technical constraints, these settings do not apply to buildings "
-"teleported by Ares' customizable ChronoSphere SW. They only have a pre-"
-"teleport delay equal to `[General] -> ChronoDelay`."
-msgstr ""
-"由于技术限制，这些设置不适用于 Ares 的自定义 ChronoSphere 超级武器传送的建筑。它们仅有一个共用的 `[General] -> "
-"ChronoDelay`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1062
-msgid "Customizable harvester ore gathering animation"
-msgstr "自定义采矿动画"
-
-#: ../../Fixed-or-Improved-Logics.md:1064
-msgid ""
-"![image](_static/images/oregath.gif) *Custom ore gathering anims in "
-"[Project Phantom](https://www.moddb.com/mods/project-phantom)*"
-msgstr ""
-"![image](_static/images/oregath.gif) *在 [幽灵计划](https://www.moddb.com/mods"
-"/project-phantom) 中的自定义矿石采集动画*"
-
-#: ../../Fixed-or-Improved-Logics.md:1067
-msgid ""
-"You can now specify which anim should be drawn when a harvester of "
-"specified type is gathering specified type of ore."
-msgstr "现在你可以在设定特定矿车在采集特定类型的矿石时哪些动画应当被绘制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1070
-msgid ""
-"[SOMETECHNO]                     ; TechnoType\n"
-"OreGathering.Anims=              ; List of AnimationTypes\n"
-"OreGathering.FramesPerDir=15     ; List of integers\n"
-"OreGathering.Tiberiums=0         ; List of Tiberium IDs\n"
-msgstr ""
-"[SOMETECHNO]                     ; TechnoType\n"
-"OreGathering.Anims=              ; List of AnimationTypes\n"
-"OreGathering.FramesPerDir=15     ; List of integers\n"
-"OreGathering.Tiberiums=0         ; List of Tiberium IDs\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1077
-msgid "Customizable target evaluation map zone check behaviour"
-msgstr "自定义目标评估地图区域检查行为"
-
-#: ../../Fixed-or-Improved-Logics.md:1079
-msgid ""
-"By default, any non-AircraftType units seeking targets via ScriptType "
-"team mission (action) `0 Attack Target Type` or any [attack team missions"
-" introduced in Phobos](AI-Scripting-and-Mapping.md#attack-actions) check "
-"if the potential target is in same map zone as the attacking unit to be "
-"able to pick it as a target. This can now be customized to allow objects "
-"from any map zone with no constraints (`TargetZoneScanType=any`) or only "
-"if they are within weapon range (`TargetZoneScanType=inrange`)."
-msgstr ""
-"默认情况下，任何非战机类类型单位通过脚本动作 `0 攻击目标类型` 或任何 [Phobos 引入的小队攻击任务](AI-Scripting-"
-"and-Mapping.md#10000-10049-attack-actions) "
-"寻找目标时都会检查潜在目标与攻击单位是否处于同一区域，以便将其选为攻击目标。现在这可以被自定义为允许选择来自任何地图区域的对象且不受限制 "
-"(`TargetZoneScanType=any`) 或者仅当目标在武器射程内时才允许选择 "
-"(`TargetZoneScanType=inrange`)。"
-
-#: ../../Fixed-or-Improved-Logics.md:1082
-msgid ""
-"[SOMETECHNO]             ; TechnoType\n"
-"TargetZoneScanType=same  ; target zone scan enumeration "
-"(same|any|inrange)\n"
-msgstr ""
-"[SOMETECHNO]             ; TechnoType\n"
-"TargetZoneScanType=same  ; target zone scan enumeration "
-"(same|any|inrange)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1087
-msgid "Customizable Teleport/Chrono Locomotor settings per TechnoType"
-msgstr "自定义超时空运动设置"
-
-#: ../../Fixed-or-Improved-Logics.md:1089
-msgid ""
-"![image](_static/images/cust-Chrono.gif) *Chrono Legionnaire and Ronco "
-"using different teleportation settings in [YR: New "
-"War](https://www.moddb.com/mods/yuris-revenge-new-war)*"
-msgstr ""
-"![image](_static/images/cust-Chrono.gif) *[YR: New "
-"War](https://www.moddb.com/mods/yuris-revenge-new-war) 中的超时空军团兵与 Ronco "
-"使用不同的超时空设置*"
-
-#: ../../Fixed-or-Improved-Logics.md:1092
-msgid ""
-"You can now specify Teleport/Chrono Locomotor settings per TechnoType to "
-"override default rules values. Unfilled values default to values in "
-"`[General]`."
-msgstr "现在你可以为每个科技类型指定其超时空运动方式设置以覆盖默认规则的值。未填充值则默认使用 `[General]` 中的值。"
-
-#: ../../Fixed-or-Improved-Logics.md:1093
-msgid ""
-"Applicable to Techno that have Teleport/Chrono Locomotor attached, or "
-"being chronowarped by chronosphere."
-msgstr "对使用超时空运动方式或者被超时空传送超武移动的科技类型有效。"
-
-#: ../../Fixed-or-Improved-Logics.md:1094
-msgid ""
-"`Chronoshift.WarpOut` and `Chronoshift.WarpIn` will override `WarpOut` "
-"and `WarpIn` respectively when the techno is being chronowarped by "
-"chronosphere, if set."
-msgstr ""
-"当单位被 `Type=ChronoSphere` 的超级武器传送时 `Chronoshift.WarpOut` 和 "
-"`Chronoshift.WarpIn` 会分别替代 `WarpOut` 和  `WarpIn` 使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:1095
-msgid ""
-"`WarpAway` specify the anim when the techno is being erased by "
-"`Temporal=yes` warhead. Will override Ares' `Temporal.WarpAway` tag on "
-"warhead, if set."
-msgstr ""
-"单位上的 `[TechnoType] -> WarpAway` 会在其被 `Temporal=yes` 的弹头抹除时覆盖 Ares 引入的 "
-"`[WarheadType] -> Temporal.WarpAway=` 生效。"
-
-#: ../../Fixed-or-Improved-Logics.md:1096
-msgid ""
-"If more than one animation is listed in `WarpOut`, `WarpIn` or "
-"`WarpAway`, a random one is selected."
-msgstr "如果 `WarpOut`、`WarpIn` 或 `WarpAway` 中列出了多个动画，则将随机选择一个。"
-
-#: ../../Fixed-or-Improved-Logics.md:1099
-msgid ""
-"[SOMETECHNO]            ; TechnoType\n"
-"WarpOut=                ; List of AnimationTypes (played when Techno "
-"warping out), default to [General] -> WarpOut\n"
-"WarpIn=                 ; List of AnimationTypes (played when Techno "
-"warping in), default to [General] -> WarpIn\n"
-"Chronoshift.WarpOut=    ; List of AnimationTypes (played when Techno "
-"warping out by chronosphere), default to [TechnoType] -> WarpOut\n"
-"Chronoshift.WarpIn=     ; List of AnimationTypes (played when Techno "
-"warping in by chronosphere), default to [TechnoType] -> WarpIn\n"
-"WarpAway=               ; List of AnimationTypes (played when Techno "
-"being erased by Temporal=yes warhead), default to [General] -> WarpAway\n"
-"ChronoTrigger=          ; boolean, if yes then delay varies by distance, "
-"if no it is a constant\n"
-"ChronoDistanceFactor=   ; integer, amount to divide the distance to "
-"destination by to get the warped out delay\n"
-"ChronoMinimumDelay=     ; integer, the minimum delay for teleporting, no "
-"matter how short the distance\n"
-"ChronoRangeMinimum=     ; integer, can be used to set a small range "
-"within which the delay is constant\n"
-"ChronoDelay=            ; integer, delay after teleport for chronosphere\n"
-msgstr ""
-"[SOMETECHNO]            ; TechnoType\n"
-"WarpOut=                ; List of AnimationTypes (played when Techno "
-"warping out), default to [General] -> WarpOut\n"
-"WarpIn=                 ; List of AnimationTypes (played when Techno "
-"warping in), default to [General] -> WarpIn\n"
-"Chronoshift.WarpOut=    ; List of AnimationTypes (played when Techno "
-"warping out by chronosphere), default to [TechnoType] -> WarpOut\n"
-"Chronoshift.WarpIn=     ; List of AnimationTypes (played when Techno "
-"warping in by chronosphere), default to [TechnoType] -> WarpIn\n"
-"WarpAway=               ; List of AnimationTypes (played when Techno "
-"being erased by Temporal=yes warhead), default to [General] -> WarpAway\n"
-"ChronoTrigger=          ; boolean, if yes then delay varies by distance, "
-"if no it is a constant\n"
-"ChronoDistanceFactor=   ; integer, amount to divide the distance to "
-"destination by to get the warped out delay\n"
-"ChronoMinimumDelay=     ; integer, the minimum delay for teleporting, no "
-"matter how short the distance\n"
-"ChronoRangeMinimum=     ; integer, can be used to set a small range "
-"within which the delay is constant\n"
-"ChronoDelay=            ; integer, delay after teleport for chronosphere\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1113
 msgid "Customizable unit image in art"
 msgstr "在 art 中自定义单位图像"
 
-#: ../../Fixed-or-Improved-Logics.md:1115
+#: ../../Fixed-or-Improved-Logics.md:352
 msgid ""
 "`Image` tag in art INI is no longer limited to AnimationTypes and "
 "BuildingTypes, and can be applied to all TechnoTypes (InfantryTypes, "
 "VehicleTypes, AircraftTypes, BuildingTypes)."
 msgstr "art INI 中的 `Image` 标签不再局限于动画类型和建筑类型，而是作用于所有科技类型（步兵类型、载具类型、战机类型、建筑类型）。"
 
-#: ../../Fixed-or-Improved-Logics.md:1116
+#: ../../Fixed-or-Improved-Logics.md:353
 msgid ""
 "The tag specifies **only** the file name (without extension) of the asset"
 " that replaces TechnoType's graphics. If the name in `Image` is also an "
@@ -4392,19 +2080,19 @@ msgstr ""
 "这个标签**仅**指定替代科技类型图像的文件名（无扩展名）。如果 `Image` 中的名称也是 art INI "
 "中的一个条目，那么**不会从中读取任何标签**。"
 
-#: ../../Fixed-or-Improved-Logics.md:1117
+#: ../../Fixed-or-Improved-Logics.md:354
 msgid ""
 "**By default this feature is disabled** to remain compatible with YR. To "
 "use this feature, enable it in rules with `ArtImageSwap=true`."
 msgstr "**此功能默认关闭**以保持对 YR 原行为的兼容。为使用该功能，需要在 rules 中使用 `ArtImageSwap=true` 来开启。"
 
-#: ../../Fixed-or-Improved-Logics.md:1118
+#: ../../Fixed-or-Improved-Logics.md:355
 msgid ""
 "This feature supports SHP images for InfantryTypes, SHP and VXL images "
 "for VehicleTypes and VXL images for AircraftTypes."
 msgstr "此功能仅支持 Shape 图像用于步兵类型，Shape 与 Voxel 图像用于载具类型以及 Voxel 图像用于战机类型。"
 
-#: ../../Fixed-or-Improved-Logics.md:1121
+#: ../../Fixed-or-Improved-Logics.md:358
 msgid ""
 "[General]\n"
 "ArtImageSwap=false  ; disabled by default\n"
@@ -4412,386 +2100,63 @@ msgstr ""
 "[General]\n"
 "ArtImageSwap=false  ; disabled by default\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1127
+#: ../../Fixed-or-Improved-Logics.md:364
 msgid ""
-"[SOMETECHNO]        ; TechnoType\n"
-"Image=              ; name of the file that will be used as image, "
-"without extension\n"
+"To use this feature properly, you need to remove or replace the following"
+" segments in the YR INI code to avoid compatibility issues between the "
+"original Westwood INI code and this feature."
 msgstr ""
-"[SOMETECHNO]        ; TechnoType\n"
-"Image=              ; name of the file that will be used as image, "
-"without extension\n"
+"为了正常使用该功能，你需要移除或替换下面这些 YR INI 代码中的选段以避免 Westwood 原有 INI 代码与该功能的兼容问题。"
 
-#: ../../Fixed-or-Improved-Logics.md:1132
-msgid "Customizable veterancy insignias"
-msgstr "自定义等级军衔"
+#: ../../Fixed-or-Improved-Logics.md:367 ../../Fixed-or-Improved-Logics.md:687
+#: ../../Fixed-or-Improved-Logics.md:708 ../../Fixed-or-Improved-Logics.md:723
+#: ../../Fixed-or-Improved-Logics.md:744 ../../Fixed-or-Improved-Logics.md:765
+#: ../../Fixed-or-Improved-Logics.md:789 ../../Fixed-or-Improved-Logics.md:799
+#: ../../Fixed-or-Improved-Logics.md:842 ../../Fixed-or-Improved-Logics.md:864
+#: ../../Fixed-or-Improved-Logics.md:1006
+#: ../../Fixed-or-Improved-Logics.md:1266
+#: ../../Fixed-or-Improved-Logics.md:1788
+#: ../../Fixed-or-Improved-Logics.md:1832
+#: ../../Fixed-or-Improved-Logics.md:2161
+msgid "In `artmd.ini`:"
+msgstr "在 `artmd.ini`："
 
-#: ../../Fixed-or-Improved-Logics.md:1134
-msgid "You can now customize veterancy insignia of TechnoTypes."
-msgstr "现在可以自定义科技类型的等级军衔。"
-
-#: ../../Fixed-or-Improved-Logics.md:1135
+#: ../../Fixed-or-Improved-Logics.md:368
 msgid ""
-"`Insignia.(Rookie|Veteran|Elite)` can be used to set a custom insignia "
-"file, optionally for each veterancy stage. Like the original / default "
-"file, `pips.shp`, they are drawn using `palette.pal` as palette."
-msgstr ""
-"`Insignia.(Rookie|Veteran|Elite)` 可用于为每个等级设置一个自定义军衔文件。与原本／默认的文件 "
-"`pips.shp` 一样，它们使用 `palette.pal` 作为色盘进行绘制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1136
-msgid ""
-"`InsigniaFrame(.Rookie|Veteran|Elite)` can be used to set (zero-based) "
-"frame index of the insignia to display, optionally for each veterancy "
-"stage. Using -1 uses the default setting. Default settings are -1 (none) "
-"for rookie, 14 for veteran and 15 for elite."
-msgstr ""
-"`InsigniaFrame(.Rookie|Veteran|Elite)` 可用于为每个等级阶段设置军衔的（从 0 开始的）帧索引。使用 -1 "
-"表示使用默认设置。默认设置对新兵为 -1（无），对老兵为 14，对精英为 15。"
-
-#: ../../Fixed-or-Improved-Logics.md:1137
-msgid ""
-"A shorthand `InsigniaFrames` can be used to list them in order from "
-"rookie, veteran and elite instead as well. "
-"`InsigniaFrame(.Rookie|Veteran|Elite)` takes priority over this."
-msgstr ""
-"也可以使用简写 `InsigniaFrames` "
-"按顺序列出新兵、老兵和精英的帧索引。`InsigniaFrame(.Rookie|Veteran|Elite)` 的优先级高于此。"
-
-#: ../../Fixed-or-Improved-Logics.md:1138
-msgid ""
-"These settings will be overriden by the properties set in "
-"[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType` is set."
-msgstr ""
-"如果设置了 `InsigniaType` 则上述设置会被 [InsigniaType](Miscellanous.md#insignia-"
-"type) 中定义的属性覆盖。"
-
-#: ../../Fixed-or-Improved-Logics.md:1139
-msgid ""
-"Normal insignia can be overridden for specific weapon modes of "
-"`Gunner=true` units by setting `Insignia(.Frame/.Frames).WeaponN` where "
-"`N` stands for 1-based weapon mode index. If not set, defaults to non-"
-"mode specific insignia settings."
-msgstr ""
-"可以通过设置 `Insignia(.Frame/.Frames).WeaponN` 来为 `Gunner=true` "
-"的单位使用不同武器时换成不同的军衔，其中 `N` 表示基于 1 的武器模式索引。如果不设置，默认使用非特定模式的军衔设置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1140
-msgid ""
-"These settings will be overriden by the properties set in "
-"[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType.WeaponN` "
-"is set."
-msgstr ""
-"如果设置了 `InsigniaType.WeaponN` 则上述设置会被 [InsigniaType](Miscellanous.md"
-"#insignia-type) 中定义的属性覆盖。"
-
-#: ../../Fixed-or-Improved-Logics.md:1141
-msgid ""
-"Normal insignia can be overridden when its current passenger size reaches"
-" a certain amount by setting `Insignia(.Frame/.Frames).PassengersN` where"
-" `N` stands for the current passenger size amount (from 0 to `Passengers`"
-" of the transport). If not set, defaults to non-passenger specific "
-"insignia settings. Will be overridden by weapon mode insignia settings, "
-"if set."
-msgstr ""
-"可以通过设置 `Insignia(.Frame/.Frames).PassengersN` 来为运输工具在拥有不同的载员数量时换成不同的军衔，其中"
-" `N` 表示当前载员数量（从 0 到运输工具 `Passengers` 的值）。如果不设置，默认无载员模式的军衔设置。如果已经设置了 "
-"`Insignia(.Frame/.Frames).WeaponN` 则覆盖该语句的效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:1142
-msgid ""
-"These settings will be overriden by the properties set in "
-"[InsigniaType](Miscellanous.md#insignia-type), if "
-"`InsigniaType.PassengersN` is set."
-msgstr ""
-"如果设置了 `InsigniaType.PassengersN` 则上述设置会被 [InsigniaType](Miscellanous.md"
-"#insignia-type) 中定义的属性覆盖。"
-
-#: ../../Fixed-or-Improved-Logics.md:1143
-msgid ""
-"`Insignia.ShowEnemy` controls whether or not the insignia is shown to "
-"enemy players."
-msgstr "`Insignia.ShowEnemy` 控制军衔是否对敌方玩家可见。"
-
-#: ../../Fixed-or-Improved-Logics.md:1144
-msgid ""
-"You can make insignias appear only on selected units using "
-"`DrawInsignia.OnlyOnSelected`."
-msgstr "你可以使用 `DrawInsignia.OnlyOnSelected` 来使军衔仅出现在被选中的单位上。"
-
-#: ../../Fixed-or-Improved-Logics.md:1145
-msgid ""
-"Position for insignias can be adjusted by setting "
-"`DrawInsignia.AdjustPos.Infantry` for infantry, "
-"`DrawInsignia.AdjustPos.Buildings` for buildings, and "
-"`DrawInsignia.AdjustPos.Units` for others."
-msgstr ""
-"可以通过为步兵设置 `DrawInsignia.AdjustPos.Infantry`、为建筑设置 "
-"`DrawInsignia.AdjustPos.Buildings`、为其他单位设置 `DrawInsignia.AdjustPos.Units`"
-" 来调整军衔的位置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1146
-msgid ""
-"`DrawInsignia.AdjustPos.BuildingsAnchor` can be set to an anchor point to"
-" anchor the insignia position relative to the building's selection "
-"bracket. By default the insignia position is not anchored to the "
-"selection bracket."
-msgstr ""
-"`DrawInsignia.AdjustPos.BuildingsAnchor` "
-"可以设置一个锚点，用于相对建筑选择框锚定军衔位置。默认情况下军衔位置未锚定到选择框。"
-
-#: ../../Fixed-or-Improved-Logics.md:1147
-msgid ""
-"`DrawInsignia.UsePixelSelectionBracketDelta` can be set to use techno's "
-"`PixelSelectionBracketDelta` to additionally adjust insignias vertically."
-msgstr ""
-"`DrawInsignia.UsePixelSelectionBracketDelta` 可以让军衔位置根据单位的 "
-"`PixelSelectionBracketDelta` 在竖直方向上调整位置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1150
-msgid ""
-"[General]\n"
-"EnemyInsignia=true                                          ; boolean\n"
+"[CAML]\n"
+"Image=JOSH\n"
 "\n"
-"[AudioVisual]\n"
-"DrawInsignia.OnlyOnSelected=false                           ; boolean\n"
-"DrawInsignia.UsePixelSelectionBracketDelta=false            ; boolean\n"
-"DrawInsignia.AdjustPos.Infantry=5,2                         ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.Units=10,6                           ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.Buildings=10,6                       ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.BuildingsAnchor=                     ; Hexagon "
-"vertex enumeration (top|lefttop|leftbottom|bottom|rightbottom|righttop)\n"
+"[BFRT]\n"
+"Image=SREF\n"
+msgstr ""
+"[CAML]\n"
+"Image=JOSH\n"
 "\n"
-"[SOMETECHNO]                                                ; TechnoType\n"
-"Insignia=                                                   ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Rookie=                                            ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Veteran=                                           ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Elite=                                             ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame=-1                                            ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Rookie=-1                                     ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Veteran=-1                                    ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Elite=-1                                      ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames=-1,-1,-1                                     ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.WeaponN=                                           ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Rookie=                                    ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Veteran=                                   ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Elite=                                     ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame.WeaponN=-1                                    ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Rookie=-1                             ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Veteran=-1                            ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Elite=-1                              ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames.WeaponN=-1,-1,-1                             ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.PassengersN=                                       ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Rookie=                                ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Veteran=                               ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Elite=                                 ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame.PassengersN=-1                                ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Rookie=-1                         ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Veteran=-1                        ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Elite=-1                          ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames.PassengersN=-1,-1,-1                         ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.ShowEnemy=                                         ; boolean, "
-"defaults to [General] -> EnemyInsignia\n"
+"[BFRT]\n"
+"Image=SREF\n"
+
+#: ../../Fixed-or-Improved-Logics.md:377
+msgid ""
+"In vanilla, `[CLNT]` does not have its own image. Originally, in "
+"`artmd.ini`, it uses another image placeholder via `Image=ARND`, but due "
+"to the lack of this feature, it has no effect. Subsequently, it and "
+"`[UTNK]` etc. also switch to using `rulesmd.ini` to call image resources;"
+" however, unlike other art sections which merely changed the "
+"implementation method, it not only changes the implementation method but "
+"also switches to using `Image=CIVC` instead of `ARND`. Although this does"
+" not directly manifest as a conflict when `[General] -> "
+"ArtImageSwap=true`, modders may need to pay attention."
 msgstr ""
-"[General]\n"
-"EnemyInsignia=true                                          ; boolean\n"
-"\n"
-"[AudioVisual]\n"
-"DrawInsignia.OnlyOnSelected=false                           ; boolean\n"
-"DrawInsignia.UsePixelSelectionBracketDelta=false            ; boolean\n"
-"DrawInsignia.AdjustPos.Infantry=5,2                         ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.Units=10,6                           ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.Buildings=10,6                       ; X,Y, "
-"position offset from default\n"
-"DrawInsignia.AdjustPos.BuildingsAnchor=                     ; Hexagon "
-"vertex enumeration (top|lefttop|leftbottom|bottom|rightbottom|righttop)\n"
-"\n"
-"[SOMETECHNO]                                                ; TechnoType\n"
-"Insignia=                                                   ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Rookie=                                            ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Veteran=                                           ; filename - "
-"excluding the .shp extension\n"
-"Insignia.Elite=                                             ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame=-1                                            ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Rookie=-1                                     ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Veteran=-1                                    ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.Elite=-1                                      ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames=-1,-1,-1                                     ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.WeaponN=                                           ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Rookie=                                    ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Veteran=                                   ; filename - "
-"excluding the .shp extension\n"
-"Insignia.WeaponN.Elite=                                     ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame.WeaponN=-1                                    ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Rookie=-1                             ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Veteran=-1                            ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.WeaponN.Elite=-1                              ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames.WeaponN=-1,-1,-1                             ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.PassengersN=                                       ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Rookie=                                ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Veteran=                               ; filename - "
-"excluding the .shp extension\n"
-"Insignia.PassengersN.Elite=                                 ; filename - "
-"excluding the .shp extension\n"
-"InsigniaFrame.PassengersN=-1                                ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Rookie=-1                         ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Veteran=-1                        ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrame.PassengersN.Elite=-1                          ; int, frame "
-"of insignia shp (zero-based) or -1 for default\n"
-"InsigniaFrames.PassengersN=-1,-1,-1                         ; int, frames"
-" of insignia shp (zero-based) or -1 for default\n"
-"Insignia.ShowEnemy=                                         ; boolean, "
-"defaults to [General] -> EnemyInsignia\n"
+"在原版中，`[CLNT]` 没有自己的图像，它原本在 `artmd.ini` 中通过 `Image=ARND` "
+"使用另一个图像占位，由于没有本功能所以没有任何效果。随后它和 `[UTNK]` 等同样转为通过 `rulesmd.ini` "
+"来实现图像资源调用，但它不是与其他 art 小节那样只是更改实现方式，还同时转为了使用 `Image=CIVC` 而非 `ARND`，虽然这在 "
+"`[General] -> ArtImageSwap=true` 时不会直接表现为冲突，但 modder 们可能需要注意。"
 
-#: ../../Fixed-or-Improved-Logics.md:1194
-msgid ""
-"Insignia customization besides the `InsigniaFrames` shorthand should "
-"function similarly to the equivalent feature introduced by Ares and takes"
-" precedence over it if Phobos is used together with Ares."
-msgstr ""
-"除了使用 `InsigniaFrames` 简写外，自定义军衔功能类似于 Ares 引入的相应功能，并且如果 Phobos 与 Ares "
-"一起使用则优先于 Ares 的。"
-
-#: ../../Fixed-or-Improved-Logics.md:1197
-msgid "Customizable wake anim"
-msgstr "自定义水波动画"
-
-#: ../../Fixed-or-Improved-Logics.md:1199
-msgid ""
-"You can now specify the `Wake` anim per TechnoType to override default "
-"rules value."
-msgstr "现在你可以为每个科技类型指定 `Wake` 动画以覆盖默认规则值。"
-
-#: ../../Fixed-or-Improved-Logics.md:1200
-msgid ""
-"`Wake.Grapple` and `Wake.Sinking` can be used to further customize wake "
-"anim when the techno is being parasited or sunken."
-msgstr "`Wake.Grapple` 和 `Wake.Sinking` 可用于在科技类型被寄生或沉没时进一步自定义水波动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:1203
-msgid ""
-"[SOMETECHNO]         ; TechnoType\n"
-"Wake=                ; Anim (played when Techno moving on the water), "
-"default to [General] -> Wake\n"
-"Wake.Grapple=        ; Anim (played when Techno being parasited on the "
-"water), defaults to [TechnoType] -> Wake\n"
-"Wake.Sinking=        ; Anim (played when Techno sinking), defaults to "
-"[TechnoType] -> Wake\n"
-msgstr ""
-"[SOMETECHNO]         ; TechnoType\n"
-"Wake=                ; Anim (played when Techno moving on the water), "
-"default to [General] -> Wake\n"
-"Wake.Grapple=        ; Anim (played when Techno being parasited on the "
-"water), defaults to [TechnoType] -> Wake\n"
-"Wake.Sinking=        ; Anim (played when Techno sinking), defaults to "
-"[TechnoType] -> Wake\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1210
-msgid "Customize bridge falling down damage"
-msgstr "自定义桥上坠落伤害"
-
-#: ../../Fixed-or-Improved-Logics.md:1212
-msgid ""
-"![image](_static/images/fallingdowndamage.gif) *Use different fall damage"
-" depending on whether it lands in water in **Zero Boundary** by "
-"@[Stormsulfur](https://space.bilibili.com/11638715/lists/5358986)*"
-msgstr ""
-"![image](_static/images/fallingdowndamage.gif) "
-"*@[暴风硫](https://space.bilibili.com/11638715/lists/5358986) 在 **零点界限** "
-"中根据是否落入水中使用不同的坠落伤害*"
-
-#: ../../Fixed-or-Improved-Logics.md:1215
-msgid ""
-"Now you can customize the damage a unit receives when it falls from a "
-"bridge."
-msgstr "现在你可以自定义单位从桥上坠落时受到的伤害。"
-
-#: ../../Fixed-or-Improved-Logics.md:1216
-msgid ""
-"`FallingDownDamage` customizes the damage a unit receives at the end of a"
-" fall. It can be a percentage or an integer."
-msgstr "`FallingDownDamage` 用于自定义单位坠落触底时所受到的伤害值，可以是比率或固定整数值。"
-
-#: ../../Fixed-or-Improved-Logics.md:1217
-msgid ""
-"`FallingDownDamage.Water` customizes the damage a unit receives when it "
-"falls onto the water. Defaults to `FallingDownDamage`."
-msgstr "`FallingDownDamage.Water` 用于自定义单位坠落到水中时所受的伤害值，默认同 `FallingDownDamage`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1218
-msgid ""
-"If it is a negative percentage, corresponding damage will be dealt based "
-"on the current health of the unit."
-msgstr "若设置负百分比则会根据单位当前生命值按比例造成对应伤害。"
-
-#: ../../Fixed-or-Improved-Logics.md:1221
-msgid ""
-"[SOMETECHNO]                    ; TechnoType\n"
-"FallingDownDamage=              ; integer / percentage\n"
-"FallingDownDamage.Water=        ; integer / percentage\n"
-msgstr ""
-"[SOMETECHNO]                    ; TechnoType\n"
-"FallingDownDamage=              ; integer / percentage\n"
-"FallingDownDamage.Water=        ; integer / percentage\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1227
+#: ../../Fixed-or-Improved-Logics.md:380
 msgid "Customize resource storage"
 msgstr "自定义资源储存"
 
-#: ../../Fixed-or-Improved-Logics.md:1229
+#: ../../Fixed-or-Improved-Logics.md:382
 msgid ""
 "Now Ares `Storage` feature can set which Tiberium type from `[Tiberiums]`"
 " list should be used for storing resources in structures with "
@@ -4800,11 +2165,11 @@ msgstr ""
 "现在 Ares 的 `Storage` 功能可以设置 `[Tiberiums]` 列表中的哪种类型被用于在拥有 "
 "`Refinery.UseStorage=yes` 且 `Storage` > 0 的建筑中存储。"
 
-#: ../../Fixed-or-Improved-Logics.md:1230
+#: ../../Fixed-or-Improved-Logics.md:383
 msgid "This tag can not be used without Ares."
 msgstr "此标签无法在没有 Ares 的情况下使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:1233
+#: ../../Fixed-or-Improved-Logics.md:386
 msgid ""
 "[General]\n"
 "Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index\n"
@@ -4812,18 +2177,18 @@ msgstr ""
 "[General]\n"
 "Storage.TiberiumIndex=-1  ; integer, [Tiberiums] list index\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1238
+#: ../../Fixed-or-Improved-Logics.md:391
 msgid "Customizing effect of level lighting on air units"
 msgstr "自定义光照等级对空中单位的影响"
 
-#: ../../Fixed-or-Improved-Logics.md:1240
+#: ../../Fixed-or-Improved-Logics.md:393
 msgid ""
 "It is now possible to customize how air units are affected by level "
 "lighting, separately for AircraftTypes and infantry/vehicles with Jumpjet"
 " `Locomotor`."
 msgstr "现在可以分别针战机类型和使用 `Locomotor=Jumpjet` 的步兵／载具自定义空中单位所受光照等级影响的方式。"
 
-#: ../../Fixed-or-Improved-Logics.md:1241
+#: ../../Fixed-or-Improved-Logics.md:394
 msgid ""
 "`AircraftLevelLightMultiplier` & `JumpjetLevelLightMultiplier` are direct"
 " multipliers to level lighting applied on the units, for height levels "
@@ -4832,7 +2197,7 @@ msgstr ""
 "`AircraftLevelLightMultiplier` 和 `JumpjetLevelLightMultiplier` "
 "是直接用于单位的光照等级强度倍率，适用于它们所飞掠单元格的高度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1244
+#: ../../Fixed-or-Improved-Logics.md:397
 msgid ""
 "[AudioVisual]\n"
 "AircraftLevelLightMultiplier=1.0  ; floating point value, percents or "
@@ -4846,323 +2211,37 @@ msgstr ""
 "JumpjetLevelLightMultiplier=0.0   ; floating point value, percents or "
 "absolute\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1250
-msgid "Damaged speed customization"
-msgstr "自定义伤残速度"
+#: ../../Fixed-or-Improved-Logics.md:403
+msgid "Customizing default ColorScheme"
+msgstr "自定义默认配色方案"
 
-#: ../../Fixed-or-Improved-Logics.md:1252
+#: ../../Fixed-or-Improved-Logics.md:405
 msgid ""
-"In vanilla, units using drive/ship loco will has hardcoded speed "
-"multiplier when damaged. Now you can customize it."
-msgstr "原版中 `Locomotor` 使用 `Drive`／`Ship` 的单位在伤残时有一个硬编码的速度倍率。现在你可以自由定义了。"
-
-#: ../../Fixed-or-Improved-Logics.md:1253
-msgid ""
-"The max valuebale value is 1.0, you cannot make unit get faster on yellow"
-" condition by it."
-msgstr "最大有效值为 1.0，你无法凭借这个逻辑让单位在黄血时变得更快。"
-
-#: ../../Fixed-or-Improved-Logics.md:1256
-msgid ""
-"[General]\n"
-"DamagedSpeed=0.75        ; floating point value, multiplier\n"
-"\n"
-"[SOMETECHNO]             ; TechnoType\n"
-"DamagedSpeed=            ; floating point value, multiplier\n"
+"In vanilla, an `AltPalette=yes` animation or `Voxel=yes` Projectile image"
+" that cannot properly remap will use the first Color Scheme in the "
+"`[Colors]` list; now it can be manually specified."
 msgstr ""
-"[General]\n"
-"DamagedSpeed=0.75        ; floating point value, multiplier\n"
-"\n"
-"[SOMETECHNO]             ; TechnoType\n"
-"DamagedSpeed=            ; floating point value, multiplier\n"
+"在原版中，一个无法正确重映射颜色的 `AltPalette=yes` 动画或 `Voxel=yes` 的抛射体图像会使用 `[Colors]` 列表中的第一个配色方案作为默认配色方案来映射所属色，现在它可以被手动指定了。"
 
-#: ../../Fixed-or-Improved-Logics.md:1264
-msgid "Debris voxel animations limitation"
-msgstr "Voxel 碎片数量限制"
-
-#: ../../Fixed-or-Improved-Logics.md:1266
-#: ../../Fixed-or-Improved-Logics.md:2104
+#: ../../Fixed-or-Improved-Logics.md:408
 msgid ""
-"Now, the original `DebrisMaximums` can be used in conjunction with new "
-"`DebrisMinimums` to limit the quantity of `DebrisTypes` when "
-"`DebrisTypes.Limit` is enabled."
+"[AudioVisual]\n"
+"AnimRemapDefaultColorScheme=      ; ColorScheme name\n"
 msgstr ""
-"当启用 `DebrisTypes.Limit` 时可通过原有的 `DebrisMaximums` 结合新增的 `DebrisMinimums` "
-"共同限制 `DebrisTypes` 的数量。"
+"[AudioVisual]\n"
+"AnimRemapDefaultColorScheme=      ; ColorScheme name\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1267
-#: ../../Fixed-or-Improved-Logics.md:2105
-msgid ""
-"The default value of `DebrisTypes.Limit` is whether the number of "
-"`DebrisMaximums` is greater than (not equal to) 1 (for compatibility "
-"reasons)."
-msgstr "出于兼容目的，若 `DebrisMaximums` 大于（不包括等于）1 则默认启用 `DebrisTypes.Limit`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1270
-msgid ""
-"[SOMETECHNO]        ; TechnoType\n"
-"DebrisTypes.Limit=  ; boolean\n"
-"DebrisMaximums=     ; List of integers\n"
-"DebrisMinimums=     ; List of integers\n"
-msgstr ""
-"[SOMETECHNO]        ; TechnoType\n"
-"DebrisTypes.Limit=  ; boolean\n"
-"DebrisMaximums=     ; List of integers\n"
-"DebrisMinimums=     ; List of integers\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1278
-msgid "How to generate `DebrisTypes` in the game:"
-msgstr "游戏如何生成 `DebrisTypes`："
-
-#: ../../Fixed-or-Improved-Logics.md:1279
-msgid ""
-"Generate the total number of debris through `MaxDebris` and `MinDebris` "
-"first."
-msgstr "首先通过 `MaxDebris` 与 `MinDebris` 确定所要生成碎片的总量。"
-
-#: ../../Fixed-or-Improved-Logics.md:1280
-msgid ""
-"Traverse `DebrisTypes` and limit the quantity range through "
-"`DebrisMaximums` and `DebrisMinimums`."
-msgstr "遍历 `DebrisTypes` 列表并通过 `DebrisMaximums` 和 `DebrisMinimums` 限制数量范围。"
-
-#: ../../Fixed-or-Improved-Logics.md:1281
-msgid ""
-"When the number of generated debris will exceeds the total number, limit "
-"the quantity and end the traversal."
-msgstr "当已生成碎片数量将要超过总量时限制数量并停止遍历。"
-
-#: ../../Fixed-or-Improved-Logics.md:1282
-msgid ""
-"When the number of debris generated after a single traversal is not "
-"enough to exceed the total number, it will end if `DebrisTypes.Limit` is "
-"enabled, otherwise the traversal will restart like vanilla game do."
-msgstr "当遍历完成但碎片的数量并未达到总量时，若启用 `DebrisTypes.Limit` 则直接结束，否则按原版游戏机制重新进行遍历。"
-
-#: ../../Fixed-or-Improved-Logics.md:1285
-msgid "Exploding object customizations"
-msgstr "爆炸对象的自定义"
-
-#: ../../Fixed-or-Improved-Logics.md:1287
-msgid ""
-"By default `Explodes=true` TechnoTypes have all of their passengers "
-"killed when they are destroyed. This behaviour can now be disabled by "
-"setting `Explodes.KillPassengers=false`."
-msgstr ""
-"默认情况下 `Explodes=true` 的科技类型被摧毁时它们的所有乘客都会被击杀。现在可以通过设置 "
-"`Explodes.KillPassengers=false` 禁用此行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:1288
-msgid ""
-"BuildingTypes with `Explodes=true` can by default explode even when they "
-"are still being built or sold. This can be disabled by setting "
-"`Explodes.DuringBuildup` to false. This causes them to behave as if "
-"`Explodes` was set to false while being built up or sold."
-msgstr ""
-"默认情况下拥有 `Explodes=true` 的建筑即使处于建造或出售过程中也可以引爆。可以通过设置 "
-"`Explodes.DuringBuildup` 为 false 来禁用。这样它们在建造或出售过程中会表现得像是 `Explodes` 被设为 "
-"false 一样。"
-
-#: ../../Fixed-or-Improved-Logics.md:1291
-msgid ""
-"[SOMETECHNO]                 ; TechnoType\n"
-"Explodes.KillPassengers=true ; boolean\n"
-"\n"
-"[SOMEBUILDING]               ; BuildingType\n"
-"Explodes.DuringBuildup=true  ; boolean\n"
-msgstr ""
-"[SOMETECHNO]                 ; TechnoType\n"
-"Explodes.KillPassengers=true ; boolean\n"
-"\n"
-"[SOMEBUILDING]               ; BuildingType\n"
-"Explodes.DuringBuildup=true  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1299
-msgid "Forbid parallel AI queues"
-msgstr "禁止 AI 并行生产队列"
-
-#: ../../Fixed-or-Improved-Logics.md:1301
-msgid ""
-"You can now set if specific types of factories do not have AI production "
-"cloning issue instead of Ares' indiscriminate behavior of "
-"`AllowParallelAIQueues=no`."
-msgstr "现在你可以设置特定类型的工厂是否禁用 AI 克隆生产而不是 Ares 的 `AllowParallelAIQueues=no` 那样全部禁用。"
-
-#: ../../Fixed-or-Improved-Logics.md:1302
-msgid ""
-"If `AllowParallelAIQueues=no` *(Ares feature)* is set, the tags have no "
-"effect."
-msgstr "如果 `AllowParallelAIQueues=no`（*Ares 功能*）被设置，该标签无效。"
-
-#: ../../Fixed-or-Improved-Logics.md:1303
-msgid ""
-"You can also exclude specific TechnoTypes from being built in parallel by"
-" AI by setting `ForbidParallelAIQueues` to true on a TechnoType."
-msgstr "你还可以通过在科技类型上将 `ForbidParallelAIQueues` 设为 true 来禁止特定科技类型被 AI 克隆生产。"
-
-#: ../../Fixed-or-Improved-Logics.md:1306
-msgid ""
-"[GlobalControls]\n"
-"AllowParallelAIQueues=yes           ; must be set yes/true unless you "
-"don't use Ares\n"
-"ForbidParallelAIQueues.Infantry=no  ; boolean\n"
-"ForbidParallelAIQueues.Vehicle=no   ; boolean\n"
-"ForbidParallelAIQueues.Navy=no      ; boolean\n"
-"ForbidParallelAIQueues.Aircraft=no  ; boolean\n"
-"ForbidParallelAIQueues.Building=no  ; boolean\n"
-"\n"
-"[SOMETECHNO]                        ; TechnoType\n"
-"ForbidParallelAIQueues=false        ; boolean\n"
-msgstr ""
-"[GlobalControls]\n"
-"AllowParallelAIQueues=yes           ; must be set yes/true unless you "
-"don't use Ares\n"
-"ForbidParallelAIQueues.Infantry=no  ; boolean\n"
-"ForbidParallelAIQueues.Vehicle=no   ; boolean\n"
-"ForbidParallelAIQueues.Navy=no      ; boolean\n"
-"ForbidParallelAIQueues.Aircraft=no  ; boolean\n"
-"ForbidParallelAIQueues.Building=no  ; boolean\n"
-"\n"
-"[SOMETECHNO]                        ; TechnoType\n"
-"ForbidParallelAIQueues=false        ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1319
-msgid "Force techno targeting in distributed frames to improve performance"
-msgstr "强制单位索敌行为分散到不同帧以提升性能"
-
-#: ../../Fixed-or-Improved-Logics.md:1321
-msgid ""
-"When you create many technos in a same frame (i.e. starting the game with"
-" a campaign map that initially has a large number of technos), they will "
-"always scan for targets in a synchronous period, causing game lag. "
-"Increasing targeting delay alone will not make things better, as their "
-"targeting is still synchronized."
-msgstr "当你在同一帧内创建大量单位（例如进入一个初始预置了大量单位的战役地图）时它们总是会同时扫描目标从而导致游戏卡顿。仅通过增大索敌间隔并不能改善这点，因为它们仍会同时索敌。"
-
-#: ../../Fixed-or-Improved-Logics.md:1322
-msgid ""
-"It is now possible to force them to seek targets separately. If "
-"`DistributeTargetingFrame=true` is set, techno's targeting timer will be "
-"initiated with a random delay, ranging in \\[0,15\\]. This can distribute"
-" their targeting timing within 15 frames, thus alleviating the above-"
-"mentioned lag."
-msgstr ""
-"现在可以强制它们分别寻找目标。如果设置 "
-"`DistributeTargetingFrame=true`，单位的瞄准计时器将在随机延迟后启动，延迟范围在 `[0,15]` "
-"之间。这可以将它们的瞄准时间分散在 15 帧内，从而缓解上述卡顿问题。"
-
-#: ../../Fixed-or-Improved-Logics.md:1323
-msgid ""
-"You can use `DistributeTargetingFrame.AIOnly` to make it only work for AI"
-" (Players are not likely to have so many technos.)"
-msgstr "你可以使用 `DistributeTargetingFrame.AIOnly` 使其仅对 AI 生效（人类玩家通常不太可能有那么多单位）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1326
-msgid ""
-"[General]\n"
-"DistributeTargetingFrame=false         ; boolean\n"
-"DistributeTargetingFrame.AIOnly=true   ; boolean\n"
-"\n"
-"[SOMETECHNO]                           ; TechnoType\n"
-"DistributeTargetingFrame=              ; boolean\n"
-msgstr ""
-"[General]\n"
-"DistributeTargetingFrame=false         ; boolean\n"
-"DistributeTargetingFrame.AIOnly=true   ; boolean\n"
-"\n"
-"[SOMETECHNO]                           ; TechnoType\n"
-"DistributeTargetingFrame=              ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1335
-msgid "Iron Curtain & Force Shield effects on organics customization"
-msgstr "铁幕和力场护盾对有机体效果的自定义"
-
-#: ../../Fixed-or-Improved-Logics.md:1337
-msgid ""
-"In vanilla game, when Iron Curtain is applied on `Organic=true` units "
-"like squids or infantry, they could only get killed instantly by "
-"`C4Warhead`. This behavior is now unhardcoded and can be set with "
-"`IronCurtain.EffectOnOrganics` globally and on per-TechnoType basis with "
-"`IronCurtain.Effect`. Following values are respected:"
-msgstr ""
-"在原本的游戏中，当铁幕效果应用于例如巨型乌贼和步兵这种 `Organic=true` 的单位时，它们只能被 `C4Warhead` "
-"瞬间击杀。现在此行为已被解除硬编码，并且可以通过全局的 `IronCurtain.EffectOnOrganics` 和每个科技类型的 "
-"`IronCurtain.Effect` 属性来自定义。可接受的值如下："
-
-#: ../../Fixed-or-Improved-Logics.md:1338
-msgid ""
-"`kill` : Iron Curtain kills the organic object with a specifc warhead. "
-"This is the default value for `Organic=true` units and infantry if not "
-"otherwise specified."
-msgstr "`kill`：铁幕会用特定的弹头杀死有机体，这是 `Organic=true` 单位和步兵的默认值，除非专门指定。"
-
-#: ../../Fixed-or-Improved-Logics.md:1339
-msgid ""
-"`invulnerable` : Iron Curtain makes the organic object invulnerable like "
-"buildings and vehicles."
-msgstr "`invulnerable`：铁幕会使有机体像建筑和载具一样获得无敌效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:1340
-msgid "`ignore` : Iron Curtain doesn't give any effect on the organic object."
-msgstr "`ignore`：铁幕不会对有机体造成任何影响。"
-
-#: ../../Fixed-or-Improved-Logics.md:1341
-msgid "Identical controls are available for Force Shield as well."
-msgstr "力场护盾也有相同的控制选项。"
-
-#: ../../Fixed-or-Improved-Logics.md:1344
-msgid ""
-"[CombatDamage]\n"
-"IronCurtain.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
-"(kill | invulnerable | ignore)\n"
-"IronCurtain.KillOrganicsWarhead=   ; WarheadType, default to "
-"[CombatDamage] -> C4Warhead\n"
-"ForceShield.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
-"(kill | invulnerable | ignore)\n"
-"ForceShield.KillOrganicsWarhead=   ; WarheadType, default to "
-"[CombatDamage] -> C4Warhead\n"
-"\n"
-"[SOMETECHNO]                       ; TechnoType with Organic=true\n"
-"IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill"
-" | invulnerable | ignore)\n"
-"IronCurtain.KillWarhead=           ; WarheadType, default to "
-"[CombatDamage] -> IronCurtain.KillOrganicsWarhead\n"
-"ForceShield.Effect=                ; IronCurtain effect Enumeration (kill"
-" | invulnerable | ignore)\n"
-"ForceShield.KillWarhead=           ; WarheadType, default to "
-"[CombatDamage] -> ForceShield.KillOrganicsWarhead\n"
-msgstr ""
-"[CombatDamage]\n"
-"IronCurtain.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
-"(kill | invulnerable | ignore)\n"
-"IronCurtain.KillOrganicsWarhead=   ; WarheadType, default to "
-"[CombatDamage] -> C4Warhead\n"
-"ForceShield.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
-"(kill | invulnerable | ignore)\n"
-"ForceShield.KillOrganicsWarhead=   ; WarheadType, default to "
-"[CombatDamage] -> C4Warhead\n"
-"\n"
-"[SOMETECHNO]                       ; TechnoType with Organic=true\n"
-"IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill"
-" | invulnerable | ignore)\n"
-"IronCurtain.KillWarhead=           ; WarheadType, default to "
-"[CombatDamage] -> IronCurtain.KillOrganicsWarhead\n"
-"ForceShield.Effect=                ; IronCurtain effect Enumeration (kill"
-" | invulnerable | ignore)\n"
-"ForceShield.KillWarhead=           ; WarheadType, default to "
-"[CombatDamage] -> ForceShield.KillOrganicsWarhead\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1358
+#: ../../Fixed-or-Improved-Logics.md:413
 msgid "Iron Curtain & Force Shield extra tint intensity"
 msgstr "铁幕和力场护盾的额外染色强度"
 
-#: ../../Fixed-or-Improved-Logics.md:1360
+#: ../../Fixed-or-Improved-Logics.md:415
 msgid ""
 "It is now possible to specify additional tint intensity applied to Iron "
 "Curtained and Force Shielded units."
 msgstr "现在可以指定应用于处于铁幕和力场护盾中的单位的额外染色强度。"
 
-#: ../../Fixed-or-Improved-Logics.md:1363
+#: ../../Fixed-or-Improved-Logics.md:418
 msgid ""
 "[AudioVisual]\n"
 "IronCurtain.ExtraTintIntensity=0.0  ; floating point value\n"
@@ -5172,370 +2251,66 @@ msgstr ""
 "IronCurtain.ExtraTintIntensity=0.0  ; floating point value\n"
 "ForceShield.ExtraTintIntensity=0.0  ; floating point value\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1369
-msgid "Jumpjet climbing logic enhancement"
-msgstr "Jumpjet 爬升逻辑增强"
+#: ../../Fixed-or-Improved-Logics.md:424
+msgid "Move IvanBomb Position"
+msgstr "移动伊文炸弹位置"
 
-#: ../../Fixed-or-Improved-Logics.md:1371
+#: ../../Fixed-or-Improved-Logics.md:426
 msgid ""
-"You can now let the jumpjets increase their height earlier by set "
-"`JumpjetClimbPredictHeight` to true. The jumpjet will raise its height 5 "
-"cells in advance, instead of only raising its height when encountering "
-"cliffs or buildings in front of it."
+"In vanilla, IvanBomb images display and the bombs detonate at the top-"
+"leftmost cell of the building foundation instead of at the center of "
+"buildings. This can now be changed."
 msgstr ""
-"现在你可以通过将 `JumpjetClimbPredictHeight` 设为 true 来使 Jumpjet "
-"单位提前增加飞行高度。Jumpjet 将会提前 5 个单元格开始抬升而非仅在悬崖和建筑马上贴脸了才抬升高度。"
+"在原版中，伊文炸弹的图像显示位置和炸弹引爆位置在建筑占地左上角的单元格而不是建筑中心。现在这可以被更改。"
 
-#: ../../Fixed-or-Improved-Logics.md:1372
+#: ../../Fixed-or-Improved-Logics.md:429
 msgid ""
-"You can also let them simply skip the stop check by set "
-"`JumpjetClimbWithoutCutOut` to true. The jumpjet will not stop moving "
-"horizontally when encountering cliffs or buildings in front of it, but "
-"will continue to move forward while raising its altitude."
+"[CombatDamage]\n"
+"IvanBombAttachToCenter=false  ; boolean\n"
 msgstr ""
-"你还可以通过将 `JumpjetClimbWithoutCutOut` 设为 true 来跳过停止移动检查。Jumpjet "
-"在已经抵近悬崖或建筑时将不会停止水平方向上的移动，而是在抬升高度的同时继续前行。"
+"[CombatDamage]\n"
+"IvanBombAttachToCenter=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1373
+#: ../../Fixed-or-Improved-Logics.md:435
+msgid "Due to technical constraints this cannot be customized per WeaponType."
+msgstr "由于技术限制，这无法在每种武器上微观定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:438
+msgid "RadialIndicator visibility"
+msgstr "范围指示环可见性"
+
+#: ../../Fixed-or-Improved-Logics.md:440
 msgid ""
-"When `JumpjetClimbPredictHeight` is enabled, if the height raised five "
-"grids in advance is still not enough to cross cliffs or buildings, it "
-"will stop and move horizontally as before, unless "
-"`JumpjetClimbWithoutCutOut` is also enabled."
-msgstr ""
-"当启用 `JumpjetClimbPredictHeight` 时，若提前 5 个单元格后的高度仍然不足以越过悬崖或建筑，Jumpjet "
-"将会像原先那样停止水平方向上的移动，除非还启用了 `JumpjetClimbWithoutCutOut`。"
+"In vanilla game, a structure's radial indicator can be drawn only when it"
+" belongs to the player. Now it can also be visible to observer. On top of"
+" that, you can specify its visibility from other houses."
+msgstr "在原本的游戏中，建筑的范围指示环只有在玩家拥有时才绘制。现在它也对观察者可见。此外，你还可以指定其他所属方的可见性。"
 
-#: ../../Fixed-or-Improved-Logics.md:1376
-msgid ""
-"[General]\n"
-"JumpjetClimbPredictHeight=false  ; boolean\n"
-"JumpjetClimbWithoutCutOut=false  ; boolean\n"
-msgstr ""
-"[General]\n"
-"JumpjetClimbPredictHeight=false  ; boolean\n"
-"JumpjetClimbWithoutCutOut=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1382
-msgid "Jumpjet rotating on crashing toggle"
-msgstr "Jumpjet 旋转着坠毁的开关"
-
-#: ../../Fixed-or-Improved-Logics.md:1384
-msgid ""
-"Jumpjet that is going to crash starts to change its facing "
-"uncontrollably, this can now be turned off."
-msgstr "即将坠毁的 Jumpjet 会开始不可控地改变其朝向，现在可以将其关闭。"
-
-#: ../../Fixed-or-Improved-Logics.md:1387
-msgid ""
-"[SOMETECHNO]               ; TechnoType\n"
-"JumpjetRotateOnCrash=true  ; boolean\n"
-msgstr ""
-"[SOMETECHNO]               ; TechnoType\n"
-"JumpjetRotateOnCrash=true  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1393
-msgid "This may subject to further changes."
-msgstr "这可能会在未来进一步更改。"
-
-#: ../../Fixed-or-Improved-Logics.md:1396
-msgid "Kill spawns on low power"
-msgstr "断电时击杀子机"
-
-#: ../../Fixed-or-Improved-Logics.md:1398
-msgid ""
-"`Powered=yes` structures that spawn aircraft like Aircraft Carriers will "
-"stop targeting the enemy if low power."
-msgstr "拥有 `Powered=yes` 的建筑航母在断电时将会停止攻击敌人。"
-
-#: ../../Fixed-or-Improved-Logics.md:1399
-msgid "Spawned aircraft self-destruct if they are flying."
-msgstr "被生成的战机如果正在飞行那么会自毁。"
-
-#: ../../Fixed-or-Improved-Logics.md:1402
-msgid ""
-"[SOMESTRUCTURE]          ; BuildingType\n"
-"Powered.KillSpawns=false ; boolean\n"
-msgstr ""
-"[SOMESTRUCTURE]          ; BuildingType\n"
-"Powered.KillSpawns=false ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1407
-msgid "PipScale pip customizations"
-msgstr "自定义 PipScale"
-
-#: ../../Fixed-or-Improved-Logics.md:1409
-msgid ""
-"It is now possible to change the size of pips (or more accurately the "
-"pixel increment to the next pip drawn) displayed on `PipScale`."
-msgstr "现在可以更改在 `PipScale` 中显示的 pip 的大小（或者更确切的说是绘制下一个 pip 的像素增量）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1410
-msgid ""
-"`Pips.Generic.(Buildings.)Size` is for non-ammo pips on non-building "
-"TechnoTypes / buildings, accordingly, and `Pips.Ammo.(Buildings.)Size` is"
-" in turn for ammo pips, split similarly between non-building technos and "
-"buildings."
-msgstr ""
-"`Pips.Generic.(Buildings.)Size` 用于非建筑科技类型／建筑的非弹药 "
-"pip，相应的，`Pips.Ammo.(Buildings.)Size` 则是针对弹药 pip，同样分别对应非建筑科技类型／建筑。"
-
-#: ../../Fixed-or-Improved-Logics.md:1411
-msgid ""
-"Ammo pip size can also be overridden on per TechnoType-basis using "
-"`AmmoPipSize`."
-msgstr "还可以通过 `AmmoPipSize` 为每个科技类型重写弹药 pip 的大小。"
-
-#: ../../Fixed-or-Improved-Logics.md:1412
-msgid "Ammo pip frames can now also be customized."
-msgstr "现在也可以自定义弹药  pip 的帧。"
-
-#: ../../Fixed-or-Improved-Logics.md:1413
-msgid ""
-"`AmmoPipFrame` and `EmptyAmmoPipFrame` are frames (zero-based) of "
-"`pips2.shp` used for ammo pip and empty ammo pip (this is not set by "
-"default) for when `PipWrap=0` (this is the default)."
-msgstr ""
-"`AmmoPipFrame` 和 `EmptyAmmoPipFrame` 是在 `PipWrap=0`（这是默认行为）时使用的 "
-"`pips2.shp` 中（从 0 开始的）帧，用于弹药 pip 和空弹药 pip。"
-
-#: ../../Fixed-or-Improved-Logics.md:1414
-msgid ""
-"`AmmoPipWrapStartFrame` is used as start frame (zero-based, from "
-"`pips2.shp`) for when `PipWrap` is above 0. The start frame is the empty "
-"frame and up to `Ammo` divided by `PipWrap` frames after it are used for "
-"the different reload stages."
-msgstr ""
-"`AmmoPipWrapStartFrame` 用作 `PipWrap` 大于 0 时将 `pips2.shp` 中（从 0 "
-"开始的）帧设为起始帧。起始帧是空帧，从起始帧之后最多有 `Ammo` 除以 `PipWrap` 个帧用于不同的装填阶段。"
-
-#: ../../Fixed-or-Improved-Logics.md:1415
-msgid "`AmmoPipOffset` can be used to shift the starting position of ammo pips."
-msgstr "`AmmoPipOffset` 可用于移动弹药 pip 的起始位置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1416
-msgid "Pips for TechnoTypes with `Spawns` can now also be customized."
-msgstr "现在带有 `Spawns` 的科技类型的 pip 也可以进行自定义。"
-
-#: ../../Fixed-or-Improved-Logics.md:1417
-msgid ""
-"`ShowSpawnsPips` determines whether or not these pips are shown at all, "
-"as they are independent from `PipScale` setting."
-msgstr "`ShowSpawnsPips` 决定这些 pip 是否显示，因为它们与 `PipScale` 设置无关。"
-
-#: ../../Fixed-or-Improved-Logics.md:1418
-msgid ""
-"`SpawnsPipFrame` and `EmptySpawnsPipFrame` are frames (zero-based) of "
-"`pips.shp` (for buildings) or `pips2.shp` (for others) used for a spawnee"
-" pip and empty spawnee pip, respectively."
-msgstr ""
-"`SpawnsPipFrame` 和 `EmptySpawnsPipFrame` 分别是 `pips.shp`（对于建筑）或 "
-"`pips2.shp`（对于其他）中（从 0 开始的）帧，用于子机 pip 和空子机 pip。"
-
-#: ../../Fixed-or-Improved-Logics.md:1419
-msgid ""
-"`SpawnsPipSize` determines the pixel increment to the next pip drawn. "
-"Defaults to `[AudioVisual] -> Pips.Generic.(Buildings.)Size` if not set."
-msgstr ""
-"`SpawnsPipSize` 决定了到下一个 pip 绘制的像素增量。若未设置则默认为 `[AudioVisual] -> "
-"Pips.Generic.(Buildings.)Size`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1420
-msgid ""
-"`SpawnsPipoffset` can be used to shift the starting position of spawnee "
-"pips."
-msgstr "`SpawnsPipoffset` 可以被用于移动子机 pip 的起始位置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1421
-msgid ""
-"Pips for `Storage` can now also be customized via new keys in "
-"`[AudioVisual]`."
-msgstr "现在可以通过 `[AudioVisual]` 中的新标签来自定义 `Storage` 的 pip。"
-
-#: ../../Fixed-or-Improved-Logics.md:1422
-msgid ""
-"`Pips.Tiberiums.Frames` can be used to list frames (zero-based) of "
-"`pips.shp` (for buildings) or `pips2.shp` (for others) used for tiberium "
-"types, in the listed order corresponding to tiberium type index. Defaults"
-" to 5 for tiberium type index 1, otherwise 2."
-msgstr ""
-"`Pips.Tiberiums.Frames` 可用于列出用于泰伯利亚类型的 `pips.shp`（用于建筑）或 "
-"`pips2.shp`（用于其他）中（从 0 开始的）帧，按与泰伯利亚类型序数对应的列表排列顺序，泰伯利亚类型为 1 时默认为 5，否则为 2。"
-
-#: ../../Fixed-or-Improved-Logics.md:1423
-msgid ""
-"`Pips.Tiberiums.EmptyFrame` can be used to set the frame for empty slots,"
-" defaults to 0."
-msgstr "`Pips.Tiberiums.EmptyFrame` 可用于设置空槽的帧，默认为 0。"
-
-#: ../../Fixed-or-Improved-Logics.md:1424
-msgid ""
-"`Pips.Tiberiums.DisplayOrder` controls in which order the tiberium type "
-"pips are displayed, takes a list of tiberium type indices. Any tiberium "
-"type not listed will be displayed in sequential order after the listed "
-"ones."
-msgstr ""
-"`Pips.Tiberiums.DisplayOrder` 控制泰伯利亚类型 pip "
-"显示的顺序，取一个泰伯利亚类型索引列表。任何未列出的将在列出后按顺序显示。"
-
-#: ../../Fixed-or-Improved-Logics.md:1425
-msgid ""
-"`Pips.Tiberiums.WeedFrame` controls which frame is displayed on Technos "
-"with `Weeder=yes`, takes a (zero-based) index of a frame in `pips.shp` "
-"(for buildings) or `pips2.shp` (for others). Defaults to 1."
-msgstr ""
-"`Pips.Tiberiums.WeedFrame` 控制在 `Weeder=yes` 科技类型上显示的帧，使用 "
-"`pips.shp`（用于建筑）或 `pips2.shp`（用于其他）中（从 0 开始的）索引，默认为 1。"
-
-#: ../../Fixed-or-Improved-Logics.md:1426
-msgid ""
-"`Pips.Tiberiums.WeedEmptyFrame` can be used to set the frame for empty "
-"weed slots, defaults to 0."
-msgstr "`Pips.Tiberiums.WeedEmptyFrame` 可用于设置空置废矿槽的帧，默认为 0。"
-
-#: ../../Fixed-or-Improved-Logics.md:1429
+#: ../../Fixed-or-Improved-Logics.md:444
 msgid ""
 "[AudioVisual]\n"
-"Pips.Generic.Size=4,0                ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Generic.Buildings.Size=4,2      ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Ammo.Size=4,0                   ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Ammo.Buildings.Size=4,2         ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Tiberiums.EmptyFrame=0          ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.Frames=2,5,2,2        ; List of integers, frames of "
-"pips.shp (buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.DisplayOrder=0,2,3,1  ; List of integers, tiberium type "
-"indices\n"
-"Pips.Tiberiums.WeedEmptyFrame=0      ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.WeedFrame=1           ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"\n"
-"[SOMETECHNO]                         ; TechnoType\n"
-"AmmoPipFrame=13                      ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"EmptyAmmoPipFrame=-1                 ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"AmmoPipWrapStartFrame=14             ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"AmmoPipSize=                         ; X,Y, increment in pixels to next "
-"pip\n"
-"AmmoPipOffset=0,0                    ; X,Y, position offset from default\n"
-"ShowSpawnsPips=true                  ; boolean\n"
-"SpawnsPipFrame=1                     ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"EmptySpawnsPipFrame=0                ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"SpawnsPipSize=                       ; X,Y, increment in pixels to next "
-"pip\n"
-"SpawnsPipOffset=0,0                  ; X,Y, position offset from default\n"
+"RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
+"(owner/self | allies/ally | enemies/enemy | all)\n"
 msgstr ""
 "[AudioVisual]\n"
-"Pips.Generic.Size=4,0                ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Generic.Buildings.Size=4,2      ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Ammo.Size=4,0                   ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Ammo.Buildings.Size=4,2         ; X,Y, increment in pixels to next "
-"pip\n"
-"Pips.Tiberiums.EmptyFrame=0          ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.Frames=2,5,2,2        ; List of integers, frames of "
-"pips.shp (buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.DisplayOrder=0,2,3,1  ; List of integers, tiberium type "
-"indices\n"
-"Pips.Tiberiums.WeedEmptyFrame=0      ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"Pips.Tiberiums.WeedFrame=1           ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"\n"
-"[SOMETECHNO]                         ; TechnoType\n"
-"AmmoPipFrame=13                      ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"EmptyAmmoPipFrame=-1                 ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"AmmoPipWrapStartFrame=14             ; integer, frame of pips2.shp (zero-"
-"based)\n"
-"AmmoPipSize=                         ; X,Y, increment in pixels to next "
-"pip\n"
-"AmmoPipOffset=0,0                    ; X,Y, position offset from default\n"
-"ShowSpawnsPips=true                  ; boolean\n"
-"SpawnsPipFrame=1                     ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"EmptySpawnsPipFrame=0                ; integer, frame of pips.shp "
-"(buildings) or pips2.shp (others) (zero-based)\n"
-"SpawnsPipSize=                       ; X,Y, increment in pixels to next "
-"pip\n"
-"SpawnsPipOffset=0,0                  ; X,Y, position offset from default\n"
+"RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
+"(owner/self | allies/ally | enemies/enemy | all)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1454
-msgid "Power drain for units"
-msgstr "单位消耗电力"
+#: ../../Fixed-or-Improved-Logics.md:449
+msgid "Re-enable obsolete `[JumpjetControls]`"
+msgstr "重启废弃的 `[JumpjetControls]`"
 
-#: ../../Fixed-or-Improved-Logics.md:1456
-msgid ""
-"Infantry, vehicles and aircraft can now drain or provide `Power` if "
-"`UnitPowerDrain=true` is set."
-msgstr "如果设置了 `UnitPowerDrain=true`，步兵、载具和战机现在都将可以消耗或提供 `Power`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1459
-msgid ""
-"[General]\n"
-"UnitPowerDrain=false  ; boolean\n"
-"\n"
-"[SOMETECHNO]          ; TechnoType\n"
-"Power=0               ; integer, positive means output, negative means "
-"drain\n"
-msgstr ""
-"[General]\n"
-"UnitPowerDrain=false  ; boolean\n"
-"\n"
-"[SOMETECHNO]          ; TechnoType\n"
-"Power=0               ; integer, positive means output, negative means "
-"drain\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1467
-msgid "RadarInvisible for non-enemy house"
-msgstr "不仅限于敌方的 `RadarInvisible`"
-
-#: ../../Fixed-or-Improved-Logics.md:1469
-msgid ""
-"In vanilla, `RadarInvisible` is ignored if the techno is allied with the "
-"current player. Now you can change this behavior."
-msgstr "在原版游戏中 `RadarInvisible` 仅对当前非友军的玩家有效，现在你可以更改这一行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:1472
-msgid ""
-"[SOMETECHNO]                         ; TechnoType\n"
-"RadarInvisibleToHouse=               ; Affected House Enumeration "
-"(none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if"
-" RadarInvisible=true, none otherwise\n"
-msgstr ""
-"[SOMETECHNO]                         ; TechnoType\n"
-"RadarInvisibleToHouse=               ; Affected House Enumeration "
-"(none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if"
-" RadarInvisible=true, none otherwise\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1477
-msgid "Re-enable obsolete [JumpjetControls]"
-msgstr "重启废弃的 [JumpjetControls]"
-
-#: ../../Fixed-or-Improved-Logics.md:1479
+#: ../../Fixed-or-Improved-Logics.md:451
 msgid ""
 "Re-enable obsolete `[JumpjetControls]`, the keys in it will be as the "
 "default value of jumpjet units."
 msgstr "重启了废弃的 `[JumpjetControls]`，其中的标签将用于 Jumpjet 单位的默认值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1480
+#: ../../Fixed-or-Improved-Logics.md:452
 msgid "Moreover, added two tags for missing ones."
 msgstr "此外，新增了两个标签用于空缺项。"
 
-#: ../../Fixed-or-Improved-Logics.md:1483
+#: ../../Fixed-or-Improved-Logics.md:455
 msgid ""
 "[JumpjetControls]\n"
 "Crash=5.0        ; floating point value\n"
@@ -5545,7 +2320,7 @@ msgstr ""
 "Crash=5.0        ; floating point value\n"
 "NoWobbles=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1490
+#: ../../Fixed-or-Improved-Logics.md:462
 msgid ""
 "`CruiseHeight` is for `JumpjetHeight`, `WobblesPerSecond` is for "
 "`JumpjetWobbles`, `WobbleDeviation` is for `JumpjetDeviation`, and "
@@ -5556,18 +2331,18 @@ msgstr ""
 "`JumpjetWobbles`、`WobbleDeviation` 对应 `JumpjetDeviation` 以及 "
 "`Acceleration` 对应 `JumpjetAccel`。其他所有相应的标签只是去掉了 Jumpjet 前缀。"
 
-#: ../../Fixed-or-Improved-Logics.md:1493
+#: ../../Fixed-or-Improved-Logics.md:465
 msgid "Skirmish AI behavior dehardcode"
 msgstr "遭遇战 AI 行为去硬编码"
 
-#: ../../Fixed-or-Improved-Logics.md:1495
+#: ../../Fixed-or-Improved-Logics.md:467
 msgid ""
 "In vanilla, there is a hardcoded behavior that when an skirmish AI player"
 " has no factory and has not taken damage for a while, it will sell its "
 "buildings and set its units to hunt. This can be customized now."
 msgstr "在原版中存在一个遭遇战 AI 玩家没有 Factory 类建筑且一段时间未受到伤害将会发起卖家冲锋（让所有单位进入 Hunt）的硬编码的行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1496
+#: ../../Fixed-or-Improved-Logics.md:468
 msgid ""
 "`[General] -> AIFireSale` and `[General] -> AIAllToHunt` control whether "
 "the AI will act selling and hunting respectively."
@@ -5575,7 +2350,7 @@ msgstr ""
 "`[General] -> AIFireSale` 和 `[General] -> AIAllToHunt` 分别控制 AI "
 "是否会执行卖家和狩猎（冲锋）行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1497
+#: ../../Fixed-or-Improved-Logics.md:469
 msgid ""
 "`[General] -> AIFireSaleDelay` defines a timer, it will only work if "
 "`[General] -> AIFireSale` is set to `true`. When the first time the AI "
@@ -5585,23 +2360,23 @@ msgstr ""
 "`[General] -> AIFireSaleDelay` 定义了一个计时器，它只有当 `[General] -> AIFireSale` 设为"
 " true 时才会生效。当 AI 首次达到原有行为的触发条件时计时器开始计时，并在计时器到期之前阻止出售建筑的行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1498
+#: ../../Fixed-or-Improved-Logics.md:470
 msgid ""
 "You can use these flags to make the AIs \"all in\" before they are "
 "defeated."
 msgstr "你可以用这些标签让 AI 被击败前 “全力以赴”"
 
-#: ../../Fixed-or-Improved-Logics.md:1499
+#: ../../Fixed-or-Improved-Logics.md:471
 msgid ""
 "Another hardcoded behavior is that, when the AI deploys a MCV, it will "
 "gather all of its forces to that place. This can be toggle off now."
 msgstr "另一个硬编码行为是，当 AI 部署 MCV 时，它会将所有部队集结到该地点。现在可以关闭这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1500
+#: ../../Fixed-or-Improved-Logics.md:472
 msgid "`[General] -> GatherWhenMCVDeploy` controls this behavior."
 msgstr "`[General] -> GatherWhenMCVDeploy` 控制这一行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:1503
+#: ../../Fixed-or-Improved-Logics.md:475
 msgid ""
 "[General]\n"
 "AIFireSale=true           ; boolean\n"
@@ -5615,1267 +2390,71 @@ msgstr ""
 "AIAllToHunt=true          ; boolean\n"
 "GatherWhenMCVDeploy=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1511
-msgid "Subterranean unit travel height and speed"
-msgstr "潜地单位移动高度和速度"
+#: ../../Fixed-or-Improved-Logics.md:483
+msgid "Use 8-bit RGB parameters for `[ColorAdd]`"
+msgstr "为 `[ColorAdd]` 使用 8 位 RGB 参数"
 
-#: ../../Fixed-or-Improved-Logics.md:1513
+#: ../../Fixed-or-Improved-Logics.md:485
 msgid ""
-"It is now possible to control the height at which units with subterranean"
-" (Tunnel) `Locomotor` travel, globally or per TechnoType."
-msgstr "现在可以控制拥有潜地（Tunnel）`Locomotor` 的单位移动的高度，可以在全局和每个科技类型上定义。"
-
-#: ../../Fixed-or-Improved-Logics.md:1514
-msgid ""
-"Subterranean movement speed is now also customizable, both globally and "
-"per TechnoType. If per-TechnoType value is negative, global value is "
-"used. This does not affect the speed at which the unit moves vertically "
-"when burrowing which is determined by `Speed` multiplied by `[General] ->"
-" TunnelSpeed`."
+"In vanilla, the values in the `[ColorAdd]` entry are used as RGB565 (0-31"
+" for red & blue, 0-63 for green). Now, with this setting, you can use the"
+" more user-friendly 8-bit RGB (0-255) for input."
 msgstr ""
-"潜地移动速度现在也可以自定义，同样拥有全局和微观标签。如果微观标签的值为负数则使用全局值。这不会影响单位在潜地时的垂直移动速度。该速度由 "
-"`Speed` * `[General] -> TunnelSpeed` 决定。"
+"在原版中，`[ColorAdd]` 条目中的值会被按照 RGB565（红色和蓝色为 0-31，绿色为 0-63）来使用，现在，你可以通过这一设置使其使用对人类用户更加友好的 8 位 RGB（0-255）来填写。"
 
-#: ../../Fixed-or-Improved-Logics.md:1517
+#: ../../Fixed-or-Improved-Logics.md:486
 msgid ""
-"[General]\n"
-"SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)"
-"\n"
-"SubterraneanSpeed=19     ; floating point value\n"
-"\n"
-"[SOMETECHNO]             ; TechnoType\n"
-"SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)"
-"\n"
-"SubterraneanSpeed=-1     ; floating point value\n"
+"This works for `LaserTargetColor`, `IronCurtainColor`, `BerserkColor` and"
+" `ForceShieldColor`."
 msgstr ""
-"[General]\n"
-"SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)"
-"\n"
-"SubterraneanSpeed=19     ; floating point value\n"
-"\n"
-"[SOMETECHNO]             ; TechnoType\n"
-"SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)"
-"\n"
-"SubterraneanSpeed=-1     ; floating point value\n"
+"这适用于 `LaserTargetColor`、`IronCurtainColor`、`BerserkColor` 和 `ForceShieldColor`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1528
-msgid ""
-"`SubterraneanHeight` expects negative values to be used and may behave "
-"erratically if set to above -50."
-msgstr "`SubterraneanHeight` 最好使用一个负值并且如果设置为大于 -50 的值可能会出现异常行为。"
-
-#: ../../Fixed-or-Improved-Logics.md:1531
-msgid "Target scanning delay optimization"
-msgstr "索敌间隔优化"
-
-#: ../../Fixed-or-Improved-Logics.md:1533
-msgid ""
-"In vanilla, the game used `NormalTargetingDelay` and "
-"`GuardAreaTargetingDelay` to globally control the target searching "
-"intervals. Increasing these values would make units stupid, while "
-"decreasing them would cause game lag."
-msgstr ""
-"原版中游戏使用 `NormalTargetingDelay` 和 `GuardAreaTargetingDelay` "
-"来全局控制单位的索敌间隔。增大这些值会导致单位反应迟钝，减小这些值则可能导致游戏卡顿。"
-
-#: ../../Fixed-or-Improved-Logics.md:1534
-msgid ""
-"Now, you can define them per techno, also allowing different values for "
-"AI and players. The default values are the same as those originally "
-"defined by the vanilla flags."
-msgstr "现在可以在每种单位上微观定义这些参数，且可为 AI 玩家和人类玩家分离设置。默认值取自原版全局。"
-
-#: ../../Fixed-or-Improved-Logics.md:1535
-msgid ""
-"You can also specific this delay for attack move mission. The default "
-"value is `NormalTargetingDelay`."
-msgstr "你还可以为移动攻击指令单独设定间隔。默认使用 `NormalTargetingDelay` 的值。"
-
-#: ../../Fixed-or-Improved-Logics.md:1538
-msgid ""
-"[General]\n"
-"AINormalTargetingDelay=              ; integer, game frames\n"
-"PlayerNormalTargetingDelay=          ; integer, game frames\n"
-"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
-"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
-"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
-"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
-"\n"
-"[SOMETECHNO]                         ; TechnoType\n"
-"AINormalTargetingDelay=              ; integer, game frames\n"
-"PlayerNormalTargetingDelay=          ; integer, game frames\n"
-"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
-"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
-"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
-"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
-msgstr ""
-"[General]\n"
-"AINormalTargetingDelay=              ; integer, game frames\n"
-"PlayerNormalTargetingDelay=          ; integer, game frames\n"
-"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
-"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
-"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
-"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
-"\n"
-"[SOMETECHNO]                         ; TechnoType\n"
-"AINormalTargetingDelay=              ; integer, game frames\n"
-"PlayerNormalTargetingDelay=          ; integer, game frames\n"
-"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
-"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
-"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
-"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1556
-msgid "Voxel body multi-section shadows"
-msgstr "Voxel 主体多组件阴影"
-
-#: ../../Fixed-or-Improved-Logics.md:1558
-msgid ""
-"![image](_static/images/uh0-be.gif) *UH-0 helicopter with dynamic "
-"propeller and its shadow in [Bellum "
-"Æternum](https://ra2be.com/download.html)*"
-msgstr ""
-"![image](_static/images/uh0-be.gif) "
-"*[万世之战](https://ra2be.com/zh/download.html) 中拥有可动螺旋桨及其影子的 UH-0 直升机*"
-
-#: ../../Fixed-or-Improved-Logics.md:1561
-msgid ""
-"It is also now possible for vehicles and aircraft to display shadows for "
-"multiple sections of the voxel body at once, instead of just one section "
-"specified by `ShadowIndex`, by specifying the section indices in "
-"`ShadowIndices` (which defaults to `ShadowIndex`) in unit's `artmd.ini` "
-"entry."
-msgstr ""
-"现在载具和战机可以通过在单位的 `artmd.ini` 条目中使用 `ShadowIndices`（默认为 "
-"`ShadowIndex`）指定多个组件索引来一性次显示出 Voxel 主体中多个组件的影子，而不再仅限于绘制 `ShadowIndex` "
-"所指定的单个组件。"
-
-#: ../../Fixed-or-Improved-Logics.md:1562
-msgid ""
-"`ShadowIndex.Frame` and `ShadowIndices.Frame` can be used to customize "
-"which frame of the HVA animation for the section from `ShadowIndex` and "
-"`ShadowIndices` is used to display the shadow, respectively. -1 is "
-"special value which means currently shown frame is used, and "
-"`ShadowIndices.Frame` defaults to this."
-msgstr ""
-"`ShadowIndex.Frame` 和 `ShadowIndices.Frame` 可以分别用于自定义从 `ShadowIndex` 和 "
-"`ShadowIndices` 所指定组件的 HVA 动画中显示影子时所使用的帧。-1 是一个用于表示使用当前帧的特殊值，并且 "
-"`ShadowIndices.Frame` 默认如此。"
-
-#: ../../Fixed-or-Improved-Logics.md:1565
-msgid ""
-"[SOMETECHNO]          ; TechnoType\n"
-"ShadowIndices=        ; List of integers (voxel section indices)\n"
-"ShadowIndex.Frame=0   ; integer (HVA animation frame index)\n"
-"ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)\n"
-msgstr ""
-"[SOMETECHNO]          ; TechnoType\n"
-"ShadowIndices=        ; List of integers (voxel section indices)\n"
-"ShadowIndex.Frame=0   ; integer (HVA animation frame index)\n"
-"ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1572
-msgid "Voxel light source customization"
-msgstr "自定义 Voxel 光源"
-
-#: ../../Fixed-or-Improved-Logics.md:1574
-msgid ""
-"![image](_static/images/VoxelLightSourceComparison1.png) "
-"![image](_static/images/VoxelLightSourceComparison2.png) *Voxel by <a "
-"class=\"reference external\" "
-"href=\"https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index\" "
-"target=\"_blank\">C&CrispS</a>, (Save and unzip the second image to "
-"obtain an example file including pal & vpl.)*"
-msgstr ""
-"![image](_static/images/VoxelLightSourceComparison1.png) "
-"![image](_static/images/VoxelLightSourceComparison2.png) *Voxel by <a "
-"class=\"reference external\" "
-"href=\"https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index\" "
-"target=\"_blank\">C&CrispS</a>（另存为并解压第二张图片即可获得包括 pal & vpl 的示例文件）*"
-
-#: ../../Fixed-or-Improved-Logics.md:1578
-msgid ""
-"It is now possible to change the position of the light relative to the "
-"voxels. This allows for better lighting to be set up."
-msgstr "现在可以改变光源相对于 Voxel 素材的位置。这有助于更好的设置光照。"
-
-#: ../../Fixed-or-Improved-Logics.md:1579
-msgid ""
-"Only the direction of the light is accounted, the distance to the voxel "
-"is not accounted."
-msgstr "仅考虑光源的方向，不考虑与 Voxel 的距离（视为平行光）"
-
-#: ../../Fixed-or-Improved-Logics.md:1580
-msgid ""
-"Vanilla game applies some weird unnecessary math which resulted in the "
-"voxel light source being \"nudged\" up by a bit and light being applied "
-"incorrectly on tilted voxels. It is now possible to fix that."
-msgstr ""
-"原本的游戏中使用了一些奇怪且不必要的数学计算导致 Voxel 的光源被 “微调” 向上了一些并在倾斜的 Voxel "
-"上光照效果不正确。现在可以修复这个问题。"
-
-#: ../../Fixed-or-Improved-Logics.md:1581
-msgid ""
-"Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly"
-" at `VoxelLightSource=0.201,-0.907,-0.362`."
-msgstr ""
-"原版光照（假设 `UseFixedVoxelLighting=false`）大致位于 "
-"`VoxelLightSource=0.201,-0.907,-0.362`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1584
-msgid ""
-"Please note that enabling this will remove the vertical offset vanilla "
-"engine applies to the light source position. Assuming vanilla lighting "
-"this will make the light shine even more from below the ground than it "
-"was before, so it is recommended to turn the Z value up in value of "
-"`VoxelLightSource`."
-msgstr ""
-"请注意启用此功能将移除原版引擎对光源位置应用的垂直偏移。假设使用原版光照这将会使光线从地下照射来更多，因此建议将 "
-"`VoxelLightSource` 的 Z 值调高。"
-
-#: ../../Fixed-or-Improved-Logics.md:1588
+#: ../../Fixed-or-Improved-Logics.md:489
 msgid ""
 "[AudioVisual]\n"
-"UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting\n"
-"VoxelLightSource=            ; X,Y,Z - position of the light in the world"
-" relative to each voxel, floating point values\n"
+"ColorAddUse8BitRGB=false  ; boolean\n"
 msgstr ""
 "[AudioVisual]\n"
-"UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting\n"
-"VoxelLightSource=            ; X,Y,Z - position of the light in the world"
-" relative to each voxel, floating point values\n"
+"ColorAddUse8BitRGB=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:1595
-msgid ""
-"In order to easily preview the light source settings use the [VXL Viewer "
-"and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon"
-"/vxl-renderer/releases). To use the tool unpack it somewhere, then drag "
-"the main VXL file of a voxel that you will use to preview onto it "
-"(auxilliary VXL and HVA files must be in the same folder)."
-msgstr ""
-"为了方便预览光源设置可以使用 [thomassneddon 的 VXL 猹看器 与 VPL "
-"生成工具](https://github.com/ThomasSneddon/vxl-"
-"renderer/releases)。使用该工具时**先将其解压**然后将需要预览的 Voxel 文件**拖拽**到工具上（辅助 VXL 和 "
-"HVA 文件必须在同一文件夹中）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1597
-msgid ""
-"Keep in mind that the tool doesn't account for "
-"`UseFixedVoxelLighting=true` as of yet, so the values shown in tool need "
-"to be offset when putting in the game with with fixed voxel lighting."
-msgstr "请注意该工具目前尚未考虑 `UseFixedVoxelLighting=true` 的情况，因此工具中显示的值在启用该修复项的游戏中需要进行调整。"
-
-#: ../../Fixed-or-Improved-Logics.md:1600
-msgid "Voxel shadow scaling in air"
-msgstr "Voxel 在空中时的影子缩放"
-
-#: ../../Fixed-or-Improved-Logics.md:1602
-msgid ""
-"It is now possible to adjust how voxel air units (`VehicleType` & "
-"`AircraftType`) shadows scale in air. By default the shadows scale by "
-"`AirShadowBaseScale` (defaults to 0.5) amount if unit is "
-"`ConsideredAircraft=true`."
-msgstr ""
-"现在可以调整 Voxel 空中单位（载具和战机）的影子如何缩放。默认情况下如果单位拥有 `ConsideredAircraft=true` "
-"那么影子会按 `AirShadowBaseScale` （默认为 0.5）进行缩放"
-
-#: ../../Fixed-or-Improved-Logics.md:1603
-msgid ""
-"If `HeightShadowScaling=true`, the shadow is scaled by amount that is "
-"determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight"
-" / ShadowSizeCharacteristicHeight), HeightShadowScaling.MinScale)`, where"
-" `currentHeight` is unit's current height in leptons, "
-"`ShadowSizeCharacteristicHeight` overrideable value that defaults to the "
-"maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and "
-"`HeightShadowScaling.MinScale` sets a floor for the scale."
-msgstr ""
-"如果 `HeightShadowScaling=true`，影子会根据以下公式缩放： `Max(AirShadowBaseScale ^ "
-"(currentHeight / ShadowSizeCharacteristicHeight), "
-"HeightShadowScaling.MinScale)`，这里的 `currentHeight` 是单位当前高度（单位 "
-"lepton），`ShadowSizeCharacteristicHeight` "
-"是一个可覆盖的值，默认为最大巡航高度（`JumpjetHeight`、`FlightLevel` 等），而 "
-"`HeightShadowScaling.MinScale` 设置了缩放的下限。"
-
-#: ../../Fixed-or-Improved-Logics.md:1606
-msgid ""
-"[AudioVisual]\n"
-"AirShadowBaseScale=0.5            ; floating point value\n"
-"HeightShadowScaling=false         ; boolean\n"
-"HeightShadowScaling.MinScale=0.0  ; floating point value\n"
-"\n"
-"[SOMETECHNO]                      ; TechnoType\n"
-"ShadowSizeCharacteristicHeight=   ; integer, height in leptons\n"
-msgstr ""
-"[AudioVisual]\n"
-"AirShadowBaseScale=0.5            ; floating point value\n"
-"HeightShadowScaling=false         ; boolean\n"
-"HeightShadowScaling.MinScale=0.0  ; floating point value\n"
-"\n"
-"[SOMETECHNO]                      ; TechnoType\n"
-"ShadowSizeCharacteristicHeight=   ; integer, height in leptons\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1616
-msgid "Terrains"
-msgstr "地形对象"
-
-#: ../../Fixed-or-Improved-Logics.md:1618
-msgid "Animated TerrainTypes"
-msgstr "动画化地形对象"
-
-#: ../../Fixed-or-Improved-Logics.md:1620
-msgid ""
-"![Waving trees](_static/images/tree-shake.gif) *Animated trees used in "
-"[Ion Shock](https://www.moddb.com/mods/tiberian-war-ionshock)*"
-msgstr ""
-"![Waving trees](_static/images/tree-shake.gif) *[Ion "
-"Shock](https://www.moddb.com/mods/tiberian-war-ionshock) 中会动的树*"
-
-#: ../../Fixed-or-Improved-Logics.md:1620
-msgid "Waving trees"
-msgstr "会动的树"
-
-#: ../../Fixed-or-Improved-Logics.md:1623
-msgid ""
-"By default `IsAnimated`, `AnimationRate` and `AnimationProbability` only "
-"work on TerrainTypes with `SpawnsTiberium` set to true. This restriction "
-"has now been lifted."
-msgstr ""
-"默认情况下 `IsAnimated`、`AnimationRate` 和 `AnimationProbability` 仅适用于 "
-"`SpawnsTiberium` 设置为 true 的地形对象。这一限制已被解除。"
-
-#: ../../Fixed-or-Improved-Logics.md:1624
-msgid ""
-"Length of the animation can now be customized by setting "
-"`AnimationLength` as well, defaulting to half (or quarter if [damaged "
-"frames](#damaged-frames-and-crumbling-animation) are enabled) the number "
-"of frames in TerrainType's image."
-msgstr ""
-"现在动画的长度可以通过设置 `AnimationLength` 来自定义，默认为地形对象图像帧数的一半（如果启用了[破损帧](#damaged-"
-"frames-and-crumbling-animation)则为四分之一）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1627
-msgid ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"AnimationLength=   ; integer, number of frames\n"
-msgstr ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"AnimationLength=   ; integer, number of frames\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1632
-msgid "Custom palette"
-msgstr "自定义色盘"
-
-#: ../../Fixed-or-Improved-Logics.md:1634
-msgid ""
-"You can now specify custom palette for TerrainTypes in similar manner as "
-"TechnoTypes can."
-msgstr "现在你可以像为科技类型那样为地形对象指定自定义色盘。"
-
-#: ../../Fixed-or-Improved-Logics.md:1637
-msgid ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"Palette=           ; filename - excluding .pal extension and three-"
-"character theater-specific suffix\n"
-msgstr ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"Palette=           ; filename - excluding .pal extension and three-"
-"character theater-specific suffix\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1643
-msgid ""
-"This palette behaves like an object palette and does not use tint etc. "
-"that have been applied to the tile the TerrainType resides on like a "
-"TerrainType using tile palette would."
-msgstr "此色盘的行为就像原有的对象色盘那样不受光效影响。也就是地形对象将不会同步使用应用于地形对象所在地块上的色调。"
-
-#: ../../Fixed-or-Improved-Logics.md:1646
-msgid "Customizable ore spawners"
-msgstr "自定义矿柱"
-
-#: ../../Fixed-or-Improved-Logics.md:1648
-msgid ""
-"![image](_static/images/ore-01.png) *Different ore spawners in [Rise of "
-"the East](https://www.moddb.com/mods/riseoftheeast)*"
-msgstr ""
-"![image](_static/images/ore-01.png) "
-"*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中不同的矿柱*"
-
-#: ../../Fixed-or-Improved-Logics.md:1651
-msgid "You can now specify which type of ore certain TerrainType would generate."
-msgstr "现在你可以指定地形对象将会生成哪种矿石。"
-
-#: ../../Fixed-or-Improved-Logics.md:1652
-msgid ""
-"It's also now possible to specify a range value for an ore generation "
-"area different compared to standard 3x3 rectangle. Ore will be uniformly "
-"distributed across all affected cells in a spread range."
-msgstr "现在还可以指定与标准 3x3 矩形不同的矿石生成区域范围值。矿石将均匀地分布在扩散范围内所有受影响的单元格中。"
-
-#: ../../Fixed-or-Improved-Logics.md:1653
-msgid ""
-"You can specify which ore growth stage will be spawned and how many cells"
-" will be filled with ore per ore generation animation. Corresponding tags"
-" accept either a single integer value or two comma-separated values to "
-"allow randomized growth stages from the range (inclusive)."
-msgstr "此外也可以指定将生成哪个矿石生长阶段以及每次播放矿石生成动画将会填充多少个单元格。相对应的标签接受单个整数值或两个逗号分隔的值以允许范围内（含）随机化的生长阶段。"
-
-#: ../../Fixed-or-Improved-Logics.md:1656
-msgid ""
-"[SOMETERRAINTYPE]             ; TerrainType\n"
-"SpawnsTiberium.Type=0         ; tiberium/ore type index\n"
-"SpawnsTiberium.Range=1        ; integer, radius in cells\n"
-"SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range\n"
-"SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range\n"
-msgstr ""
-"[SOMETERRAINTYPE]             ; TerrainType\n"
-"SpawnsTiberium.Type=0         ; tiberium/ore type index\n"
-"SpawnsTiberium.Range=1        ; integer, radius in cells\n"
-"SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range\n"
-"SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1664
-msgid "Damaged frames and crumbling animation"
-msgstr "伤残和倒坍动画"
-
-#: ../../Fixed-or-Improved-Logics.md:1666
-msgid ""
-"By default game shows damage frame only for TerrainTypes alive at only 1 "
-"point of health left. Because none of the original game TerrainType "
-"assets were made with this in mind, the logic is now locked behind a new "
-"key `HasDamagedFrames`."
-msgstr ""
-"默认情况下游戏在地形对象仅 1 点血时显示破损帧。由于原本游戏中的地形对象资源文件并未考虑这一点因此目前该逻辑仅限添加了 "
-"`HasDamagedFrames` 的情况下使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:1667
-msgid ""
-"Instead of showing at 1 point of HP left, TerrainTypes switch to damaged "
-"frames once their health reaches `[AudioVisual] -> "
-"ConditionYellow.Terrain` percentage of their maximum health."
-msgstr ""
-"地形对象不再在仅剩 1 点血时显示破损帧，而是在其血量达到 `[AudioVisual] -> ConditionYellow.Terrain` "
-"的百分比时才进行切换。"
-
-#: ../../Fixed-or-Improved-Logics.md:1668
-msgid ""
-"In addition, TerrainTypes can now show 'crumbling' animation after their "
-"health has reached zero and before they are deleted from the map by "
-"setting `HasCrumblingFrames` to true."
-msgstr ""
-"此外，地形对象现在可以在其血量归 0 后到从地图中删除前的这段时间中通过设置 `HasCrumblingFrames` 为 true 来显示一个 "
-"“倒坍” 动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:1669
-msgid ""
-"Crumbling frames start from first frame after both regular & damaged "
-"frames and ends at halfway point of the frames in TerrainType's image."
-msgstr "倒坍所用的帧从紧随于常规帧和破损帧之后的第一帧开始直到地形对象图像帧的一半处中止（另一半是影子）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1670
-msgid ""
-"Sound event from `CrumblingSound` (if set) is played when crumbling "
-"animation starts playing."
-msgstr "当倒坍动画开始播放时将会播放 `CrumblingSound`（如果设置）指定的音效。"
-
-#: ../../Fixed-or-Improved-Logics.md:1671
-msgid ""
-"[Destroy animation & sound](New-or-Enhanced-Logics.md#destroy-animation--"
-"sound) only play after crumbling animation has finished."
-msgstr "[摧毁动画和音效](New-or-Enhanced-Logics.md#destroy-animation--sound) 仅在倒坍动画结束后播放。"
-
-#: ../../Fixed-or-Improved-Logics.md:1674
-msgid ""
-"[AudioVisual]\n"
-"ConditionYellow.Terrain=  ; floating-point value, default to "
-"[AudioVisual] -> ConditionYellow\n"
-"\n"
-"[SOMETERRAINTYPE]         ; TerrainType\n"
-"HasDamagedFrames=false    ; boolean\n"
-"HasCrumblingFrames=false  ; boolean\n"
-"CrumblingSound=           ; Sound entry\n"
-msgstr ""
-"[AudioVisual]\n"
-"ConditionYellow.Terrain=  ; floating-point value, default to "
-"[AudioVisual] -> ConditionYellow\n"
-"\n"
-"[SOMETERRAINTYPE]         ; TerrainType\n"
-"HasDamagedFrames=false    ; boolean\n"
-"HasCrumblingFrames=false  ; boolean\n"
-"CrumblingSound=           ; Sound entry\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1685
-msgid ""
-"The number of regular & damage frames considered for this depends on "
-"value of `HasDamagedFrames` and for `IsAnimated` TerrainTypes, "
-"`AnimationLength` (see [Animated TerrainTypes](#animated-terraintypes)). "
-"Exercise caution and ensure there are correct amount of frames to "
-"display."
-msgstr ""
-"此处考虑的常规帧和破损帧数量取决于 `HasDamagedFrames` 的值，对于 `IsAnimated` 的地形对象则取决于 "
-"`AnimationLength` 的值（见 [动画化地形对象](#animated-"
-"terraintypes)）。请谨慎操作以确保显示的帧数正确。"
-
-#: ../../Fixed-or-Improved-Logics.md:1688
-#: ../../Fixed-or-Improved-Logics.md:1713
-msgid "Minimap color customization"
-msgstr "自定义小地图颜色"
-
-#: ../../Fixed-or-Improved-Logics.md:1690
-msgid ""
-"TerrainTypes can now be made to display on minimap with different colors "
-"by setting `MinimapColor`."
-msgstr "现在地形对象可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
-
-#: ../../Fixed-or-Improved-Logics.md:1693
-msgid ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"MinimapColor=      ; integer - Red,Green,Blue\n"
-msgstr ""
-"[SOMETERRAINTYPE]  ; TerrainType\n"
-"MinimapColor=      ; integer - Red,Green,Blue\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1698
-msgid "Passable & buildable-upon TerrainTypes"
-msgstr "可通行和可建造于其上的地形对象"
-
-#: ../../Fixed-or-Improved-Logics.md:1700
-msgid ""
-"TerrainTypes can now be made passable or buildable upon by setting "
-"`IsPassable` or `CanBeBuiltOn`, respectively."
-msgstr "现在可以分别通过设置 `IsPassable` 或 `CanBeBuiltOn` 来让地形对象可通行或可以将建筑建造于其上。"
-
-#: ../../Fixed-or-Improved-Logics.md:1701
-msgid ""
-"Movement cursor is displayed on `IsPassable` TerrainTypes unless force-"
-"firing."
-msgstr "除非使用强制开火否则 `IsPassable` 的地形对象上会显示移动光标。"
-
-#: ../../Fixed-or-Improved-Logics.md:1702
-msgid ""
-"`CanBeBuiltOn=true` terrain objects are removed when building is placed "
-"on them."
-msgstr "`CanBeBuiltOn=true` 的地形对象在建筑建造于其上时会被移除。"
-
-#: ../../Fixed-or-Improved-Logics.md:1705
-msgid ""
-"[SOMETERRAINTYPE]   ; TerrainType\n"
-"IsPassable=false    ; boolean\n"
-"CanBeBuiltOn=false  ; boolean\n"
-msgstr ""
-"[SOMETERRAINTYPE]   ; TerrainType\n"
-"IsPassable=false    ; boolean\n"
-"CanBeBuiltOn=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1711
-msgid "Tiberiums (ores)"
-msgstr "泰伯利亚（矿石）"
-
-#: ../../Fixed-or-Improved-Logics.md:1715
-msgid ""
-"Ore can now be made to display on minimap with different colors by "
-"setting `MinimapColor` on Tiberiums."
-msgstr "矿石现在可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
-
-#: ../../Fixed-or-Improved-Logics.md:1718
-msgid ""
-"[SOMEORE]      ; Tiberium\n"
-"MinimapColor=  ; integer - Red,Green,Blue\n"
-msgstr ""
-"[SOMEORE]      ; Tiberium\n"
-"MinimapColor=  ; integer - Red,Green,Blue\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1723
-msgid "Vehicles"
-msgstr "载具类型"
-
-#: ../../Fixed-or-Improved-Logics.md:1725
-msgid "Allow miners do area guard"
-msgstr "允许矿车区域警戒"
-
-#: ../../Fixed-or-Improved-Logics.md:1727
-msgid ""
-"In vanilla, when miners enter area guard mission, they immediately switch"
-" to harvest mission. Now you can make them perform area guard mission "
-"normally like other technos."
-msgstr ""
-"在原版中当一个矿车进入 `Area Guard` 任务时会立即切换为 `Havrest` 任务。现在你可以让它们像其他单位那样正常执行 `Area"
-" Guard` 任务了。"
-
-#: ../../Fixed-or-Improved-Logics.md:1728
-msgid ""
-"We made it work only for miners controlled by the player, because this "
-"will prevent AI's miners from going work."
-msgstr "这仅对玩家控制的矿车有效，因为这会阻断 AI 矿车正常工作。"
-
-#: ../../Fixed-or-Improved-Logics.md:1731
-msgid ""
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"Harvester.CanGuardArea=no          ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"Harvester.CanGuardArea=no          ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1736
-msgid "Bunker entering check dehardcode"
-msgstr "去除坦克碉堡准入检查的硬编码"
-
-#: ../../Fixed-or-Improved-Logics.md:1738
-msgid ""
-"In vanilla, vehicles entering tank bunkers are subject to a series of "
-"hardcoding restrictions, including having to have turrets, having to have"
-" weapons, and not having Hover speed types. Now you can skip these "
-"restrictions."
-msgstr ""
-"在原版，载具进入坦克碉堡时受到一系列硬编码限制，包括必须拥有炮塔、必须拥有武器以及速度类型不能为 "
-"`SpeedType=Hover`。现在你可以跳过这些限制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1739
-msgid "This needs to be used with `Bunkerable=yes`."
-msgstr "这需要与 `Bunkerable=yes` 共同使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:1740
-msgid ""
-"This flag only skips the static check, that is, the check on the unit "
-"type. The dynamic check (cannot be parasitized) remains unchanged."
-msgstr "这个标签仅跳过静态检查，即对单位类型的检查。动态检查（不能处于被寄生状态）保持不变。"
-
-#: ../../Fixed-or-Improved-Logics.md:1743
-msgid ""
-"[SOMEVEHICLE]              ; VehicleType\n"
-"BunkerableAnyway=false     ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]              ; VehicleType\n"
-"BunkerableAnyway=false     ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1749
-msgid ""
-"Skipping checks with this feature doesn't mean that vehicles and tank "
-"bunkers will interact correctly. Following the simple checks performed by"
-" the provider of this feature, bunkerability is mainly determined by "
-"Locomotor. The details about locomotors' bunkerability can be found on "
-"[ModEnc](https://modenc.renegadeprojects.com/Bunkerable)."
-msgstr ""
-"使用此功能跳过检查并不就意味着载具和坦克碉堡可以正确的交互。根据次功能提供者的简单检查，坦克碉堡的效果主要受到运动模式影响。不同运动模式进入坦克碉堡的详细信息可以在"
-" [MODENC](https://modenc.renegadeprojects.com/Bunkerable) 上找到。"
-
-#: ../../Fixed-or-Improved-Logics.md:1752
-msgid "Customize harvester dump amount"
-msgstr "自定义矿车单次倒矿量"
-
-#: ../../Fixed-or-Improved-Logics.md:1754
-msgid ""
-"Now you can limit how much ore the harvester can dump out per time, like "
-"it in Tiberium Sun."
-msgstr "现在你可以限制矿车每次倒矿时卸载的矿石量，就像《泰伯利亚之日》中的设定"
-
-#: ../../Fixed-or-Improved-Logics.md:1755
-msgid ""
-"Less than or equal to 0 means no limit, it will always dump out all at "
-"one time."
-msgstr "若该值小于等于 0 则表示一次倒完，就像《红色警戒2》中原本的行为"
-
-#: ../../Fixed-or-Improved-Logics.md:1758
-msgid ""
-"[General]\n"
-"HarvesterDumpAmount=0.0               ; float point value\n"
-"\n"
-"[SOMEVEHICLE]                         ; VehicleType\n"
-"HarvesterDumpAmount=                  ; float point value\n"
-msgstr ""
-"[General]\n"
-"HarvesterDumpAmount=0.0               ; float point value\n"
-"\n"
-"[SOMEVEHICLE]                         ; VehicleType\n"
-"HarvesterDumpAmount=                  ; float point value\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1766
-msgid "Customizing crushing tilt and slowdown"
-msgstr "自定义碾压倾斜和减速"
-
-#: ../../Fixed-or-Improved-Logics.md:1768
-msgid ""
-"Vehicles with `Crusher=true` and `OmniCrusher=true` / "
-"`MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles /"
-" walls respectively. This now obeys `TiltsWhenCrushes` but can be "
-"customized individually for these two scenarios using "
-"`TiltsWhenCrusher.Vehicles` and `TiltsWhenCrusher.Overlays`, which both "
-"default to `TiltsWhenCrushes`."
-msgstr ""
-"拥有 `Crusher=true` 和 `OmniCrusher=true` / `MovementZone=CrusherAll` "
-"的载具在碾压载具／围墙时原版被硬编码进行倾斜。现在这遵守 `TiltsWhenCrushes`，并且可以对 "
-"`TiltsWhenCrusher.Vehicles` 和 `TiltsWhenCrusher.Overlays` "
-"对两种情况分别进行定义，它们都默认为 `TiltsWhenCrushes`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1769
-msgid ""
-"`CrushForwardTiltPerFrame` determines how much the forward tilt is "
-"adjusted per frame when crushing overlays or vehicles. Defaults to -0.02 "
-"for vehicles using Ship locomotor crushing overlays, -0.050000001 for all"
-" other cases."
-msgstr ""
-"`CrushForwardTiltPerFrame` 决定在碾压覆盖物或载具时每帧前倾的幅度。对于 `Locomotor=Ship` "
-"的载具碾压覆盖物的时默认为 -0.02，其他情况默认为 -0.050000001。"
-
-#: ../../Fixed-or-Improved-Logics.md:1770
-msgid ""
-"`CrushOverlayExtraForwardTilt` is additional forward tilt applied after "
-"an overlay has been crushed by the vehicle."
-msgstr "`CrushOverlayExtraForwardTilt` 是载具碾压覆盖物后额外的向前倾斜量"
-
-#: ../../Fixed-or-Improved-Logics.md:1771
-msgid ""
-"It is possible to customize the movement speed slowdown when "
-"`MovementZone=CrusherAll` vehicle crushes walls by setting "
-"`CrushSlowdownMultiplier`."
-msgstr ""
-"可以通过设置 `CrushSlowdownMultiplier` 来自定义 `MovementZone=CrusherAll` "
-"的载具碾压围墙时移动速度的减速幅度。"
-
-#: ../../Fixed-or-Improved-Logics.md:1772
-msgid ""
-"You can also disable the slowdown completely by using the flag "
-"`SkipCrushSlowdown`. This is not the same as "
-"`CrushSlowdownMultiplier=1.0`. Used to avoid a bug where the vehicle "
-"sometimes loses speed when `Accelerates=true` and `MovementZone=CrushAll`"
-" are set."
-msgstr ""
-"你还可以使用 `SkipCrushSlowdown` 来完全禁用这一减速效果。这不同于 "
-"`CrushSlowdownMultiplier=1.0`。它可以避免 `Accelerates=true` 与 "
-"`MovementZone=CrushAll` 共用时单位有时会减速的 Bug。"
-
-#: ../../Fixed-or-Improved-Logics.md:1775
-msgid ""
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"TiltsWhenCrushes.Vehicles=         ; boolean\n"
-"TiltsWhenCrushes.Overlays=         ; boolean\n"
-"CrushForwardTiltPerFrame=          ; floating point value\n"
-"CrushOverlayExtraForwardTilt=0.02  ; floating point value\n"
-"CrushSlowdownMultiplier=0.2        ; floating point value\n"
-"SkipCrushSlowdown=false            ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"TiltsWhenCrushes.Vehicles=         ; boolean\n"
-"TiltsWhenCrushes.Overlays=         ; boolean\n"
-"CrushForwardTiltPerFrame=          ; floating point value\n"
-"CrushOverlayExtraForwardTilt=0.02  ; floating point value\n"
-"CrushSlowdownMultiplier=0.2        ; floating point value\n"
-"SkipCrushSlowdown=false            ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1785
-msgid "Destroy animations"
-msgstr "摧毁动画"
-
-#: ../../Fixed-or-Improved-Logics.md:1787
-msgid ""
-"`DestroyAnim` has been extended to work with VehicleTypes, with option to"
-" pick random animation if `DestroyAnim.Random` is set to true. These "
-"animations store owner and facing information for use with [CreateUnit "
-"logic](New-or-Enhanced-Logics.md#anim-to-unit)."
-msgstr ""
-"`DestroyAnim` 已扩展至载具类型，并且如果 `DestroyAnim.Random` 设为 true "
-"那么可以随机选取其中一个动画。这些动画存储了所属方和朝向信息以供[生成单位](New-or-Enhanced-Logics.md#anim-to-"
-"unit)逻辑使用。"
-
-#: ../../Fixed-or-Improved-Logics.md:1790
-msgid ""
-"[SOMEVEHICLE]                          ; VehicleType\n"
-"DestroyAnim=                           ; List of AnimationTypes\n"
-"DestroyAnim.Random=true                ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]                          ; VehicleType\n"
-"DestroyAnim=                           ; List of AnimationTypes\n"
-"DestroyAnim.Random=true                ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1796
-msgid "`IsSimpleDeployer` vehicle ammo change on deploy"
-msgstr "`IsSimpleDeployer` 载具在部署时更改弹药"
-
-#: ../../Fixed-or-Improved-Logics.md:1798
-msgid ""
-"`Ammo.AddOnDeploy` determines the number of ammo added or subtracted "
-"after the vehicle has deployed or undeployed."
-msgstr "`Ammo.AddOnDeploy` 决定载具部署或反部署后增加或减少的弹药量。"
-
-#: ../../Fixed-or-Improved-Logics.md:1799
-msgid ""
-"Ammo count cannot go below 0 or above the maximum ammo for vehicle's type"
-" (in case the deploy results in type conversion, type is the one after "
-"the conversion)."
-msgstr "弹药数不得低于 0 或高于该载具类型的最大弹药量（若部署操作导致单位转换则以转换后的量为准）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1802
-msgid ""
-"[SOMEVEHICLE]       ; VehicleType\n"
-"Ammo.AddOnDeploy=0  ; integer\n"
-msgstr ""
-"[SOMEVEHICLE]       ; VehicleType\n"
-"Ammo.AddOnDeploy=0  ; integer\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1807
-msgid "IsSimpleDeployer customizations"
-msgstr "自定义 IsSimpleDeployer"
-
-#: ../../Fixed-or-Improved-Logics.md:1809
-msgid ""
-"It is possible to enable checking if the deployed unit (if type "
-"conversion is in use, the conversion result will be used for these "
-"checks) is allowed to deploy on the cell which will also affect deploy "
-"cursor availability by setting `IsSimpleDeployer.ConsiderPathfinding` to "
-"true."
-msgstr ""
-"现在可以通过 `IsSimpleDeployer.ConsiderPathfinding=true` "
-"来开启对将部署的单位（若使用单位转换则检查作为转换目标的单位）是否允许在当前单元格上部署的检查，部署光标也会跟随变化。"
-
-#: ../../Fixed-or-Improved-Logics.md:1810
-msgid ""
-"You can explicitly disable deploying on cells of specified land types "
-"using `IsSimpleDeployer.DisallowedLandTypes`. Defaults to `water,beach` "
-"for units with Jumpjet or Hover locomotor with `DeployToLand=true`, "
-"`none` for others."
-msgstr ""
-"你可以使用 `IsSimpleDeployer.DisallowedLandTypes` 来指定单位不能在哪些土地类型上部署。对于 "
-"`Locomotor=Jumpjet` 或 `Locomotor=Hover` 且拥有 `DeployToLand=true` 的单位默认为 "
-"`water,beach`；对于其他单位则默认为 `none`。"
-
-#: ../../Fixed-or-Improved-Logics.md:1811
-msgid ""
-"In vanilla game only units with `DeployingAnim` were constrained to a "
-"specific deploy facing and it was not customizable per unit. `DeployDir` "
-"can be set to override this per unit (defaults to `[AudioVisual] -> "
-"DeployDir` for units with `DeployingAnim`, -1 otherwise), including using"
-" value of -1 to disable the facing restriction."
-msgstr ""
-"在原版游戏中仅拥有 `DeployingAnim` 的单位会被限制使用特定的部署朝向且无法为每个单位自定义。Ares 允许通过 "
-"`DeployDir`（对于拥有 `DeployingAnim` 的单位默认为 `[AudioVisual] -> DeployDir`，否则为 "
-"-1）来为每个单位单独设定，Phobos 允许使用特殊值 -1 来解除朝向限制。"
-
-#: ../../Fixed-or-Improved-Logics.md:1812
-msgid "Multiple new options for deploy animations:"
-msgstr "部署动画相关的多个新增选项："
-
-#: ../../Fixed-or-Improved-Logics.md:1813
-msgid ""
-"`DeployingAnims` can be used instead of `DeployingAnim` (if both are set,"
-" `DeployingAnims` takes precedence) to define a list of direction-"
-"specific deploy animations to play. Largest power of 2 the number of "
-"listed animations falls to is used as number of directions/animations. "
-"Less than 8 animations listed results in only first listed one being "
-"used."
-msgstr ""
-"可使用 `DeployingAnims` 代替 "
-"`DeployingAnim`（当都被设置时优先使用前者）来定义一组与方向对应的部署动画。根据所列动画的最大数量取 2 "
-"的幂值作为方向数／动画数。若少于 8 个则仅适用列出的第一个动画。"
-
-#: ../../Fixed-or-Improved-Logics.md:1814
-msgid ""
-"`DeployingAnim.KeepUnitVisible` determines if the unit is **not** hidden "
-"while the animation is playing."
-msgstr "`DeployingAnim.KeepUnitVisible` 决定单位是否在动画播放期间**不**被隐藏。"
-
-#: ../../Fixed-or-Improved-Logics.md:1815
-msgid ""
-"`DeployingAnim.ReverseForUndeploy` controls whether or not the animation "
-"is played in reverse for undeploying."
-msgstr "`DeployingAnim.ReverseForUndeploy` 控制反部署时是否使动画反向播放。"
-
-#: ../../Fixed-or-Improved-Logics.md:1816
-msgid ""
-"`DeployingAnim.UseUnitDrawer` controls whether or not the animation is "
-"displayed in the unit's palette and team colours or regular animation "
-"palette, including a potential custom palette."
-msgstr "`DeployingAnim.UseUnitDrawer` 控制动画使用 unit 色盘以及所属色还是常规动画色盘，包括潜在的自定义色盘。"
-
-#: ../../Fixed-or-Improved-Logics.md:1819
-msgid ""
-"[SOMEVEHICLE]                               ; VehicleType\n"
-"IsSimpleDeployer.ConsiderPathfinding=false  ; boolean\n"
-"IsSimpleDeployer.DisallowedLandTypes=       ; List of LandTypes (none | "
-"clear | road | water | rock | wall | tiberium | beach | rough | ice | "
-"railroad | tunnel | weeds)\n"
-"DeployDir=                                  ; Facing type (integers from "
-"0-7 or -1)\n"
-"DeployingAnims=                             ; List of AnimationTypes\n"
-"DeployingAnim.KeepUnitVisible=false         ; boolean\n"
-"DeployingAnim.ReverseForUndeploy=true       ; boolean\n"
-"DeployingAnim.UseUnitDrawer=true            ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]                               ; VehicleType\n"
-"IsSimpleDeployer.ConsiderPathfinding=false  ; boolean\n"
-"IsSimpleDeployer.DisallowedLandTypes=       ; List of LandTypes (none | "
-"clear | road | water | rock | wall | tiberium | beach | rough | ice | "
-"railroad | tunnel | weeds)\n"
-"DeployDir=                                  ; Facing type (integers from "
-"0-7 or -1)\n"
-"DeployingAnims=                             ; List of AnimationTypes\n"
-"DeployingAnim.KeepUnitVisible=false         ; boolean\n"
-"DeployingAnim.ReverseForUndeploy=true       ; boolean\n"
-"DeployingAnim.UseUnitDrawer=true            ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1830
-msgid "Make harvesters do addtional scan after unload"
-msgstr "使矿车卸载后重新扫描较近的矿区"
-
-#: ../../Fixed-or-Improved-Logics.md:1832
-msgid ""
-"In vanilla, miners will remember their current location when they reach "
-"full load and move to that location after unloading. This makes miners to"
-" gradually move deeper into the mine and ignore the closer minerals."
-msgstr "在原版中矿车在满载时会记录当前位置并在卸载后返回该坐标。这一机制会让矿车逐渐向原矿区深处探索但却容易忽略距离更近的矿区。"
-
-#: ../../Fixed-or-Improved-Logics.md:1833
-msgid ""
-"Now you can have the miner search for the nearest mineral again after "
-"unloading. If a closer mineral is found, the miner will go to that "
-"location instead of the previously recorded location."
-msgstr "现在你可以让矿车在卸载后重新搜索最近的矿区。如果发现了更近的矿区那么矿车会优先前往它而不是返回先前记录的坐标。"
-
-#: ../../Fixed-or-Improved-Logics.md:1836
-msgid ""
-"[General]\n"
-"HarvesterScanAfterUnload=false     ; boolean\n"
-"\n"
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
-"HarvesterScanAfterUnload\n"
-msgstr ""
-"[General]\n"
-"HarvesterScanAfterUnload=false     ; boolean\n"
-"\n"
-"[SOMEVEHICLE]                      ; VehicleType\n"
-"HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
-"HarvesterScanAfterUnload\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1844
-msgid "Preserve Iron Curtain / Force Shield status on type conversion"
-msgstr "在单位转换时保留铁幕／力场护盾状态"
-
-#: ../../Fixed-or-Improved-Logics.md:1846
-msgid "![image](_static/images/preserve-ic.gif) *Bugfix in action*"
-msgstr "![image](_static/images/preserve-ic.gif) *Bug 修复后的行为*"
-
-#: ../../Fixed-or-Improved-Logics.md:1849
-msgid ""
-"Iron Curtain status is now preserved by default when converting between "
-"TechnoTypes via `DeploysInto` / `UndeploysInto`. Force Shield status "
-"preservation is turned off by default."
-msgstr "通过 `DeploysInto`／`UndeploysInto` 在科技类型之间的转换现在默认保留铁幕状态。力场护盾则默认不保留。"
-
-#: ../../Fixed-or-Improved-Logics.md:1850
-msgid "This behavior can be turned on/off per-TechnoType and on global basis."
-msgstr "这一行为可以对每个科技类型和全局进行开启／关闭。"
-
-#: ../../Fixed-or-Improved-Logics.md:1851
-msgid ""
-"`IronCurtain.Modifier` / `ForceShield.Modifier` (whichever is applicable)"
-" is re-applied upon type conversion."
-msgstr "`IronCurtain.Modifier`／`ForceShield.Modifier`（视情况而定）将在单位转换时刷新。"
-
-#: ../../Fixed-or-Improved-Logics.md:1854
-msgid ""
-"[CombatDamage]\n"
-"IronCurtain.KeptOnDeploy=true   ; boolean\n"
-"ForceShield.KeptOnDeploy=false  ; boolean\n"
-"\n"
-"[SOMETECHNO]                    ; VehicleType with DeploysInto or "
-"BuildingType with UndeploysInto\n"
-"IronCurtain.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
-"IronCurtain.KeptOnDeploy\n"
-"ForceShield.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
-"ForceShield.KeptOnDeploy\n"
-msgstr ""
-"[CombatDamage]\n"
-"IronCurtain.KeptOnDeploy=true   ; boolean\n"
-"ForceShield.KeptOnDeploy=false  ; boolean\n"
-"\n"
-"[SOMETECHNO]                    ; VehicleType with DeploysInto or "
-"BuildingType with UndeploysInto\n"
-"IronCurtain.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
-"IronCurtain.KeptOnDeploy\n"
-"ForceShield.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
-"ForceShield.KeptOnDeploy\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1864
-msgid "Retain target on movement command"
-msgstr "在命令移动后保留目标"
-
-#: ../../Fixed-or-Improved-Logics.md:1866
-msgid ""
-"It is now possible for vehicles to retain their target when issued "
-"movement command by setting `KeepTargetOnMove` to true."
-msgstr "现在可以通过设置 `KeepTargetOnMove` 为 true 来使载具在接收到移动命令时保留其目标。"
-
-#: ../../Fixed-or-Improved-Logics.md:1867
-msgid ""
-"Note that no check is done whether or not the vehicle or the weapon can "
-"actually fire while moving, this is on modder's discretion."
-msgstr "注意这不会检查载具或武器实际上能否在移动中开火，这由 modder 自行决定。"
-
-#: ../../Fixed-or-Improved-Logics.md:1868
-msgid ""
-"The target is automatically reset if the vehicle moves beyond the "
-"weapon's range from the target."
-msgstr "如果由于载具移动导致目标超出武器射程那么目标将自动重置。"
-
-#: ../../Fixed-or-Improved-Logics.md:1869
-msgid ""
-"`KeepTargetOnMove.Weapon` determines the weapon to be used for range "
-"check. If set to -1, the game will select the weapon against the target "
-"by default logic."
-msgstr "`KeepTargetOnMove.Weapon` 决定用于射程检查的武器。如果设为 -1，游戏将会根据默认武器选用规则针对目标对象选取。"
-
-#: ../../Fixed-or-Improved-Logics.md:1870
-msgid ""
-"It's recommended to set it to a specific weapon for better performance, "
-"unless there's a need to use multiple weapons for different targets."
-msgstr "建议将其设为特定武器以优化性能，除非需要针对不同目标使用多种武器。"
-
-#: ../../Fixed-or-Improved-Logics.md:1871
-msgid ""
-"`KeepTargetOnMove.NoMorePursuit` controls whether the unit will restart "
-"chasing the target for attack when it stops again, otherwise it will "
-"clear the target when it moves away."
-msgstr "`KeepTargetOnMove.NoMorePursuit` 控制单位是否会在再次停止后重新开始追击目标以发起攻击，否则会在移动时清除目标。"
-
-#: ../../Fixed-or-Improved-Logics.md:1872
-msgid ""
-"`KeepTargetOnMove.ExtraDistance` can be used to modify the distance "
-"considered 'out of range' from the target (it is added to weapon range), "
-"negative values work to reduce the distance."
-msgstr ""
-"`KeepTargetOnMove.ExtraDistance` 可以用来修改被认为 “超出射程” "
-"的范围（基于武器射程的修正值），负值会缩短判定距离。"
-
-#: ../../Fixed-or-Improved-Logics.md:1875
-msgid ""
-"[SOMEVEHICLE]                        ; VehicleType\n"
-"KeepTargetOnMove=false               ; boolean\n"
-"KeepTargetOnMove.Weapon=-1           ; integer, weapon slot index\n"
-"KeepTargetOnMove.NoMorePursuit=true  ; boolean\n"
-"KeepTargetOnMove.ExtraDistance=0     ; floating point value, distance in "
-"cells\n"
-msgstr ""
-"[SOMEVEHICLE]                        ; VehicleType\n"
-"KeepTargetOnMove=false               ; boolean\n"
-"KeepTargetOnMove.Weapon=-1           ; integer, weapon slot index\n"
-"KeepTargetOnMove.NoMorePursuit=true  ; boolean\n"
-"KeepTargetOnMove.ExtraDistance=0     ; floating point value, distance in "
-"cells\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1883
-msgid "Sinking behavior dehardcode"
-msgstr "自定义沉没行为"
-
-#: ../../Fixed-or-Improved-Logics.md:1885
-msgid ""
-"In vanilla, whether a ship sinks when it dies on the water is determined "
-"by multiple settings of hardcoding. The speed of the sinking is hardcoded"
-" to 5 Leptons per frame."
-msgstr "原版中一艘舰船在水上死亡是否会沉没由多个硬编码设置决定。沉没速度硬编码为每帧 5 leptons。"
-
-#: ../../Fixed-or-Improved-Logics.md:1886
-msgid ""
-"Now you can determine whether a ship sinks with a dedicated flag "
-"`Sinkable`, and use `SinkSpeed` to customize the speed at which the ship "
-"sinks."
-msgstr "现在你可以通过专门的标签 `Sinkable` 来决定一艘舰船是否会沉没，并且可以使用 `SinkSpeed` 来定义舰船的沉没速度。"
-
-#: ../../Fixed-or-Improved-Logics.md:1887
-msgid ""
-"`Sinkable.SquidGrab` controls the behavior of a ship when it is killed by"
-" a squid. Set it to `false` to cause the ship to take a lethal damage "
-"instead of sinking directly at that time (and thus obey `Sinkable` "
-"settings)."
-msgstr ""
-"`Sinkable.SquidGrab` 控制一艘船在被巨型乌贼击杀时的行为。将其设为 false "
-"会导致舰船受到致命伤害而非在此时直接沉没（从而遵循 `Sinkable` 的设置）。"
-
-#: ../../Fixed-or-Improved-Logics.md:1890
-msgid ""
-"[SOMEVEHICLE]              ; VehicleType\n"
-"Sinkable=                  ; boolean\n"
-"SinkSpeed=5                ; integer, leptons per frame\n"
-"Sinkable.SquidGrab=true    ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]              ; VehicleType\n"
-"Sinkable=                  ; boolean\n"
-"SinkSpeed=5                ; integer, leptons per frame\n"
-"Sinkable.SquidGrab=true    ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1897
-msgid "Stationary vehicles"
-msgstr "静止的载具"
-
-#: ../../Fixed-or-Improved-Logics.md:1899
-msgid ""
-"Setting VehicleType `Speed` to 0 now makes game treat them as stationary,"
-" behaving in very similar manner to deployed vehicles with "
-"`IsSimpleDeployer` set to true. Should not be used on buildable vehicles,"
-" as they won't be able to exit factories."
-msgstr ""
-"现在载具将在 `Speed` 设置为 0 时使游戏将它们视为静止，其行为方式非常类似于 `IsSimpleDeployer` 设置为 true "
-"的部署状态载具。不应用于可生产的载具，否则它们将无法退出工厂。"
-
-#: ../../Fixed-or-Improved-Logics.md:1901
-msgid "Turret recoil"
-msgstr "炮塔制退"
-
-#: ../../Fixed-or-Improved-Logics.md:1903
-msgid ""
-"Now you can use `TurretRecoil` to control units' turret/barrel recoil "
-"effect when firing."
-msgstr "现在你可以使用 `TurretRecoil` 来控制单位开火时的炮塔／炮管制退效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:1904
-msgid "`TurretTravel` and `BarrelTravel` control the maximum recoil distance."
-msgstr "`TurretTravel` 和 `BarrelTravel` 控制最大制退距离。"
-
-#: ../../Fixed-or-Improved-Logics.md:1905
-msgid ""
-"`TurretRecoil.Suppress` can prevent the weapon from producing this effect"
-" when firing."
-msgstr "`TurretRecoil.Suppress` 可以在特定武器上阻止其产生此效果。"
-
-#: ../../Fixed-or-Improved-Logics.md:1908
-msgid ""
-"[SOMEVEHICLE]             ; VehicleType\n"
-"TurretRecoil=no           ; boolean\n"
-"TurretTravel=2            ; integer, pixels\n"
-"TurretCompressFrames=1    ; integer, game frames\n"
-"TurretHoldFrames=1        ; integer, game frames\n"
-"TurretRecoverFrames=1     ; integer, game frames\n"
-"BarrelTravel=2            ; integer, pixels\n"
-"BarrelCompressFrames=1    ; integer, game frames\n"
-"BarrelHoldFrames=1        ; integer, game frames\n"
-"BarrelRecoverFrames=1     ; integer, game frames\n"
-"\n"
-"[SOMEWEAPON]              ; WeaponType\n"
-"TurretRecoil.Suppress=no  ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]             ; VehicleType\n"
-"TurretRecoil=no           ; boolean\n"
-"TurretTravel=2            ; integer, pixels\n"
-"TurretCompressFrames=1    ; integer, game frames\n"
-"TurretHoldFrames=1        ; integer, game frames\n"
-"TurretRecoverFrames=1     ; integer, game frames\n"
-"BarrelTravel=2            ; integer, pixels\n"
-"BarrelCompressFrames=1    ; integer, game frames\n"
-"BarrelHoldFrames=1        ; integer, game frames\n"
-"BarrelRecoverFrames=1     ; integer, game frames\n"
-"\n"
-"[SOMEWEAPON]              ; WeaponType\n"
-"TurretRecoil.Suppress=no  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1925
-msgid ""
-"The logic above was not reverse-engineered but reimplemented to achieve "
-"the same effect, hence there might be some differences in behavior "
-"compared to Tiberian Sun version."
-msgstr "上面的逻辑并非来自逆向工程复原而是模拟复刻效果，因此与《泰伯利亚之日》中的行为相比可能存在一些差异。"
-
-#: ../../Fixed-or-Improved-Logics.md:1928
-msgid "Unit Without Turret Always Turn To Target"
-msgstr "无炮塔单位始终面向目标"
-
-#: ../../Fixed-or-Improved-Logics.md:1930
-msgid ""
-"Now vehicles without turret will attempt to turn to the target while the "
-"weapon is cooling down, rather than after the weapon has cooled down, by "
-"setting `NoTurret.TrackTarget` to true."
-msgstr ""
-"现在可以通过将 `NoTurret.TrackTarget` 设为 true "
-"来让没有炮塔的载具在武器冷却期间就尝试更改朝向以面向目标而不是等到武器冷却完成后。"
-
-#: ../../Fixed-or-Improved-Logics.md:1933
-msgid ""
-"[General]\n"
-"NoTurret.TrackTarget=false   ; boolean\n"
-"\n"
-"[SOMEVEHICLE]                ; VehicleType\n"
-"NoTurret.TrackTarget=        ; boolean, defaults to [General] -> "
-"NoTurret.TrackTarget\n"
-msgstr ""
-"[General]\n"
-"NoTurret.TrackTarget=false   ; boolean\n"
-"\n"
-"[SOMEVEHICLE]                ; VehicleType\n"
-"NoTurret.TrackTarget=        ; boolean, defaults to [General] -> "
-"NoTurret.TrackTarget\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1942
-msgid ""
-"Jumpjet can also be affected by this if firing an `OmniFire` weapon with "
-"`OmniFire.TurnToTarget` set to true."
-msgstr ""
-"如果 Jumpjet 在 `OmniFire.TurnToTarget` 设为 true 的情况下发射一个 `OmniFire` "
-"武器那么也会受到影响。"
-
-#: ../../Fixed-or-Improved-Logics.md:1945
-msgid "Voxel turret shadow"
-msgstr "Voxel 炮塔影子"
-
-#: ../../Fixed-or-Improved-Logics.md:1947
-msgid ""
-"Vehicle voxel turrets can now draw shadows if `[AudioVisual] -> "
-"DrawTurretShadow` is set to true. This can be overridden per VehicleType "
-"by setting `TurretShadow` in the vehicle's `artmd.ini` section."
-msgstr ""
-"如果 `[AudioVisual] -> DrawTurretShadow` 被设为 true 那么载具的 Voxel "
-"炮塔现在可以绘制影子。这可以在载具的 `artmd.ini` 小节中设置 `TurretShadow` 来覆盖。"
-
-#: ../../Fixed-or-Improved-Logics.md:1950
-msgid ""
-"[AudioVisual]\n"
-"DrawTurretShadow=false  ; boolean\n"
-msgstr ""
-"[AudioVisual]\n"
-"DrawTurretShadow=false  ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1956
-msgid ""
-"[SOMEVEHICLE]   ; VehicleType\n"
-"TurretShadow=   ; boolean\n"
-msgstr ""
-"[SOMEVEHICLE]   ; VehicleType\n"
-"TurretShadow=   ; boolean\n"
-
-#: ../../Fixed-or-Improved-Logics.md:1961
+#: ../../Fixed-or-Improved-Logics.md:494 ../../Fixed-or-Improved-Logics.md:2167
 msgid "Veinholes & Weeds"
 msgstr "泰伯利亚藤蔓与泰伯利亚废矿"
 
-#: ../../Fixed-or-Improved-Logics.md:1963
+#: ../../Fixed-or-Improved-Logics.md:496 ../../Fixed-or-Improved-Logics.md:2169
 msgid "Veinholes"
 msgstr "泰伯利亚藤蔓"
 
-#: ../../Fixed-or-Improved-Logics.md:1965
+#: ../../Fixed-or-Improved-Logics.md:498 ../../Fixed-or-Improved-Logics.md:2171
 msgid "Veinhole monsters now work like they used to in Tiberian Sun."
 msgstr "泰伯利亚藤蔓怪现在可以像《泰伯利亚之日》中那样工作。"
 
-#: ../../Fixed-or-Improved-Logics.md:1966
+#: ../../Fixed-or-Improved-Logics.md:499 ../../Fixed-or-Improved-Logics.md:2172
 msgid "Their core parameters are still loaded from `[General]`."
 msgstr "它们的核心参数仍然从 `[General]` 读取。"
 
-#: ../../Fixed-or-Improved-Logics.md:1967
+#: ../../Fixed-or-Improved-Logics.md:500 ../../Fixed-or-Improved-Logics.md:2173
 msgid ""
 "The Warhead used by veins is specified under `[CombatDamage]`. The "
 "warhead has to have `Veinhole=yes` set."
 msgstr "藤蔓的弹头在 `[CombatDamage]` 下指定。弹头必须设置 `Veinhole=yes`。"
 
-#: ../../Fixed-or-Improved-Logics.md:1968
+#: ../../Fixed-or-Improved-Logics.md:501 ../../Fixed-or-Improved-Logics.md:2174
 msgid "Veinholes are hardcoded to use several overlay types."
 msgstr "泰伯利亚藤蔓被硬编码使用几种覆盖物。"
 
-#: ../../Fixed-or-Improved-Logics.md:1969
+#: ../../Fixed-or-Improved-Logics.md:502 ../../Fixed-or-Improved-Logics.md:2175
 msgid ""
 "The vein attack animation specified under `[AudioVisual]` is what deals "
 "the damage. The animation has to be properly listed under `[Animations]` "
 "as well."
 msgstr "泰伯利亚藤蔓造成杀伤的攻击效果动画于 `[AudioVisual]` 下指定。动画必须列于 `[Animations]` 注册表中。"
 
-#: ../../Fixed-or-Improved-Logics.md:1970
+#: ../../Fixed-or-Improved-Logics.md:503 ../../Fixed-or-Improved-Logics.md:2176
 msgid "Units can be made immune to veins the same way as in Tiberian Sun."
 msgstr "单位可以像在《泰伯利亚之日》中一样设置对泰伯利亚藤蔓免疫。"
 
-#: ../../Fixed-or-Improved-Logics.md:1971
+#: ../../Fixed-or-Improved-Logics.md:504 ../../Fixed-or-Improved-Logics.md:2177
 msgid ""
 "The monster itself is represented by the `VEINTREE` TerrainType, which "
 "has `IsVeinhole=true` set. Its strength is what determines the strength "
@@ -6884,7 +2463,7 @@ msgstr ""
 "怪物主体以 `VEINTREE` 地形对象的形式存在，其拥有 `IsVeinhole=true` 设置。并且它的 `Strength` "
 "决定了泰伯利亚藤蔓的生命值。"
 
-#: ../../Fixed-or-Improved-Logics.md:1974
+#: ../../Fixed-or-Improved-Logics.md:507 ../../Fixed-or-Improved-Logics.md:2180
 msgid ""
 "Everything listed below functions identically to Tiberian Sun. Many of "
 "the tags from Tiberian Sun have been re-enabled. The values provided "
@@ -6907,7 +2486,7 @@ msgstr ""
 "中的值相同。你可以在 MODENC "
 "上了解更多关于它们的信息：[VeinholeGrowthRate](https://modenc.renegadeprojects.com/VeinholeGrowthRate)、[VeinholeShrinkRate](https://modenc.renegadeprojects.com/VeinholeShrinkRate)、[MaxVeinholeGrowth](https://modenc.renegadeprojects.com/MaxVeinholeGrowth)、[VeinDamage](https://modenc.renegadeprojects.com/VeinDamage)、[VeinholeTypeClass](https://modenc.renegadeprojects.com/VeinholeTypeClass)、[VeinholeWarhead](https://modenc.renegadeprojects.com/VeinholeWarhead)、[Veinhole](https://modenc.renegadeprojects.com/Veinhole)、[VeinAttack](https://modenc.renegadeprojects.com/VeinAttack)、[ImmuneToVeins](https://modenc.renegadeprojects.com/ImmuneToVeins)、[IsVeinhole](https://modenc.renegadeprojects.com/IsVeinhole)"
 
-#: ../../Fixed-or-Improved-Logics.md:1981
+#: ../../Fixed-or-Improved-Logics.md:514 ../../Fixed-or-Improved-Logics.md:2187
 msgid ""
 "[General]\n"
 "VeinholeGrowthRate=300        ; integer\n"
@@ -6957,7 +2536,7 @@ msgstr ""
 "IsVeinhole=true\n"
 "Strength=1000                 ; integer - the strength of the Veinhole\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2008
+#: ../../Fixed-or-Improved-Logics.md:541 ../../Fixed-or-Improved-Logics.md:2214
 msgid ""
 "The game expects certain overlays related to Veinholes to have certain "
 "indices, they are listed below. Please keep in mind that the indices in "
@@ -6968,7 +2547,7 @@ msgstr ""
 "游戏需要泰伯利亚藤蔓相关的覆盖物使用特定的索引，如下所示。请注意 `OverlayTypes` 注册表中的索引是从 0 "
 "开始的，由于游戏内部规则，等号左侧的标识符无关紧要。原版 `rulesmd.ini` 已经在正确的索引处列出了所需的覆盖物。"
 
-#: ../../Fixed-or-Improved-Logics.md:2012
+#: ../../Fixed-or-Improved-Logics.md:545 ../../Fixed-or-Improved-Logics.md:2218
 msgid ""
 "[OverlayTypes]\n"
 "126=VEINS                     ; The veins (weeds)\n"
@@ -6980,55 +2559,55 @@ msgstr ""
 "167=VEINHOLE                  ; The Veinhole itself\n"
 "178=VEINHOLEDUMMY             ; A technical overlay\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2019
+#: ../../Fixed-or-Improved-Logics.md:552 ../../Fixed-or-Improved-Logics.md:2225
 msgid "Weeds & Weed Eaters"
 msgstr "泰伯利亚废矿与废矿采集者"
 
-#: ../../Fixed-or-Improved-Logics.md:2021
+#: ../../Fixed-or-Improved-Logics.md:554 ../../Fixed-or-Improved-Logics.md:2227
 msgid ""
 "Vehicles with `Weeder=yes` can now collect weeds. The weeds can then be "
 "deposited into a building with `Weeder=yes`."
 msgstr "拥有 `Weeder=yes` 的载具现在可以收集泰伯利亚废矿。然后这些废矿可以存入 `Weeder=yes` 的建筑中。"
 
-#: ../../Fixed-or-Improved-Logics.md:2022
+#: ../../Fixed-or-Improved-Logics.md:555 ../../Fixed-or-Improved-Logics.md:2228
 msgid ""
 "Weeds are not stored in a building's storage, but rather in a House's "
 "storage. The weed capacity is listed under `[General] -> WeedCapacity`."
 msgstr "泰伯利亚废矿并不是储藏在储存仓建筑中而是这个阵营的内部数据。废矿的储藏量读取自 `[General] -> WeedCapacity`。"
 
-#: ../../Fixed-or-Improved-Logics.md:2023
+#: ../../Fixed-or-Improved-Logics.md:556 ../../Fixed-or-Improved-Logics.md:2229
 msgid ""
 "Weeders now show the ore gathering animation. It can be customized the "
 "same way as for harvesters."
 msgstr "废矿矿车现在可以像普通矿车那样自定义矿石采集动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:2024
+#: ../../Fixed-or-Improved-Logics.md:557 ../../Fixed-or-Improved-Logics.md:2230
 msgid "Weeders can use the Teleport locomotor like chrono miners."
 msgstr "废矿矿车可以像超时空矿车一样使用 Teleport 运动模式。"
 
-#: ../../Fixed-or-Improved-Logics.md:2025
+#: ../../Fixed-or-Improved-Logics.md:558 ../../Fixed-or-Improved-Logics.md:2231
 msgid ""
 "Total amount of weeds in storage can be displayed on sidebar, see [Weeds "
 "counter](User-Interface.md#weeds-counter)."
 msgstr "储存的废矿总量可以在侧边栏上显示，参见 [废矿计数器](User-Interface.md#weeds-counter)。"
 
-#: ../../Fixed-or-Improved-Logics.md:2027
+#: ../../Fixed-or-Improved-Logics.md:560 ../../Fixed-or-Improved-Logics.md:2233
 msgid "Weed-consuming superweapons"
 msgstr "消耗废矿的超级武器"
 
-#: ../../Fixed-or-Improved-Logics.md:2029
+#: ../../Fixed-or-Improved-Logics.md:562 ../../Fixed-or-Improved-Logics.md:2235
 msgid ""
 "Superweapons can consume weeds to recharge, like the Chemical Missile "
 "special in Tiberian Sun."
 msgstr "超级武器可以消耗泰伯利亚废矿来加载，就像《泰伯利亚之日》中的化学飞弹一样。"
 
-#: ../../Fixed-or-Improved-Logics.md:2032
+#: ../../Fixed-or-Improved-Logics.md:565 ../../Fixed-or-Improved-Logics.md:2238
 msgid ""
 "As the code for the Chemical Missile had been removed, setting "
 "`Type=ChemMissile` will not work."
 msgstr "由于化学飞弹的代码已被移除，设置 `Type=ChemMissile` 并不会生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:2036
+#: ../../Fixed-or-Improved-Logics.md:569 ../../Fixed-or-Improved-Logics.md:2242
 #, python-format
 msgid ""
 "[SOMESW]                                        ; SuperWeaponType\n"
@@ -7053,11 +2632,4706 @@ msgstr ""
 " weeds % are stored, the SW will show it's ready on the building (open "
 "nuke/open chrono, etc.)\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2044
+#: ../../Fixed-or-Improved-Logics.md:577
+msgid "Voxel light source customization"
+msgstr "自定义 Voxel 光源"
+
+#: ../../Fixed-or-Improved-Logics.md:579
+msgid ""
+"![image](_static/images/VoxelLightSourceComparison1.png) "
+"![image](_static/images/VoxelLightSourceComparison2.png) *Voxel by <a "
+"class=\"reference external\" "
+"href=\"https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index\" "
+"target=\"_blank\">C&CrispS</a>*"
+msgstr ""
+"![image](_static/images/VoxelLightSourceComparison1.png) "
+"![image](_static/images/VoxelLightSourceComparison2.png) *Voxel by <a "
+"class=\"reference external\" "
+"href=\"https://bbs.ra2diy.com/home.php?mod=space&uid=20016&do=index\" "
+"target=\"_blank\">C&CrispS</a>（另存为并解压第二张图片即可获得包括 pal & vpl 的示例文件）*"
+
+#: ../../Fixed-or-Improved-Logics.md:583
+msgid ""
+"It is now possible to change the position of the light relative to the "
+"voxels. This allows for better lighting to be set up."
+msgstr "现在可以改变光源相对于 Voxel 素材的位置。这有助于更好的设置光照。"
+
+#: ../../Fixed-or-Improved-Logics.md:584
+msgid ""
+"Only the direction of the light is accounted, the distance to the voxel "
+"is not accounted."
+msgstr "仅考虑光源的方向，不考虑与 Voxel 的距离（视为平行光）"
+
+#: ../../Fixed-or-Improved-Logics.md:585
+msgid ""
+"Vanilla light (assuming `UseFixedVoxelLighting=false`) is located roughly"
+" at `VoxelLightSource=0.201,-0.907,-0.362`."
+msgstr ""
+"原版光照（假设 `UseFixedVoxelLighting=false`）大致位于 "
+"`VoxelLightSource=0.201,-0.907,-0.362`。"
+
+#: ../../Fixed-or-Improved-Logics.md:588
+msgid ""
+"[AudioVisual]\n"
+"UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting\n"
+"VoxelLightSource=            ; X,Y,Z - position of the light in the world"
+" relative to each voxel, floating point values\n"
+msgstr ""
+"[AudioVisual]\n"
+"UseFixedVoxelLighting=false  ; boolean, whether to fix the lighting\n"
+"VoxelLightSource=            ; X,Y,Z - position of the light in the world"
+" relative to each voxel, floating point values\n"
+
+#: ../../Fixed-or-Improved-Logics.md:595
+msgid ""
+"In order to easily preview the light source settings use the [VXL Viewer "
+"and VPL Generator tool by thomassneddon](https://github.com/ThomasSneddon"
+"/vxl-renderer/releases). To use the tool unpack it somewhere, then drag "
+"the main VXL file of a voxel that you will use to preview onto it "
+"(auxilliary VXL and HVA files must be in the same folder)."
+msgstr ""
+"为了方便预览光源设置可以使用 [thomassneddon 的 VXL 猹看器 与 VPL "
+"生成工具](https://github.com/ThomasSneddon/vxl-"
+"renderer/releases)。使用该工具时**先将其解压**然后将需要预览的 Voxel 文件**拖拽**到工具上（辅助 VXL 和 "
+"HVA 文件必须在同一文件夹中）。"
+
+#: ../../Fixed-or-Improved-Logics.md:597
+msgid ""
+"Keep in mind that the tool doesn't account for "
+"`UseFixedVoxelLighting=true` as of yet, so the values shown in tool need "
+"to be offset when putting in the game with with fixed voxel lighting."
+msgstr "请注意该工具目前尚未考虑 `UseFixedVoxelLighting=true` 的情况，因此工具中显示的值在启用该修复项的游戏中需要进行调整。"
+
+#: ../../Fixed-or-Improved-Logics.md:600
+msgid "Aircraft"
+msgstr "战机类型"
+
+#: ../../Fixed-or-Improved-Logics.md:602
+msgid "Carryall pickup voice"
+msgstr "吊运拾取音效"
+
+#: ../../Fixed-or-Improved-Logics.md:604
+msgid ""
+"It is now possible to override `VoiceMove` for `Carryall=true` aircraft "
+"for when commanding it to pick up vehicles by setting `VoicePickup`."
+msgstr "现在可以通过设置 `VoicePickup` 来覆盖 `Carryall=true` 战机在命令其拾取载具时的 `VoiceMove` 音效。"
+
+#: ../../Fixed-or-Improved-Logics.md:607
+msgid ""
+"[SOMEAIRCRAFT]  ; AircraftType\n"
+"VoicePickup=    ; Sound entry\n"
+msgstr ""
+"[SOMEAIRCRAFT]  ; AircraftType\n"
+"VoicePickup=    ; Sound entry\n"
+
+#: ../../Fixed-or-Improved-Logics.md:612
+msgid "Customize the scatter caused by aircraft attack mission"
+msgstr "自定义战机攻击任务引发分散"
+
+#: ../../Fixed-or-Improved-Logics.md:614
+msgid ""
+"In vanilla, when an aircraft attacks, it forces the target's cell to "
+"trigger a scatter. Now you can disable this behavior by setting the "
+"following flag to `false`."
+msgstr "在原版中当一架战机发起攻击它会强制触发目标单元格上的分散效果。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:617
+msgid ""
+"[SOMEAIRCRAFT]            ; AircraftType\n"
+"FiringForceScatter=true   ; boolean\n"
+msgstr ""
+"[SOMEAIRCRAFT]            ; AircraftType\n"
+"FiringForceScatter=true   ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:622
+msgid "Extended Aircraft Missions"
+msgstr "拓展的战机任务"
+
+#: ../../Fixed-or-Improved-Logics.md:624
+msgid "Aircraft will now be able to use waypoints."
+msgstr "战机现在将能够使用路径点。"
+
+#: ../../Fixed-or-Improved-Logics.md:625
+msgid ""
+"When a `guard` command (`[G]` by default) or a `area guard` command "
+"(`[Ctrl]+[Alt]`) is issued, the aircraft will search for targets around "
+"the position (for `guard` is the current location, for `area guard` is "
+"the target position) and return immediately when ammos are depleted."
+msgstr ""
+"当发出 `guard` 命令（默认为 `[G]`）或 `area guard` "
+"命令（`[Ctrl]+[Alt]`）时战机将根据位置（`guard` 为当前位置，`area guard` "
+"为目标位置）周围搜素目标并在弹药耗尽时立即返回。"
+
+#: ../../Fixed-or-Improved-Logics.md:626
+msgid ""
+"If the target is not found, or if there is still ammo when the target is "
+"destroyed, it will continue to hover over the guarded area."
+msgstr "若未发现目标，或摧毁目标后仍有弹药，则继续在警戒区域上方巡游。"
+
+#: ../../Fixed-or-Improved-Logics.md:627
+msgid ""
+"When an `attack move` command (`[Ctrl]+[Shift]`) is issued, the aircraft "
+"will move towards the destination and search for nearby targets on the "
+"route for attack. Once ammo is depleted or the destination is reached, it"
+" will return."
+msgstr ""
+"当发出 `attack move` "
+"命令（`[Ctrl]+[Shift]`）时战机将向目的地移动并在路线上搜索附近的目标进行攻击。一旦弹药耗尽或抵达目的地，它将返回。"
+
+#: ../../Fixed-or-Improved-Logics.md:628
+msgid ""
+"If the automatically selected target is destroyed but ammo is not "
+"depleted yet during the process, the aircraft will continue flying to the"
+" destination."
+msgstr "如果在过程中自动选择的目标被摧毁但弹药尚未耗尽，战机将继续飞往目的地。"
+
+#: ../../Fixed-or-Improved-Logics.md:629
+msgid "In addition, the actions of aircraft are also changed."
+msgstr "此外，战机的行为也可以更改。"
+
+#: ../../Fixed-or-Improved-Logics.md:630
+msgid ""
+"`ExtendedAircraftMissions.SmoothMoving` controls whether the aircraft "
+"will return to the airport when the distance to the destination is less "
+"than half of `SlowdownDistance` or its turning radius."
+msgstr ""
+"`ExtendedAircraftMissions.SmoothMoving` 控制战机距离目的地距离小于 `SlowdownDistance` "
+"的一半或其转弯半径时是否会返回机场。"
+
+#: ../../Fixed-or-Improved-Logics.md:631
+msgid ""
+"`ExtendedAircraftMissions.EarlyDescend` controls whether the aircraft not"
+" have to fly directly above the airport before starting to descend when "
+"the distance between the aircraft and the landing point is less than "
+"`SlowdownDistance` (also work for aircraft spawned by aircraft carriers)."
+msgstr ""
+"`ExtendedAircraftMissions.EarlyDescend` 控制战机距离着陆点小于 `SlowdownDistance` "
+"时是否无需飞越机场正上方即可开始下降（对航母舰载机同样有效）。"
+
+#: ../../Fixed-or-Improved-Logics.md:632
+msgid ""
+"`ExtendedAircraftMissions.RearApproach` controls whether the aircraft "
+"should start landing at the airport from the opposite direction of "
+"`LandingDir`."
+msgstr ""
+"`ExtendedAircraftMissions.RearApproach` 控制战机返回机场时是否应从与 `LandingDir` "
+"相反的方向飞入，即下降时向 `LandingDir` 的方向飞行并着陆。"
+
+#: ../../Fixed-or-Improved-Logics.md:633
+msgid ""
+"`ExtendedAircraftMissions.FastScramble` controls whether the aircraft can"
+" scramble when its airport has been destroyed."
+msgstr "`ExtendedAircraftMissions.FastScramble` 控制战机在所属的机场被摧毁后是否仍能紧急升空。"
+
+#: ../../Fixed-or-Improved-Logics.md:634
+msgid ""
+"`ExtendedAircraftMissions.UnlandDamage` controls the damage suffered by "
+"the aircraft every 4 frames when there is no airport for the aircraft to "
+"land. If the value is negative, it will crash immediately. Not "
+"recommended to use when `ExtendedAircraftMissions` is not enabled."
+msgstr ""
+"`ExtendedAircraftMissions.UnlandDamage` 控制战机在无机场可降落时每 4 "
+"帧受到的损伤。若为负则立即坠毁。未启用 `ExtendedAircraftMissions` 时不建议使用此参数。"
+
+#: ../../Fixed-or-Improved-Logics.md:637
+msgid ""
+"[General]\n"
+"ExtendedAircraftMissions=false            ; boolean\n"
+"ExtendedAircraftMissions.UnlandDamage=-1  ; integer\n"
+"\n"
+"[SOMEAIRCRAFT]                            ; AircraftType\n"
+"ExtendedAircraftMissions.SmoothMoving=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.EarlyDescend=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.RearApproach=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.FastScramble=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.UnlandDamage=    ; integer, default to [General]"
+" -> ExtendedAircraftMissions.UnlandDamage\n"
+msgstr ""
+"[General]\n"
+"ExtendedAircraftMissions=false            ; boolean\n"
+"ExtendedAircraftMissions.UnlandDamage=-1  ; integer\n"
+"\n"
+"[SOMEAIRCRAFT]                            ; AircraftType\n"
+"ExtendedAircraftMissions.SmoothMoving=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.EarlyDescend=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.RearApproach=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.FastScramble=    ; boolean, default to [General]"
+" -> ExtendedAircraftMissions\n"
+"ExtendedAircraftMissions.UnlandDamage=    ; integer, default to [General]"
+" -> ExtendedAircraftMissions.UnlandDamage\n"
+
+#: ../../Fixed-or-Improved-Logics.md:651
+msgid ""
+"And now when `ExtendedAircraftMissions` is enabled, aircraft that can "
+"land at the airport will check at any time to see if they have a dock. "
+"Therefore, if there are aircraft in your mission that require dock and "
+"you have not provided enough or not disabled the feature, they will crash"
+" immediately"
+msgstr ""
+"目前当 `ExtendedAircraftMissions` "
+"被启用时，能够降落到机场的战机会始终检查自身是否拥有用于停靠的机位。因此若你的任务中需要存在能够降落到机场的战机但没有提供足够的空余机位也没有禁用该功能，那么这些战机将立即坠毁。"
+
+#: ../../Fixed-or-Improved-Logics.md:654
+msgid "Fixed spawn distance & spawn height for airstrike / SpyPlane aircraft"
+msgstr "空袭战机和侦察机的生成距离和生成高度"
+
+#: ../../Fixed-or-Improved-Logics.md:656
+msgid ""
+"It is now possible to have aircraft spawned from "
+"`(Elite)AirstrikeTeamType` or `Type=SpyPlane` superweapons to be created "
+"at fixed distance from their intended target/destination instead of from "
+"edge of the map by setting `SpawnDistanceFromTarget`."
+msgstr ""
+"现在可以通过设置 `SpawnDistanceFromTarget` 来让由 `(Elite)AirstrikeTeamType` 或 "
+"`Type=SpyPlane` 超级武器生成的战机在与目标／目的地固定距离处生成而不再是地图边界。"
+
+#: ../../Fixed-or-Improved-Logics.md:657
+msgid ""
+"`SpawnHeight` can also be used to override the initial height of the "
+"aircraft, which defaults to `FlightLevel`, or if not set then `[General] "
+"-> FlightLevel`."
+msgstr ""
+"也可以通过 `SpawnHeight` 来覆盖战机的初始高度，默认为 `FlightLevel`，如果没有设置则使用 `[General] -> "
+"FlightLevel`。"
+
+#: ../../Fixed-or-Improved-Logics.md:660
+msgid ""
+"[SOMEAIRCRAFT]            ; AircraftType\n"
+"SpawnDistanceFromTarget=  ; floating point value, distance in cells\n"
+"SpawnHeight=              ; integer, height in leptons\n"
+msgstr ""
+
+#: ../../Fixed-or-Improved-Logics.md:666
+msgid "Landing direction"
+msgstr "降落方向"
+
+#: ../../Fixed-or-Improved-Logics.md:668
+msgid ""
+"By default aircraft land facing the direction specified by `[AudioVisual]"
+" -> PoseDir`. This can now be customized per AircraftType via "
+"`LandingDir`, defaults to `[AudioVisual] -> PoseDir`. If the building the"
+" aircraft is docking to has [aircraft docking direction](#aircraft-"
+"docking-direction) set, that setting takes priority over this."
+msgstr ""
+"默认情况下战机降落时朝向 `[AudioVisual] -> PoseDir` 指定的方向。现在可以通过每个战机类型上的 `LandingDir`"
+" 进行自定义，默认为 `[AudioVisual] -> PoseDir`。如果战机停靠的建筑设置了[战机停靠方向](#aircraft-"
+"docking-direction)，则该设置优先于此设置。"
+
+#: ../../Fixed-or-Improved-Logics.md:669
+msgid ""
+"Negative values are allowed as a special case for `AirportBound=false` "
+"aircraft which makes them land facing their current direction."
+msgstr "对于 `AirportBound=false` 的战机允许使用负值以使其降落时面向当前方向。"
+
+#: ../../Fixed-or-Improved-Logics.md:672
+msgid ""
+"[SOMEAIRCRAFT]  ; AircraftType\n"
+"LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
+"values as a special case.\n"
+msgstr ""
+"[SOMEAIRCRAFT]  ; AircraftType\n"
+"LandingDir=     ; Direction type (integers from 0-255). Accepts negative "
+"values as a special case.\n"
+
+#: ../../Fixed-or-Improved-Logics.md:677
+msgid "Animations"
+msgstr "动画类型"
+
+#: ../../Fixed-or-Improved-Logics.md:679
+msgid "Animation weapon and damage settings"
+msgstr "动画武器和伤害设置"
+
+#: ../../Fixed-or-Improved-Logics.md:681
+msgid ""
+"`Weapon` can be set to a WeaponType, to create a projectile and "
+"immediately detonate it instead of simply dealing `Damage` by `Warhead`. "
+"This allows weapon effects to be applied."
+msgstr ""
+"现在 `Weapon` 可以设置为完整的 WeaponType，以创建一个抛射体并立即引爆，而不是简单地通过 `Warhead` 造成 "
+"`Damage`。这允许武器效果正常使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:682
+msgid ""
+"`Damage.Delay` determines delay between two applications of `Damage`. "
+"Requires `Damage` to be set to 1.0 or above. Value of 0 disables the "
+"delay. Keep in mind that this is measured in animation frames, not game "
+"frames. Depending on `Rate`, animation may or may not advance animation "
+"frames on every game frame."
+msgstr ""
+"`Damage.Delay` 确定两次应用 `Damage` 之间的间隔。需要将 `Damage` 设置为 1.0 或更高。值为 0 "
+"将禁用间隔。请注意这是以动画帧为单位而不是游戏帧。动画会根据 `Rate` 可能在每个游戏帧上推进动画帧也可能不进行推进。"
+
+#: ../../Fixed-or-Improved-Logics.md:683
+msgid ""
+"`Damage.DealtByInvoker`, if set to true, makes any `Damage` dealt to be "
+"considered as coming from the animation's invoker (f.ex, firer of the "
+"weapon if it is Warhead `AnimList/SplashList` animation, the destroyed "
+"vehicle if it is `DestroyAnim` animation or the object the animation is "
+"attached to). If invoker has died or does not exist, the house the "
+"invoker belonged to is still used to deal damage and apply Phobos-"
+"introduced Warhead effects etc. If not set, the animation's owner house, "
+"or failing that, owning house of object it is attached to or the building"
+" it belongs to is used to deal the damage."
+msgstr ""
+"如果设置 `Damage.DealtByInvoker` 为 true，则任何造成的 `Damage` 都被视为来自动画的调用者（例如弹头的 "
+"`AnimList/SplashList` 动画则为武器发射者；如果是 `DestroyAnim` "
+"动画则为被摧毁的载具；或者动画所附着的对象）。即便调用者已经死亡或不存在也会继续使用调用者的所属方来造成伤害并应用 Phobos "
+"引入的弹头效果。若未设置该参数则默认使用动画所有者的所属方，若动画无所有者则使用动画所附着对象的所属方。"
+
+#: ../../Fixed-or-Improved-Logics.md:684
+msgid ""
+"`Damage.ApplyFirepowerMult` determines whether or not firepower modifiers"
+" from the animation's invoker are applied on the damage dealt from this "
+"animation, if exists."
+msgstr "`Damage.ApplyFirepowerMult` 决定动画存在调用者时是否可以获取其火力加成效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:685
+msgid ""
+"`Damage.ApplyOncePerLoop`, if set to true, makes `Damage` be dealt only "
+"once per animation loop (on single loop animations, only once, period) "
+"instead of on every frame or intervals defined by `Damage.Delay`. The "
+"frame on which it is dealt is determined by `Damage.Delay`, defaulting to"
+" after the first animation frame."
+msgstr ""
+"如果设置 `Damage.ApplyOncePerLoop` 为 true，则动画每次循环只造成一次 "
+"`Damage`（在单次循环的动画中只会造成一次）而不是在每帧或由 `Damage.Delay` 定义的间隔造成。造成伤害的帧由 "
+"`Damage.Delay` 决定，默认为在第一个动画帧之后。"
+
+#: ../../Fixed-or-Improved-Logics.md:688
+msgid ""
+"[SOMEANIM]                      ; AnimationType\n"
+"Weapon=                         ; WeaponType\n"
+"Damage.Delay=0                  ; integer, animation frames\n"
+"Damage.DealtByInvoker=false     ; boolean\n"
+"Damage.ApplyOncePerLoop=false   ; boolean\n"
+"Damage.ApplyFirepowerMult=false ; boolean\n"
+msgstr ""
+"[SOMEANIM]                      ; AnimationType\n"
+"Weapon=                         ; WeaponType\n"
+"Damage.Delay=0                  ; integer, animation frames\n"
+"Damage.DealtByInvoker=false     ; boolean\n"
+"Damage.ApplyOncePerLoop=false   ; boolean\n"
+"Damage.ApplyFirepowerMult=false ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:698
+msgid ""
+"`Weapon` and `Damage.Delay`, beyond the other additions, should function "
+"similarly to the equivalent features introduced by Ares and take "
+"precedence over them if Phobos is used together with Ares."
+msgstr ""
+"`Weapon` 和 `Damage.Delay`，除了其他新增功能外应与 Ares 引入的等效功能类似，并且在 Phobos 与 Ares "
+"一起使用时优先于它们。"
+
+#: ../../Fixed-or-Improved-Logics.md:701
+msgid "Attached animation position customization"
+msgstr "自定义附着动画位置"
+
+#: ../../Fixed-or-Improved-Logics.md:703
+msgid ""
+"You can now customize position of attached animations via different "
+"values for `AttachedAnimPosition`."
+msgstr "现在你可以通过为 `AttachedAnimPosition` 设置不同的值来自定义附着动画显示的位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:704
+msgid ""
+"`default`: Animation shows up at the parent object's logical position "
+"(for buildings, this is the top-leftmost cell / cell #0)."
+msgstr "`default`：动画显示在父对象的逻辑中心（对于建筑，这是最上方的 0 号单元格）。"
+
+#: ../../Fixed-or-Improved-Logics.md:705
+msgid "`center`: Animation shows up at the parent object's visual center."
+msgstr "`center`：动画显示在父对象的视觉中心。"
+
+#: ../../Fixed-or-Improved-Logics.md:706
+msgid ""
+"`ground`: Animation shows up at the parent object's visual center but "
+"forced to ground level. Note that the animations is still considered "
+"attached to the object and is likely to be drawn above objects that the "
+"object itself would cover unless other settings are used to compensate."
+msgstr "`ground`：动画显示在父对象视觉中心正下方所对应的地面。注意该动画仍被视为附着于对象，因此如果不通过其他设置进行调整的话该动画的图层可能在该对象本应覆盖的其他对象之上。"
+
+#: ../../Fixed-or-Improved-Logics.md:709
+msgid ""
+"[SOMEANIM]                   ; AnimationType\n"
+"AttachedAnimPosition=default ; Attached animation position enumeration "
+"(default|center|ground)\n"
+msgstr ""
+"[SOMEANIM]                   ; AnimationType\n"
+"AttachedAnimPosition=default ; Attached animation position enumeration "
+"(default|center|ground)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:714 ../../Fixed-or-Improved-Logics.md:2252
+msgid "Customizable debris & meteor impact and warhead detonation behaviour"
+msgstr "自定义碎片 & 流星撞击和弹头引爆行为"
+
+#: ../../Fixed-or-Improved-Logics.md:716
+msgid ""
+"`ExplodeOnWater` can be set to true to make the animation explode on "
+"impact with water. `ExpireAnim` will be played and `Warhead` is detonated"
+" or used to deal damage / generate light flash."
+msgstr ""
+"`Warhead.Detonate` 设置为 true 可以使动画在与水面接触时爆炸。`ExpireAnim` 将被触发，`Warhead` "
+"将被引爆或用于造成伤害／产生闪光。"
+
+#: ../../Fixed-or-Improved-Logics.md:717
+msgid ""
+"`Warhead.Detonate`, if set to true, makes the `Warhead` fully detonate "
+"instead of simply being used to deal damage and generate light flash if "
+"it has `Bright=true`."
+msgstr ""
+"如果将 `Warhead.Detonate` 设置为 true，则 `Warhead` 将完全引爆，而不仅仅是用于造成伤害和产生闪光（如果它拥有 "
+"`Bright=true`）。"
+
+#: ../../Fixed-or-Improved-Logics.md:718
+msgid ""
+"`WakeAnim` contains wake animations to play if `ExplodeOnWater` is not "
+"set and the animation impacts with water. Defaults to `[General] -> Wake`"
+" if `IsMeteor` is not set to true, otherwise no animation. If more than "
+"one animation is listed, a random one is selected."
+msgstr ""
+"`WakeAnim` 包含一组在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水波动画。如果 `IsMeteor` 未设置为"
+" true 则默认为 `[General] -> Wake`，否则无动画。如果列出了多个动画，则将随机选择一个。"
+
+#: ../../Fixed-or-Improved-Logics.md:719
+msgid ""
+"`SplashAnims` contains list of splash animations used if `ExplodeOnWater`"
+" is not set and the animation impacts with water."
+msgstr "`SplashAnims` 包含一组在 `ExplodeOnWater` 没有设置且动画与水面接触时使用的水花动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:720
+msgid ""
+"If `SplashAnims.PickRandom` is set to true, picks a random animation from"
+" `SplashAnims` to use on each impact with water. Otherwise last listed "
+"animation from `SplashAnims` is used."
+msgstr ""
+"如果设置 `SplashAnims.PickRandom` 为 true，则从 `SplashAnims` 中随机选择一个动画。否则使用 "
+"`SplashAnims` 中列出的最后一个动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:721
+msgid ""
+"`ExtraShadow` can be set to false to disable the display of shadows on "
+"the ground."
+msgstr "`ExtraShadow` 可以设为 false 以禁用地面上的影子显示。"
+
+#: ../../Fixed-or-Improved-Logics.md:724
+msgid ""
+"[SOMEANIM]                    ; AnimationType\n"
+"ExplodeOnWater=false          ; boolean\n"
+"Warhead.Detonate=false        ; boolean\n"
+"WakeAnim=                     ; List of AnimationTypes\n"
+"SplashAnims=                  ; List of AnimationTypes, default to "
+"[CombatDamage] -> SplashList\n"
+"SplashAnims.PickRandom=false  ; boolean\n"
+"ExtraShadow=true              ; boolean\n"
+msgstr ""
+"[SOMEANIM]                    ; AnimationType\n"
+"ExplodeOnWater=false          ; boolean\n"
+"Warhead.Detonate=false        ; boolean\n"
+"WakeAnim=                     ; List of AnimationTypes\n"
+"SplashAnims=                  ; List of AnimationTypes, default to "
+"[CombatDamage] -> SplashList\n"
+"SplashAnims.PickRandom=false  ; boolean\n"
+"ExtraShadow=true              ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:734
+msgid "Customize whether `Crater=yes` animation would destroy tiberium"
+msgstr "自定义 `Crater=yes` 的动画能否摧毁矿石"
+
+#: ../../Fixed-or-Improved-Logics.md:736
+msgid ""
+"In vanilla, the anim with `Crater=yes` is hardcoded to destroy the "
+"tiberium in its cell. Now you can disable this behavior by setting the "
+"following tags to `false`."
+msgstr "在原版中带有 `Crater=yes` 的动画硬编码会摧毁其所在单元格的矿石。现在你可以通过将下面的语句设为 `false` 来禁用该行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:739
+msgid ""
+"[General]\n"
+"AnimCraterDestroyTiberium=true  ; boolean\n"
+msgstr ""
+"[General]\n"
+"AnimCraterDestroyTiberium=true  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:745
+msgid ""
+"[SOMEANIM]                      ; AnimationType\n"
+"Crater.DestroyTiberium=         ; boolean, default to [General] -> "
+"AnimCraterDestroyTiberium\n"
+msgstr ""
+"[SOMEANIM]                      ; AnimationType\n"
+"Crater.DestroyTiberium=         ; boolean, default to [General] -> "
+"AnimCraterDestroyTiberium\n"
+
+#: ../../Fixed-or-Improved-Logics.md:750
+msgid "Fire animations spawned by Scorch & Flamer"
+msgstr "由 Scorch 和 Flamer 生成的火焰动画"
+
+#: ../../Fixed-or-Improved-Logics.md:752
+msgid ""
+"Tiberian Sun allowed `Scorch=true` and `Flamer=true` animations to spawn "
+"fire animations from `[AudioVisual] -> SmallFire` & `LargeFire`. This "
+"behaviour has been reimplemented and is fully customizable."
+msgstr ""
+"《泰伯利亚之日》中允许 `Scorch=true` 和 `Flamer=true` 的动画生成 `[AudioVisual] -> "
+"SmallFire` 和 `LargeFire` 指定的火焰动画。此行为已重新实现，并且完全可自定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:753
+msgid ""
+"`ConstrainFireAnimsToCellSpots` controls whether or not spawned "
+"animations are locked to cell spots (e.g the subcell positions infantry "
+"are also constrained to)."
+msgstr "`ConstrainFireAnimsToCellSpots` 控制生成的动画是否锁定到单元格位置（例如步兵也受子单元格位置限制）。"
+
+#: ../../Fixed-or-Improved-Logics.md:754
+msgid ""
+"`FireAnimDisallowedLandTypes` controls which landtypes the fire "
+"animations are not allowed to spawn on. Defaults to "
+"`water,rock,beach,ice` for `Scorch=true`, `none` otherwise."
+msgstr ""
+"`FireAnimDisallowedLandTypes` 控制不允许生成火焰动画的地形类型。对于 `Scorch=true` 默认为 "
+"`water,rock,beach,ice` 否则为 `none`。"
+
+#: ../../Fixed-or-Improved-Logics.md:755
+msgid ""
+"`AttachFireAnimsToParent` controls if the spawned animations are attached"
+" to the owner of the parent animation if it is also attached. Defaults to"
+" true for `Scorch=true`, otherwise false."
+msgstr ""
+"`AttachFireAnimsToParent` 控制生成的动画是否附着于父动画所附着的对象（如果父动画也是附着动画）。对于 "
+"`Scorch=true` 默认为 true，否则为 false。"
+
+#: ../../Fixed-or-Improved-Logics.md:756
+msgid ""
+"`SmallFireCount` determines number of small fire animations to spawn by "
+"both `Scorch=true` and `Flamer=true` animations. Defaults to 2 for "
+"`Flamer=true`, otherwise 1."
+msgstr ""
+"`SmallFireCount` 决定由 `Scorch=true` 和 `Flamer=true` 动画生成小火焰动画的数量。对于 "
+"`Flamer=true` 默认为 2，否则为 1。"
+
+#: ../../Fixed-or-Improved-Logics.md:757
+msgid ""
+"`SmallFireAnims` can be used to set the animation types, defaults to "
+"`[AudioVisual] -> SmallFire` (single animation)."
+msgstr "`SmallFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> SmallFire`（单个动画）。"
+
+#: ../../Fixed-or-Improved-Logics.md:758
+msgid ""
+"`SmallFireChances` is a list of probabilities for the animations to "
+"spawn, up to `SmallFireCount` amount of items are read. Last item listed "
+"is used if count exceeds the number of listed probabilities. Defaults to "
+"`1.0,0.5` for `Flamer=true`, `1.0` otherwise."
+msgstr ""
+"`SmallFireChances` 是一个用于动画生成的概率列表，最多读取前 `SmallFireCount` "
+"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `1.0,0.5`，否则为 "
+"`1.0`。"
+
+#: ../../Fixed-or-Improved-Logics.md:759
+msgid ""
+"`SmallFireDistances` is a list of distances in cells for the animations "
+"to spawn at from the parent animation's coordinates, up to "
+"`SmallFireCount` amount of items are read. Last item listed is used if "
+"count exceeds the number of listed probabilities. Defaults to "
+"`0.25,0.625` for `Flamer=true`, `0.0` otherwise."
+msgstr ""
+"`SmallFireDistances` 是一个用于动画相对父动画坐标生成位置单元格距离的列表，最多读取前 `SmallFireCount` "
+"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。对于 `Flamer=true` 默认为 `0.25,0.625`，否则为 "
+"`0.0`。"
+
+#: ../../Fixed-or-Improved-Logics.md:760
+msgid ""
+"`LargeFireCount` determines number of large fire animations to spawn by "
+"`Flamer=true` animations only."
+msgstr "`LargeFireCount` 决定仅由 `Flamer=true` 动画生成的大火焰动画的数量。"
+
+#: ../../Fixed-or-Improved-Logics.md:761
+msgid ""
+"`LargeFireAnims` can be used to set the animation types, defaults to "
+"`[AudioVisual] -> LargeFire` (single animation)."
+msgstr "`LargeFireAnims` 可以用于设置动画类型，默认为 `[AudioVisual] -> LargeFire`（单个动画）。"
+
+#: ../../Fixed-or-Improved-Logics.md:762
+msgid ""
+"`LargeFireChances` is a list of probabilities for the animations to "
+"spawn, up to `LargeFireCount` amount of items are read. Last item listed "
+"is used if count exceeds the number of listed probabilities."
+msgstr ""
+"`LargeFireChances` 是一个用于动画生成的概率列表，最多读取前 `LargeFireCount` "
+"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
+
+#: ../../Fixed-or-Improved-Logics.md:763
+msgid ""
+"`LargeFireDistances` is a list of distances in cells for the animations "
+"to spawn at from the parent animation's coordinates, up to "
+"`LargeFireCount` amount of items are read. Last item listed is used if "
+"count exceeds the number of listed probabilities."
+msgstr ""
+"`SmallFireDistances` 是一个用于动画相对父动画坐标生成位置单元格距离的列表，最多读取前 `LargeFireCount` "
+"数量的项。如果计数超出列出的概率数量则超出部分使用最后一个列出的概率。"
+
+#: ../../Fixed-or-Improved-Logics.md:766
+msgid ""
+"[SOMEANIM]                          ; AnimationType\n"
+"ConstrainFireAnimsToCellSpots=true  ; boolean\n"
+"FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | "
+"road | water | rock | wall | tiberium | beach | rough | ice | railroad | "
+"tunnel | weeds)\n"
+"AttachFireAnimsToParent=            ; boolean\n"
+"SmallFireCount=                     ; integer\n"
+"SmallFireAnims=                     ; List of AnimationTypes\n"
+"SmallFireChances=                   ; List of floating point values "
+"(percent or absolute)\n"
+"SmallFireDistances=                 ; List of floating point values, "
+"distance in cells\n"
+"LargeFireCount=1                    ; integer\n"
+"LargeFireAnims=                     ; List of AnimationTypes\n"
+"LargeFireChances=0.5                ; List of floating point values "
+"(percent or absolute)\n"
+"LargeFireDistances=0.4375           ; List of floating point values, "
+"distance in cells\n"
+msgstr ""
+"[SOMEANIM]                          ; AnimationType\n"
+"ConstrainFireAnimsToCellSpots=true  ; boolean\n"
+"FireAnimDisallowedLandTypes=        ; List of LandTypes (none | clear | "
+"road | water | rock | wall | tiberium | beach | rough | ice | railroad | "
+"tunnel | weeds)\n"
+"AttachFireAnimsToParent=            ; boolean\n"
+"SmallFireCount=                     ; integer\n"
+"SmallFireAnims=                     ; List of AnimationTypes\n"
+"SmallFireChances=                   ; List of floating point values "
+"(percent or absolute)\n"
+"SmallFireDistances=                 ; List of floating point values, "
+"distance in cells\n"
+"LargeFireCount=1                    ; integer\n"
+"LargeFireAnims=                     ; List of AnimationTypes\n"
+"LargeFireChances=0.5                ; List of floating point values "
+"(percent or absolute)\n"
+"LargeFireDistances=0.4375           ; List of floating point values, "
+"distance in cells\n"
+
+#: ../../Fixed-or-Improved-Logics.md:782
+msgid ""
+"Save for the change that `Flamer` does not spawn animations if the parent"
+" animation is in air, the default settings should provide identical "
+"results to similar feature from Ares."
+msgstr "除了 `Flamer` 在父动画位于空中时不生成这一更改外，默认设置应该与 Ares 中类似功能拥有相同的效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:785
+msgid "Layer on animations attached to objects"
+msgstr "附加动画的图层"
+
+#: ../../Fixed-or-Improved-Logics.md:787
+msgid ""
+"You can now customize whether or not animations attached to objects "
+"follow the object's layer or respect their own `Layer` setting. If this "
+"is unset, attached animations use `ground` layer."
+msgstr "现在你可以自定义让附加于对象的动画跟随对象的图层还是遵循它们自身的 `Layer` 设置。如果不设置，附加的动画会使用 `ground` 图层。"
+
+#: ../../Fixed-or-Improved-Logics.md:790
+msgid ""
+"[SOMEANIM]             ; AnimationType\n"
+"Layer.UseObjectLayer=  ; boolean\n"
+msgstr ""
+"[SOMEANIM]             ; AnimationType\n"
+"Layer.UseObjectLayer=  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:795
+msgid "Ore stage threshold for `HideIfNoOre`"
+msgstr "`HideIfNoOre` 的矿石阶段阈值"
+
+#: ../../Fixed-or-Improved-Logics.md:797
+msgid ""
+"You can now customize which growth stage should an ore/tiberium cell have"
+" to have animation with `HideIfNoOre` displayed. Cells with growth stage "
+"less than specified value won't allow the anim to display."
+msgstr ""
+"现在你可以自定义一个矿石／泰伯利亚所在的单元格至少需要到哪个生长阶段才能显示带有 `HideIfNoOre` "
+"的动画。生长阶段低于指定值的单元格将不允许动画显示。"
+
+#: ../../Fixed-or-Improved-Logics.md:800
+msgid ""
+"[SOMEANIM]               ; AnimationType\n"
+"HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
+msgstr ""
+"[SOMEANIM]               ; AnimationType\n"
+"HideIfNoOre.Threshold=0  ; integer, minimal ore growth stage\n"
+
+#: ../../Fixed-or-Improved-Logics.md:805
+msgid "Buildings"
+msgstr "建筑类型"
+
+#: ../../Fixed-or-Improved-Logics.md:807
+msgid "AI base construction modification"
+msgstr "AI 基地建设机制更改"
+
+#: ../../Fixed-or-Improved-Logics.md:809
+msgid "AI can now have some new behaviors."
+msgstr "现在 AI 可以执行一些新的行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:810
+msgid ""
+"`AIAutoDeployMCV` controls whether AI will still automatically deploy the"
+" mcv after owning a construction yard."
+msgstr "`AIAutoDeployMCV` 控制 AI 在拥有建造厂后是否仍然会自动部署 MCV。"
+
+#: ../../Fixed-or-Improved-Logics.md:811
+msgid ""
+"`AISetBaseCenter` controls whether AI will still set the newly deployed "
+"construction yard as the base center after owning a construction yard."
+msgstr "`AISetBaseCenter` 控制 AI 在拥有建造厂后是否仍会将新部署的建造厂设为基地中心。"
+
+#: ../../Fixed-or-Improved-Logics.md:812
+msgid ""
+"`AIBiasSpawnCell` controls whether AI will preferentially select the "
+"construction yard close to the birth point as the base center (useless in"
+" campaign)."
+msgstr "`AIBiasSpawnCell` 控制 AI 是否优先选择靠近出生点的建造厂作为基地中心（战役模式无效）。"
+
+#: ../../Fixed-or-Improved-Logics.md:813
+msgid ""
+"`AIForbidConYard` controls whether AI cannot place buildings with "
+"`ConstructionYard=true`. AI will try to build one after a construction "
+"yard is destroyed but will not put it down. After that, it will continue "
+"to build other buildings. Building a construction yard will still take "
+"some time. You can try to reduce the build time of it."
+msgstr ""
+"`AIForbidConYard` 控制 AI 是否禁止摆放拥有 `ConstructionYard=true` 的建筑。当建造厂被摧毁后 AI "
+"会尝试重建但不会实际摆放。随后它会继续建造其他建筑。建造厂的建造仍会占用时间。你可以尝试缩短它的建造所需时长。"
+
+#: ../../Fixed-or-Improved-Logics.md:814
+msgid ""
+"`AINodeWallsOnly` controls whether AI can only automatically connect "
+"adjacent walls when there are wall base nodes around."
+msgstr "`AINodeWallsOnly` 控制 AI 是否仅在周围存在围墙节点时才自动连接相邻围墙。"
+
+#: ../../Fixed-or-Improved-Logics.md:815
+msgid ""
+"`AICleanWallNode` controls whether AI cannot place walls when there are "
+"no `ProtectWithWall` buildings around. If it cannot be placed, this base "
+"node will also be removed."
+msgstr ""
+"`AICleanWallNode` 控制 AI 是否在周边都是无 `ProtectWithWall` "
+"的建筑时禁止摆放围墙。若无法摆放，该基地节点将被一同移除。"
+
+#: ../../Fixed-or-Improved-Logics.md:818
+msgid ""
+"[AI]\n"
+"AIAutoDeployMCV=true   ; boolean\n"
+"AISetBaseCenter=true   ; boolean\n"
+"AIBiasSpawnCell=false  ; boolean\n"
+"AIForbidConYard=false  ; boolean\n"
+"AINodeWallsOnly=false  ; boolean\n"
+"AICleanWallNode=false  ; boolean\n"
+msgstr ""
+"[AI]\n"
+"AIAutoDeployMCV=true   ; boolean\n"
+"AISetBaseCenter=true   ; boolean\n"
+"AIBiasSpawnCell=false  ; boolean\n"
+"AIForbidConYard=false  ; boolean\n"
+"AINodeWallsOnly=false  ; boolean\n"
+"AICleanWallNode=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:828
+msgid "Aircraft docking direction"
+msgstr "战机停靠方向"
+
+#: ../../Fixed-or-Improved-Logics.md:830
+msgid ""
+"It is now possible to customize the landing direction for docking "
+"aircraft via `AircraftDockingDir(N)` (`N` optionally replaced by 0-based "
+"index for each `DockingOffset` separately, `AircraftDockingDir` and "
+"`AircraftDockingDir0` are synonymous and will be used if direction is not"
+" set for a specific offset) on the dock building. This overrides the "
+"aircraft's own [landing direction](#landing-direction) setting and "
+"defaults to `[AudioVisual] -> PoseDir`."
+msgstr ""
+"现在可以通过在停靠建筑上使用 `AircraftDockingDir(N)` （`N` 可选地分别替换为每个从 0 开始的 "
+"`DockingOffset` 索引，`AircraftDockingDir` 与 `AircraftDockingDir0` "
+"是没有为特定偏移设置方向时将使用的同义词）来设置停靠战机的降落方向。这会覆盖战机自己的 [降落方向](#landing-direction) "
+"设置并默认为 `[AudioVisual] -> PoseDir`。"
+
+#: ../../Fixed-or-Improved-Logics.md:833
+msgid ""
+"[SOMEBUILDING]          ; BuildingType\n"
+"AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
+msgstr ""
+"[SOMEBUILDING]          ; BuildingType\n"
+"AircraftDockingDir(N)=  ; Direction type (integers from 0-255)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:838
+msgid "Allows refineries to use multiple ActiveAnim simultaneously"
+msgstr "允许矿场同时播放多个 `ActiveAnim` 动画"
+
+#: ../../Fixed-or-Improved-Logics.md:840
+msgid ""
+"In vanilla, the refinery uses different ActiveAnims depending on the "
+"storage. You can now make it use multiple ActiveAnims simultaneously like"
+" any other building."
+msgstr "在原版中矿场会根据其矿石存储量的不同播放不同的 `ActiveAnim`。现在你可以让它像其他建筑一样同时播放多个 `ActiveAnim`。"
+
+#: ../../Fixed-or-Improved-Logics.md:843
+msgid ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"Refinery.UseNormalActiveAnim=false     ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"Refinery.UseNormalActiveAnim=false     ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:848
+msgid "Allowed / disallowed types for FactoryPlant"
+msgstr "工业工厂的类型限制"
+
+#: ../../Fixed-or-Improved-Logics.md:850
+msgid ""
+"It is now possible to customize which TechnoTypes benefit from bonuses of"
+" a `FactoryPlant=true` building by listing them on "
+"`FactoryPlant.AllowTypes` and/or `FactoryPlant.DisallowTypes`."
+msgstr ""
+"现在可以通过在 `FactoryPlant.AllowTypes` 和 `FactoryPlant.DisallowTypes` "
+"中列出有哪些科技类型受到 `FactoryPlant=true` 建筑的加成。"
+
+#: ../../Fixed-or-Improved-Logics.md:851
+msgid ""
+"`FactoryPlant.Multiplier` *(Ares feature)* is still applied on the "
+"bonuses if they are in effect."
+msgstr "`FactoryPlant.Multiplier`（*Ares 功能*）仍然会应用于加成。"
+
+#: ../../Fixed-or-Improved-Logics.md:854
+msgid ""
+"[SOMEBUILDING]               ; BuildingType\n"
+"FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
+"FactoryPlant.DisallowTypes=  ; List of TechnoTypes\n"
+msgstr ""
+"[SOMEBUILDING]               ; BuildingType\n"
+"FactoryPlant.AllowTypes=     ; List of TechnoTypes\n"
+"FactoryPlant.DisallowTypes=  ; List of TechnoTypes\n"
+
+#: ../../Fixed-or-Improved-Logics.md:860
+msgid "Apply ZShapePointMove during buildups"
+msgstr "在拔起期间应用 ZShapePointMove"
+
+#: ../../Fixed-or-Improved-Logics.md:862
+msgid ""
+"By default buildings do not apply `ZShapePointMove` (which offsets the 'z"
+" shape' applied on buildings which is used to adjust them in depth buffer"
+" and is used to fix issues related to that such as corners of buildings "
+"getting cut off when drawn) when buildup is being displayed. This "
+"behaviour can now be toggled by setting `ZShapePointMove.OnBuildup`."
+msgstr ""
+"默认情况下建筑物在播放建造动画时并不应用 `ZShapePointMove`（这会调整应用于建筑物的 z shape "
+"以在深度缓冲区中调整它们并用于修复与此相关的例如建筑缺角等问题）。现在可以通过设置 `ZShapePointMove.OnBuildup` "
+"来开关此行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:865
+msgid ""
+"[SOMEBUILDING]                   ; BuildingType\n"
+"ZShapePointMove.OnBuildup=false  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]                   ; BuildingType\n"
+"ZShapePointMove.OnBuildup=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:870
+msgid "Buildings considered as vehicles"
+msgstr "被视为载具的建筑"
+
+#: ../../Fixed-or-Improved-Logics.md:872
+msgid ""
+"By default game considers buildings with both `UndeploysInto` set and "
+"`Foundation` equaling `1x1` as vehicles, in a manner of speaking. This "
+"behaviour can now be toggled individually of these conditions by setting "
+"`ConsideredVehicle`. These buildings are counted as vehicles for unit "
+"count tracking, are not considered as base under attack when damaged and "
+"can be mass selected by default, for an example."
+msgstr ""
+"总的来说默认情况下游戏将同时设置了 `UndeploysInto` 且 `Foundation=1x1` 的建筑视为载具。现在可以通过设置 "
+"`ConsideredVehicle` 来开关此行为。这些建筑在单位计数追踪中被视为载具，受损时不会被视为基地受到攻击，并且默认可以进行批量选择。"
+
+#: ../../Fixed-or-Improved-Logics.md:873
+msgid ""
+"When capturing such \"buildings\", the player won't be notified by EVA "
+"capture event."
+msgstr "当占领此类 “建筑” 时，玩家不会收到 EVA 占领事件的播报。"
+
+#: ../../Fixed-or-Improved-Logics.md:876
+msgid ""
+"[SOMEBUILDING]      ; BuildingType\n"
+"ConsideredVehicle=  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]      ; BuildingType\n"
+"ConsideredVehicle=  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:881
+msgid "Custom exit cell for infantry factory"
+msgstr "兵营自定义出口"
+
+#: ../../Fixed-or-Improved-Logics.md:883
+msgid ""
+"By default `Factory=InfantryType` buildings use exit cell for the created"
+" infantry based on hardcoded settings if any of `GDIBarracks`, "
+"`NODBarracks` or `YuriBarracks` are set to true. It is now possible to "
+"define arbitrary exit cell for such building via `BarracksExitCell`. "
+"Below is a reference of the cell offsets for the hardcoded values."
+msgstr ""
+"默认情况下如果 `GDIBarracks`、`NODBarracks` 或 `YuriBarracks` 中的任何一个设置为 true，则 "
+"`Factory=InfantryType` 的建筑将会根据硬编码设置为创建的步兵设置出口单元格。现在可以通过 "
+"`BarracksExitCell` 为这类建筑定义任意单元格为出口。以下是硬编码值的单元格偏移量参考值。"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "Key"
+msgstr "标签"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "Cell Offset"
+msgstr "单元格偏移"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "`GDIBarracks`"
+msgstr "`GDIBarracks`"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "1,2"
+msgstr "1,2"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "`NODBarracks`"
+msgstr "`NODBarracks`"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "2,2"
+msgstr "2,2"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "`YuriBarracks`"
+msgstr "`YuriBarracks`"
+
+#: ../../Fixed-or-Improved-Logics.md:781
+msgid "2,1"
+msgstr "2,1"
+
+#: ../../Fixed-or-Improved-Logics.md:892
+msgid ""
+"[SOMEBUILDING]     ; BuildingType\n"
+"BarracksExitCell=  ; X,Y - cell offset\n"
+msgstr ""
+"[SOMEBUILDING]     ; BuildingType\n"
+"BarracksExitCell=  ; X,Y - cell offset\n"
+
+#: ../../Fixed-or-Improved-Logics.md:897
+msgid "Customizable garrison and bunker properties"
+msgstr "自定义驻军建筑与坦克碉堡属性"
+
+#: ../../Fixed-or-Improved-Logics.md:899
+msgid ""
+"You can now customize damage or ROF multipliers of a garrison or tank "
+"bunker building."
+msgstr "现在可以自定义驻军建筑或坦克堡垒的 Damage 或 ROF 倍率。"
+
+#: ../../Fixed-or-Improved-Logics.md:900
+msgid "You can now customize enter or exit sound of a tank bunker building."
+msgstr "现在可以自定义坦克碉堡建筑进入和离开时的音效。"
+
+#: ../../Fixed-or-Improved-Logics.md:903
+msgid ""
+"[SOMEBUILDING]              ; BuildingType\n"
+"OccupyDamageMultiplier=     ; floating point value, default to "
+"[CombatDamage] -> OccupyDamageMultiplier\n"
+"OccupyROFMultiplier=        ; floating point value, default to "
+"[CombatDamage] -> OccupyROFMultiplier\n"
+"BunkerDamageMultiplier=     ; floating point value, default to "
+"[CombatDamage] -> BunkerDamageMultiplier\n"
+"BunkerROFMultMultiplier=    ; floating point value, default to "
+"[CombatDamage] -> BunkerROFMultMultiplier\n"
+"BunkerWallsUpSound=         ; Sound entry, default to [AudioVisual] -> "
+"BunkerWallsUpSound\n"
+"BunkerWallsDownSound=       ; Sound entry, default to [AudioVisual] -> "
+"BunkerWallsDownSound\n"
+msgstr ""
+"[SOMEBUILDING]              ; BuildingType\n"
+"OccupyDamageMultiplier=     ; floating point value, default to "
+"[CombatDamage] -> OccupyDamageMultiplier\n"
+"OccupyROFMultiplier=        ; floating point value, default to "
+"[CombatDamage] -> OccupyROFMultiplier\n"
+"BunkerDamageMultiplier=     ; floating point value, default to "
+"[CombatDamage] -> BunkerDamageMultiplier\n"
+"BunkerROFMultMultiplier=    ; floating point value, default to "
+"[CombatDamage] -> BunkerROFMultMultiplier\n"
+"BunkerWallsUpSound=         ; Sound entry, default to [AudioVisual] -> "
+"BunkerWallsUpSound\n"
+"BunkerWallsDownSound=       ; Sound entry, default to [AudioVisual] -> "
+"BunkerWallsDownSound\n"
+
+#: ../../Fixed-or-Improved-Logics.md:913
+msgid ""
+"Customizable selling buildup sequence length for buildings that can "
+"undeploy"
+msgstr "自定义可反部署建筑出售序列动画长度"
+
+#: ../../Fixed-or-Improved-Logics.md:915
+msgid ""
+"By default buildings with `UndeploysInto` will only play 23 frames of "
+"their buildup sequence (in reverse starting from last frame) when being "
+"sold as opposed to being undeployed. This can now be customized via "
+"`SellBuildupLength`."
+msgstr ""
+"默认情况下拥有 `UndeploysInto` 的建筑在出售时只会播放其建造动画序列的前 23 帧（从最后一帧开始反向播放）。现在可以通过 "
+"`SellBuildupLength` 自定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:918
+msgid ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"SellBuildupLength=23  ; integer, number of buildup frames to play\n"
+msgstr ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"SellBuildupLength=23  ; integer, number of buildup frames to play\n"
+
+#: ../../Fixed-or-Improved-Logics.md:923
+msgid "Customizable & new grinder properties"
+msgstr "自定义 & 新的部队回收站特性"
+
+#: ../../Fixed-or-Improved-Logics.md:925
+msgid ""
+"![image](_static/images/grinding.gif) *Using ally grinder, restricting to"
+" vehicles only and refund display ([Project "
+"Phantom](https://www.moddb.com/mods/project-phantom))*"
+msgstr ""
+"![image](_static/images/grinding.gif) *[幽灵计划](https://www.moddb.com/mods"
+"/project-phantom) 中使用友军的部队回收站、仅限载具以及显示资金*"
+
+#: ../../Fixed-or-Improved-Logics.md:928
+msgid ""
+"You can now customize which types of objects a building with `Grinding` "
+"set can grind as well as the grinding sound."
+msgstr "现在你可以自定义具有 `Grinding` 设置的建筑可回收的对象类别以及回收使用的音效。"
+
+#: ../../Fixed-or-Improved-Logics.md:929
+msgid ""
+"`Grinding.AllowAllies` changes whether or not to allow units to enter "
+"allies' buildings."
+msgstr "`Grinding.AllowAllies` 决定是否允许单位进入友军的这座建筑。"
+
+#: ../../Fixed-or-Improved-Logics.md:930
+msgid ""
+"`Grinding.AllowOwner` changes whether or not to allow units to enter your"
+" own buildings."
+msgstr "`Grinding.AllowOwner` 决定是否允许单位进入己方的这座建筑。"
+
+#: ../../Fixed-or-Improved-Logics.md:931
+msgid ""
+"`Grinding.AllowTypes` can be used to define InfantryTypes and "
+"VehicleTypes that can be grinded by the building. Listing any will "
+"disable grinding for all types except those listed."
+msgstr "`Grinding.AllowTypes` 可以用于定义可以被这座建筑回收的步兵和载具。只要设置列表就会导致其他不在表中的任何类型无法被回收。"
+
+#: ../../Fixed-or-Improved-Logics.md:932
+msgid ""
+"`Grinding.DisallowTypes` can be used to exclude InfantryTypes or "
+"VehicleTypes from being able to enter the grinder building."
+msgstr "`Grinding.DisallowTypes` 可以定义不可被这座建筑回收的步兵和载具。"
+
+#: ../../Fixed-or-Improved-Logics.md:933
+msgid ""
+"`Grinding.PlayDieSound` controls if the units' `DieSound` and `VoiceDie` "
+"are played when entering the grinder."
+msgstr "`Grinding.PlayDieSound` 控制单位的 `DieSound` 和 `VoiceDie` 是否都会在进入回收站时播放。"
+
+#: ../../Fixed-or-Improved-Logics.md:934
+msgid ""
+"`Grinding.Sound` is a sound played by when object is grinded by the "
+"building."
+msgstr "`Grinding.Sound` 用于定义物体被这座建筑回收时所播放的音效。"
+
+#: ../../Fixed-or-Improved-Logics.md:935
+msgid ""
+"`Grinding.Weapon` is a weapon fired at the building & by the building "
+"when it grinds an object. Will only be fired if at least weapon's `ROF` "
+"amount of frames have passed since it was last fired."
+msgstr ""
+"`Grinding.Weapon` 用于定义当建筑回收物体时由建筑向该建筑发射的武器。只有在其上次开火以来至少经过了武器 `ROF` "
+"设置的帧数后才能被发射。"
+
+#: ../../Fixed-or-Improved-Logics.md:936
+msgid ""
+"`Grinding.Weapon.RequiredCredits` can be set to have the weapon require "
+"accumulated credits from grinding to fire. Accumulated credits for this "
+"purpose are reset every time when the weapon fires."
+msgstr "`Grinding.Weapon.RequiredCredits` 可以设置武器开火所需的资金。为此目的积累的资金会在每次武器开火时重置。"
+
+#: ../../Fixed-or-Improved-Logics.md:937
+msgid ""
+"For money string indication upon grinding, please refer to "
+"[`DisplayIncome`](User-Interface.md#visual-indication-of-income-from-"
+"grinders-and-refineries)."
+msgstr ""
+"关于回收时的资金字符串提示，请参考 [`DisplayIncome`](User-Interface.md#visual-indication-"
+"of-income-from-grinders-and-refineries)。"
+
+#: ../../Fixed-or-Improved-Logics.md:940
+msgid ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"Grinding.AllowAllies=false         ; boolean\n"
+"Grinding.AllowOwner=true           ; boolean\n"
+"Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes"
+"\n"
+"Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes"
+"\n"
+"Grinding.PlayDieSound=true         ; boolean\n"
+"Grinding.Sound=                    ; Sound entry, default to "
+"[AudioVisual] -> EnterGrinderSound\n"
+"Grinding.Weapon=                   ; WeaponType\n"
+"Grinding.Weapon.RequiredCredits=0  ; integer\n"
+msgstr ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"Grinding.AllowAllies=false         ; boolean\n"
+"Grinding.AllowOwner=true           ; boolean\n"
+"Grinding.AllowTypes=               ; List of InfantryTypes / VehicleTypes"
+"\n"
+"Grinding.DisallowTypes=            ; List of InfantryTypes / VehicleTypes"
+"\n"
+"Grinding.PlayDieSound=true         ; boolean\n"
+"Grinding.Sound=                    ; Sound entry, default to "
+"[AudioVisual] -> EnterGrinderSound\n"
+"Grinding.Weapon=                   ; WeaponType\n"
+"Grinding.Weapon.RequiredCredits=0  ; integer\n"
+
+#: ../../Fixed-or-Improved-Logics.md:952
+msgid "Customize overpower logic"
+msgstr "自定义磁暴线圈充能"
+
+#: ../../Fixed-or-Improved-Logics.md:954
+msgid "Now you can specific how building can be overpowerd."
+msgstr "现在你可以设定建筑什么情形下才会过载。"
+
+#: ../../Fixed-or-Improved-Logics.md:957
+msgid ""
+"[SOMEWARHEAD]             ; WarheadType\n"
+"ElectricAssaultLevel=1    ; integer\n"
+"\n"
+"[SOMEBUILDING]            ; BuildingType\n"
+"Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
+"keep online\n"
+"Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
+"can never be switched\n"
+msgstr ""
+"[SOMEWARHEAD]             ; WarheadType\n"
+"ElectricAssaultLevel=1    ; integer\n"
+"\n"
+"[SOMEBUILDING]            ; BuildingType\n"
+"Overpower.KeepOnline=2    ; integer, negative values mean that cannot "
+"keep online\n"
+"Overpower.ChargeWeapon=1  ; integer, negative values mean that weapons "
+"can never be switched\n"
+
+#: ../../Fixed-or-Improved-Logics.md:967
+msgid ""
+"Ares' [Battery Super Weapon](https://ares-developers.github.io/Ares-"
+"docs/new/superweapons/types/battery.html) won't be affected by this."
+msgstr ""
+"Ares 的 [电池超武](https://ares-developers.github.io/Ares-"
+"docs/new/superweapons/types/battery.html) 不受此影响。"
+
+#: ../../Fixed-or-Improved-Logics.md:970
+msgid "Disable `DamageSound`"
+msgstr "禁用 `DamageSound`"
+
+#: ../../Fixed-or-Improved-Logics.md:972
+msgid "Now you can disable `DamageSound` of a building."
+msgstr "现在你可以禁用一个建筑的 `DamageSound`。"
+
+#: ../../Fixed-or-Improved-Logics.md:975
+msgid ""
+"[SOMEBUILDING]            ; BuildingType\n"
+"DisableDamageSound=false  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]            ; BuildingType\n"
+"DisableDamageSound=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:980
+msgid "Exclude Factory from providing multiple factory bonus"
+msgstr "排除特定工厂的多工厂加成"
+
+#: ../../Fixed-or-Improved-Logics.md:982
+msgid ""
+"It is now possible to exclude a building with `Factory` from counting "
+"towards `MultipleFactory` bonus."
+msgstr "现在可以将某个具有 `Factory` 的建筑排除在 `MultipleFactory` 之外"
+
+#: ../../Fixed-or-Improved-Logics.md:985
+msgid ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]                         ; BuildingType\n"
+"ExcludeFromMultipleFactoryBonus=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:990
+msgid "Power plant damage factor"
+msgstr "伤残电厂电量系数"
+
+#: ../../Fixed-or-Improved-Logics.md:992
+msgid ""
+"It is possible to customize the power decrement of a power plant when "
+"it's damaged. The actual power output for this plant will be: `Power` "
+"minuses the product of original power decrement and "
+"`Powerplant.DamageFactor`. Can't reduce power output lower than 0."
+msgstr ""
+"现在可以自定义电厂血量与发电功率的关系。`Power * PowerPlant.DamageFactor` 相当于电厂血量无限接近于 0 "
+"时损失的发电量，即 `损失发电量 = [1 - (当前血量 / 最大血量)] * PowerPlant.DamageFactor * "
+"Power=`；发电功率无法低于 0。"
+
+#: ../../Fixed-or-Improved-Logics.md:993
+msgid ""
+"Specifically, if the factor is set to 0.0, power output won't be "
+"decreased by losing health for this power plant."
+msgstr "具体来说，如果该系数设为 0.0，则电厂的发电功率不受血量影响。"
+
+#: ../../Fixed-or-Improved-Logics.md:996
+msgid ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"PowerPlant.DamageFactor=1.0        ; floating point value\n"
+msgstr ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"PowerPlant.DamageFactor=1.0        ; floating point value\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1001
+msgid "Skip anim delay for burst fire"
+msgstr "跳过 `DelayedFireDelay`"
+
+#: ../../Fixed-or-Improved-Logics.md:1003
+msgid ""
+"In Red Alert 1, the tesla coil will attack multiple times after charging "
+"animation. This is not possible in Red Alert 2, where the building must "
+"play the charge animation every time it fires."
+msgstr "《红色警戒 1》中的磁暴线圈会在充能后多次攻击。这在《红色警戒 2》中是不可能的，因为建筑必须每次发射时都播放充能动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:1004
+msgid "Now you can implement the above logic using the following flag."
+msgstr "现在你可以使用下面的标签实现上述逻辑。"
+
+#: ../../Fixed-or-Improved-Logics.md:1007
+msgid ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"IsAnimDelayedBurst=true            ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]                     ; BuildingType\n"
+"IsAnimDelayedBurst=true            ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1013
+msgid ""
+"The prism towers' fire is hardcoded to be delayed. Their fire will ignore"
+" this flag, just as they ignore `IsAnimDelayedFire`."
+msgstr "光棱塔开火硬编码延迟。就像无视 `IsAnimDelayedFire` 那样，它们同样无视该语句。"
+
+#: ../../Fixed-or-Improved-Logics.md:1016
+msgid "Unit repair customization"
+msgstr "在建筑上自定义单位维修参数"
+
+#: ../../Fixed-or-Improved-Logics.md:1018
+msgid ""
+"It is now possible to customize the repairing of units by "
+"`UnitRepair=true`, `UnitReload=true` and `Hospital=true` buildings."
+msgstr ""
+"现在可以通过 `UnitRepair=true`、`UnitReload=true` 和 `Hospital=true` "
+"的建筑来自定义单位的维修参数。"
+
+#: ../../Fixed-or-Improved-Logics.md:1019
+msgid ""
+"`Units.RepairRate` customizes the rate at which the units are repaired. "
+"This defaults to `[General] -> ReloadRate` if `UnitReload=true` and if "
+"overridden per AircraftType *(Ares feature)* can tick at different time "
+"for each docked aircraft. Setting this overrides that behaviour. For "
+"`UnitRepair=true` buildings this defaults to `[General] -> URepairRate`."
+msgstr ""
+"`Units.RepairRate` 自定义单位的维修速度。如果 `UnitReload=true` 那么默认为 `[General] -> "
+"ReloadRate` 并覆盖每个战机类型独立的时间设置（*Ares 功能*）。对于 `UnitRepair=true` 的建筑则默认为 "
+"`[General] -> URepairRate`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1020
+msgid ""
+"On `UnitReload=true` building setting this to negative value will fully "
+"disable the repair functionality."
+msgstr "在 `UnitReload=true` 的建筑上将此值设置为负数将完全禁用维修功能。"
+
+#: ../../Fixed-or-Improved-Logics.md:1021
+msgid "`Units.RepairStep` how much `Strength` is restored per repair tick."
+msgstr "`Units.RepairStep` 设置每次维修时恢复多少点 `Strength`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1022
+msgid ""
+"`Units.RepairPercent` is a multiplier to cost of repairing (cost / "
+"(maximum health / repair step)). Note that the final cost is set to 1 if "
+"it is less than that."
+msgstr ""
+"`Units.RepairPercent` "
+"是维修成本的倍率［`Cost`/(`Strength`/`RepairStep`)］。注意如果最终的成本低于 1 那么会设为 1。"
+
+#: ../../Fixed-or-Improved-Logics.md:1023
+msgid ""
+"`Units.UseRepairCost` can be used to customize if repair cost is applied "
+"at all. Defaults to false for infantry, true for everything else."
+msgstr "`Units.UseRepairCost` 可以用于自定义是否使用维修成本。步兵默认为 false，其他默认为 true。"
+
+#: ../../Fixed-or-Improved-Logics.md:1026
+msgid ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"Units.RepairRate=     ; floating point value, ingame minutes\n"
+"Units.RepairStep=     ; integer, default to [General] -> RepairStep\n"
+"Units.RepairPercent=  ; floating point value, percents or absolute, "
+"default to [General] -> RepairPercent\n"
+"Units.UseRepairCost=  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"Units.RepairRate=     ; floating point value, ingame minutes\n"
+"Units.RepairStep=     ; integer, default to [General] -> RepairStep\n"
+"Units.RepairPercent=  ; floating point value, percents or absolute, "
+"default to [General] -> RepairPercent\n"
+"Units.UseRepairCost=  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1034
+msgid "Waypoints for buildings"
+msgstr "建筑路径点"
+
+#: ../../Fixed-or-Improved-Logics.md:1036
+msgid ""
+"In vanilla, buildings are forbidden to use waypoints. Now you can allow "
+"that using the following flag."
+msgstr "在原版中，建筑被禁止使用路径点。现在你可以使用以下标签来允许使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1039
+msgid ""
+"[General]\n"
+"BuildingWaypoints=false  ; boolean\n"
+msgstr ""
+"[General]\n"
+"BuildingWaypoints=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1044
+msgid "Customize if cloning need power"
+msgstr "自定义克隆耗电"
+
+#: ../../Fixed-or-Improved-Logics.md:1046
+msgid ""
+"In vanilla, cloning vats can work fine even low power. Starting from Ares"
+" 2.0, they need power to work. Now you can specific it."
+msgstr "在原版中，克隆缸即便没电也可以工作。从 Ares 2.0 开始，它们需要电力运作。现在你可以指定。"
+
+#: ../../Fixed-or-Improved-Logics.md:1049
+msgid ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"Cloning.Powered=true  ; boolean\n"
+msgstr ""
+"[SOMEBUILDING]        ; BuildingType\n"
+"Cloning.Powered=true  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1054
+msgid "Infantry"
+msgstr "步兵"
+
+#: ../../Fixed-or-Improved-Logics.md:1056
+msgid "Auto deploy for GI-like infantry"
+msgstr "GI 式步兵自动部署"
+
+#: ../../Fixed-or-Improved-Logics.md:1058
+msgid ""
+"In RA2, the GI-like infantry controlled by the AI will automatically "
+"deploy to use their more powerful secondary weapons when engaging the "
+"enemy. This feature was broken in Yuri's Revenge. Now you can use the "
+"following flags to re-enable this feature."
+msgstr ""
+"在《红色警戒2》中，由 AI "
+"控制的美国大兵在与敌人交战时会自动部署以使用火力更强的副武器。此特性在《尤里的复仇》中遭到破坏。现在你可以通过下面的开关语句重启这一特性。"
+
+#: ../../Fixed-or-Improved-Logics.md:1061
+msgid ""
+"[General]\n"
+"InfantryAutoDeploy=false      ; boolean\n"
+"\n"
+"[SOMEINFANTRY]                ; InfantryType\n"
+"InfantryAutoDeploy=           ; boolean, default to [General] -> "
+"InfantryAutoDeploy\n"
+msgstr ""
+"[General]\n"
+"InfantryAutoDeploy=false      ; boolean\n"
+"\n"
+"[SOMEINFANTRY]                ; InfantryType\n"
+"InfantryAutoDeploy=           ; boolean, default to [General] -> "
+"InfantryAutoDeploy\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1069
+msgid "Prone speed customization"
+msgstr "自定义匍匐速度"
+
+#: ../../Fixed-or-Improved-Logics.md:1071
+msgid "In vanilla, infantry has hardcoded prone speed. Now you can customize it."
+msgstr "原版中步兵匍匐前进的速度是硬编码的。现在你可以自由定义了。"
+
+#: ../../Fixed-or-Improved-Logics.md:1074
+msgid ""
+"[General]\n"
+"ProneSpeed.Crawls=0.67        ; floating point value, multiplier\n"
+"ProneSpeed.NoCrawls=1.5       ; floating point value, multiplier\n"
+"\n"
+"[SOMEINFANTRY]                ; InfantryType\n"
+"ProneSpeed=                   ; floating point value, multiplier, by "
+"default, use the corresponding global value according to Crawls\n"
+msgstr ""
+"[General]\n"
+"ProneSpeed.Crawls=0.67        ; floating point value, multiplier\n"
+"ProneSpeed.NoCrawls=1.5       ; floating point value, multiplier\n"
+"\n"
+"[SOMEINFANTRY]                ; InfantryType\n"
+"ProneSpeed=                   ; floating point value, multiplier, by "
+"default, use the corresponding global value according to Crawls\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1083
+msgid "Overlays"
+msgstr "覆盖物"
+
+#: ../../Fixed-or-Improved-Logics.md:1085
+msgid "Customize the chained damage of the wall"
+msgstr "自定义墙的连锁伤害"
+
+#: ../../Fixed-or-Improved-Logics.md:1087
+msgid ""
+"In vanilla, when the wall is damaged, it will deal 200 damage to the "
+"walls in the 4 nearby cells. This makes connected walls more vulnerable "
+"to damage compared to single walls."
+msgstr ""
+"原版中当围墙受到伤害时会对周围 4 个单元格内的墙体造成 200 "
+"点伤害。这使得相连的墙体比单独矗立的墙体更容易被损伤（这就是打完剩下的单格墙体更能抗伤的原因）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1088
+msgid "Now you can customize that damage by using the following flag."
+msgstr "现在你可以使用下面的标签自定义这个杀伤值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1091
+msgid ""
+"[CombatDamage]\n"
+"AdjacentWallDamage=200  ; integer\n"
+msgstr ""
+"[CombatDamage]\n"
+"AdjacentWallDamage=200  ; integer\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1096
+msgid "Particle systems"
+msgstr "粒子系统"
+
+#: ../../Fixed-or-Improved-Logics.md:1098
+msgid "Fire particle target coordinate adjustment when firer rotates"
+msgstr "开火者旋转时火焰粒子目标坐标调整"
+
+#: ../../Fixed-or-Improved-Logics.md:1100
+msgid ""
+"By default particle systems with `BehavesLike=Fire` shift their target "
+"coordinates if the object that created the particle system (e.g firer of "
+"a weapon) is rotating. This behavior can now be disabled per particle "
+"system type."
+msgstr ""
+"默认情况下拥有 `BehavesLike=Fire` "
+"的粒子系统会根据创建粒子系统的对象（例如武器的开火者）是否旋转来调整其坐标。现在可以为每个粒子系统禁用这一行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1103
+msgid ""
+"[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
+"AdjustTargetCoordsOnRotation=true  ; boolean\n"
+msgstr ""
+"[SOMEPARTICLESYSTEM]               ; ParticleSystemType\n"
+"AdjustTargetCoordsOnRotation=true  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1108
+msgid "Particles"
+msgstr "粒子"
+
+#: ../../Fixed-or-Improved-Logics.md:1110
+msgid "Customizable gas particle speed"
+msgstr "自定义 gas 粒子速度"
+
+#: ../../Fixed-or-Improved-Logics.md:1112
+msgid "Gas particles can now drift at a custom speed."
+msgstr "Gas 类的粒子现在可以自定义漂浮速度。"
+
+#: ../../Fixed-or-Improved-Logics.md:1115
+msgid ""
+"[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
+"Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
+msgstr ""
+"[GASPARTICLE]          ; Particle with BehavesLike=Gas\n"
+"Gas.MaxDriftSpeed=2    ; integer (TS default is 5)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1120
+msgid "Projectiles"
+msgstr "抛射体"
+
+#: ../../Fixed-or-Improved-Logics.md:1122
+msgid "Airburst & Splits"
+msgstr "空爆与分裂"
+
+#: ../../Fixed-or-Improved-Logics.md:1124
+msgid ""
+"`AirburstWeapon` logic has been reimplemented and thus there are several "
+"additions & changes to it."
+msgstr "`AirburstWeapon` 逻辑已被重新实现从而对其进行了一些添加和更改。"
+
+#: ../../Fixed-or-Improved-Logics.md:1125
+msgid ""
+"`Splits` can be set to true to use projectile splitting logic from "
+"Firestorm, with the number of split projectiles defined by `Cluster`."
+msgstr "`Splits` 可以设置为 true 以使用 《火风暴》 中的抛射体分裂逻辑，分裂抛射体的数量由 `Cluster` 决定。"
+
+#: ../../Fixed-or-Improved-Logics.md:1126
+msgid ""
+"`RetargetAccuracy` defines the probability that the splitted projectiles "
+"head to the same target as the original projectile."
+msgstr "`RetargetAccuracy` 决定了分裂抛射体与原抛射体瞄准同一目标的概率。"
+
+#: ../../Fixed-or-Improved-Logics.md:1127
+msgid ""
+"`RetargetSelf` determines if it is possible for the splitted projectiles "
+"to aim at the firer of the original projectile."
+msgstr "`RetargetSelf` 决定了分裂抛射体是否可以将原抛射体的发射者视为目标。"
+
+#: ../../Fixed-or-Improved-Logics.md:1128
+msgid ""
+"`RetargetSelf.Probability` is the probability that if the original firer "
+"is chosen as a target, it is kept as the target instead of rerolled to "
+"another."
+msgstr "`RetargetSelf.Probability` 是选择了原本的开火者为目标时它将保留其为目标而不是去重新随机另一个目标的概率。"
+
+#: ../../Fixed-or-Improved-Logics.md:1129
+msgid ""
+"`Splits.TargetingDistance` is the distance in cells that any potential "
+"target has to be within from the original target coordinates to be "
+"eligible for targeting by the splitted projectiles."
+msgstr "`Splits.TargetingDistance` 是以单元格为单位的距离，任何潜在目标都必须在原始目标坐标的这个范围内才能够被分裂的抛射体瞄准。"
+
+#: ../../Fixed-or-Improved-Logics.md:1130
+msgid ""
+"`Splits.TargetCellRange` is the distance in whole cells from the original"
+" target cell from which the splitted projectiles can pick new target "
+"cells if not enough TechnoType targets were found nearby."
+msgstr ""
+"`Splits.TargetCellRange` "
+"是以完整单元格数为单位的距离，用于附近没有发现足够的科技类型目标时分裂的抛射体从该范围选取新的目标单元格。"
+
+#: ../../Fixed-or-Improved-Logics.md:1131
+msgid ""
+"`Splits.UseWeaponTargeting`, if set to true, enables weapon targeting "
+"filter for when checking targets for splitted projectiles. Target's "
+"`LegalTarget` setting, Warhead `Verses` against `Armor` as well as "
+"`AirburstWeapon` [weapon targeting filters](New-or-Enhanced-Logics.md"
+"#weapon-targeting-filter) & [AttachEffect filters](New-or-Enhanced-"
+"Logics.md#attached-effects) will be checked."
+msgstr ""
+"`Splits.UseWeaponTargeting` 如果设为 true，则在检查分裂抛射体的目标时启用武器瞄准筛选。目标上的 "
+"`LegalTarget` 设置、弹头的 `Verses` 对 `Armor` 的设置以及 `AirburstWeapon` 所填武器的 "
+"[武器瞄准筛选](New-or-Enhanced-Logics.md#weapon-targeting-filter) 和 "
+"[AttachEffect 筛选](New-or-Enhanced-Logics.md#attached-effects) 都将被检查。"
+
+#: ../../Fixed-or-Improved-Logics.md:1132
+msgid ""
+"Do note that this overrides checking Warhead for "
+"`AffectsAllies/Owner/Enemies` for targeting. You can use "
+"`CanTargetHouses` on `AirburstWeapon` to achieve similar behaviour, "
+"however."
+msgstr ""
+"注意这会在瞄准时覆盖弹头对 `AffectsAllies/Owner/Enemies` 的检查。不过，你可以通过在 "
+"`AirburstWeapon` 设置的武器上使用 `CanTargetHouses` 来实现类似的行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1133
+msgid "Behaviour for if `Airburst` is set to true can also be customized."
+msgstr "如果将 `Airburst` 设为 true 其行为也同样可以自定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:1134
+msgid ""
+"`AirburstSpread` is the distance in cells that the effect covers, with "
+"each cell in range being targeted by `AirburstWeapon` by default."
+msgstr "`AirburstSpread` 是以单元格为单位的效果所覆盖范围，默认情况下范围内的每个单元格都会被 `AirburstWeapon` 瞄准。"
+
+#: ../../Fixed-or-Improved-Logics.md:1135
+msgid ""
+"`Airburst.UseCluster`, if set to true, makes it so that only number of "
+"cells in the affected area dictated by `Cluster` will be affected, "
+"instead of all of them."
+msgstr "`Airburst.UseCluster` 如果设为 true，则只有 `Cluster` 所指定数量的单元格会被影响，而不是所有单元格。"
+
+#: ../../Fixed-or-Improved-Logics.md:1136
+msgid ""
+"If `Airburst.RandomClusters` is set to true, the cells affected will be "
+"picked by random. Otherwise they will be evenly spaced (counting from "
+"center to edges of affected area)."
+msgstr "`Airburst.RandomClusters` 如果设为 true，则受影响的单元格将随机选取。否则它们将均匀分布（从受影响区域的中心到边缘）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1137
+msgid ""
+"`Airburst.TargetAsSource` can be used to override source or 'firing' "
+"coordinate to match that of the intended target instead of projectile's "
+"current position."
+msgstr ""
+"`Airburst.TargetAsSource` 可用于令空爆中心坐标跟随目标坐标而非使用抛射体当前位置。例如原先会在爆点生成根据 "
+"`[Projectile] -> AroundTarget` 决定飞向原点或目标位置，现在会直接以目标为中心爆开。"
+
+#: ../../Fixed-or-Improved-Logics.md:1138
+msgid ""
+"If `Airburst.TargetAsSource.SkipHeight` is also set, then projectile's "
+"current height will be used instead of target's height still."
+msgstr "如果还设置了 `Airburst.TargetAsSource.SkipHeight` 则仍然使用抛射体当前高度而非目标高度。"
+
+#: ../../Fixed-or-Improved-Logics.md:1139
+msgid ""
+"`AroundTarget` controls whether or not targets for projectiles created by"
+" `Airburst` or `Splits` are checked for in area around the original "
+"projectile's intended target, or where the original projectile detonated."
+" Defaults to value of `Splits`."
+msgstr ""
+"`AroundTarget` 控制由 `Airburst` 或 `Splits` "
+"创建的抛射体的目标是否在原抛射体目标周围的区域检查获取，否则从原抛射体爆炸的位置。默认为 `Splits` 值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1140
+msgid ""
+"`AirburstWeapon.ApplyFirepowerMult` determines whether or not firepower "
+"modifiers from the firer of the original projectile are applied on the "
+"projectiles created from `AirburstWeapon`."
+msgstr ""
+"`AirburstWeapon.ApplyFirepowerMult` 决定是否将原抛射体发射者的火力加成应用于由 "
+"`AirburstWeapon` 创建的抛射体。"
+
+#: ../../Fixed-or-Improved-Logics.md:1141
+msgid ""
+"`AirburstWeapon.SourceScatterMin` and `AirburstWeapon.SourceScatterMax` "
+"can be used to scatter the source or 'firing' coordinate around the "
+"original coordinate."
+msgstr ""
+"`AirburstWeapon.SourceScatterMin` 和 `AirburstWeapon.SourceScatterMax` "
+"可用于令空爆中心坐标产生散布。"
+
+#: ../../Fixed-or-Improved-Logics.md:1144
+msgid ""
+"[SOMEPROJECTILE]                          ; Projectile\n"
+"Splits=                                   ; boolean\n"
+"RetargetAccuracy=0.0                      ; floating point value, "
+"percents or absolute (0.0-1.0)\n"
+"RetargetSelf=true                         ; boolean\n"
+"RetargetSelf.Probability=0.5              ; floating point value, "
+"percents or absolute (0.0-1.0)\n"
+"Splits.TargetingDistance=5.0              ; floating point value, "
+"distance in cells\n"
+"Splits.TargetCellRange=3                  ; integer, cell offset\n"
+"Splits.UseWeaponTargeting=false           ; boolean\n"
+"AirburstSpread=1.5                        ; floating point value, "
+"distance in cells\n"
+"Airburst.UseCluster=false                 ; boolean\n"
+"Airburst.RandomClusters=false             ; boolean\n"
+"Airburst.TargetAsSource=false             ; boolean\n"
+"Airburst.TargetAsSource.SkipHeight=false  ; boolean\n"
+"AroundTarget=                             ; boolean\n"
+"AirburstWeapon.ApplyFirepowerMult=false   ; boolean\n"
+"AirburstWeapon.SourceScatterMin=0.0       ; floating point value, "
+"distance in cells\n"
+"AirburstWeapon.SourceScatterMax=0.0       ; floating point value, "
+"distance in cells\n"
+msgstr ""
+"[SOMEPROJECTILE]                          ; Projectile\n"
+"Splits=                                   ; boolean\n"
+"RetargetAccuracy=0.0                      ; floating point value, "
+"percents or absolute (0.0-1.0)\n"
+"RetargetSelf=true                         ; boolean\n"
+"RetargetSelf.Probability=0.5              ; floating point value, "
+"percents or absolute (0.0-1.0)\n"
+"Splits.TargetingDistance=5.0              ; floating point value, "
+"distance in cells\n"
+"Splits.TargetCellRange=3                  ; integer, cell offset\n"
+"Splits.UseWeaponTargeting=false           ; boolean\n"
+"AirburstSpread=1.5                        ; floating point value, "
+"distance in cells\n"
+"Airburst.UseCluster=false                 ; boolean\n"
+"Airburst.RandomClusters=false             ; boolean\n"
+"Airburst.TargetAsSource=false             ; boolean\n"
+"Airburst.TargetAsSource.SkipHeight=false  ; boolean\n"
+"AroundTarget=                             ; boolean\n"
+"AirburstWeapon.ApplyFirepowerMult=false   ; boolean\n"
+"AirburstWeapon.SourceScatterMin=0.0       ; floating point value, "
+"distance in cells\n"
+"AirburstWeapon.SourceScatterMax=0.0       ; floating point value, "
+"distance in cells\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1165
+msgid ""
+"`Splits`, `AirburstSpread`, `RetargetAccuracy`, `RetargetSelf` and "
+"`AroundTarget`, beyond the other additions, should function similarly to "
+"the equivalent features introduced by Ares and take precedence over them "
+"if Phobos is used together with Ares."
+msgstr ""
+"`Splits`、`AirburstSpread`、`RetargetAccuracy`、`RetargetSelf` 和 "
+"`AroundTarget`，除了其他新增功能外，应该与 Ares 所引入的类似功能拥有相同效果并且如果 Phobos 与 Ares "
+"一起使用则优先于 Ares 的。"
+
+#: ../../Fixed-or-Improved-Logics.md:1168
+msgid "Cluster scatter distance customization"
+msgstr "自定义 Cluster 散布距离"
+
+#: ../../Fixed-or-Improved-Logics.md:1170
+msgid ""
+"`ClusterScatter.Min` and `ClusterScatter.Max` can be used to set minimum "
+"and maximum distance, respectively, in cells from the original detonation"
+" coordinate any additional detonations if `Cluster` is set to value "
+"higher than 1 can appear at."
+msgstr ""
+"`ClusterScatter.Min` 和 `ClusterScatter.Max` 可各自用于设置最小和最大距离，用于当 `Cluster` "
+"设为一个大于 1 的值时任何额外爆炸可出现的位置相对原爆炸坐标以单元格为单位的距离。"
+
+#: ../../Fixed-or-Improved-Logics.md:1173
+msgid ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
+"ClusterScatter.Max=2.0  ; floating point value, distance in cells\n"
+msgstr ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"ClusterScatter.Min=1.0  ; floating point value, distance in cells\n"
+"ClusterScatter.Max=2.0  ; floating point value, distance in cells\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1179
+msgid "Customizable projectile gravity"
+msgstr "自定义抛射体重力"
+
+#: ../../Fixed-or-Improved-Logics.md:1181
+msgid "You can now specify individual projectile gravity."
+msgstr "现在你可以为特定抛射体指定其重力。"
+
+#: ../../Fixed-or-Improved-Logics.md:1182
+msgid ""
+"Setting `Gravity=0` is not recommended as it will cause the projectile to"
+" fly backwards and be unable to hit the target which is not at the same "
+"height. We suggest to use `Straight` Trajectory instead. See [here](New-"
+"or-Enhanced-Logics.md#projectile-trajectories)."
+msgstr ""
+"由于 `Gravity=0` 会导致抛射体向后飞行并且无法击中不在相同高度的目标因此不推荐设置 `Gravity=0` 。我们建议使用 [直线弹道"
+"](New-or-Enhanced-Logics.md#projectile-trajectories) 替代。"
+
+#: ../../Fixed-or-Improved-Logics.md:1185
+msgid ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"Gravity=6.0             ; floating point value\n"
+msgstr ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"Gravity=6.0             ; floating point value\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1190
+msgid "Customizing initial facing behavior"
+msgstr "自定义初始朝向行为"
+
+#: ../../Fixed-or-Improved-Logics.md:1192
+msgid ""
+"Previously projectiles that had `Voxel=true` images were hardcoded to "
+"have downwards initial trajectory. This behavior can now be toggled on "
+"for other types of projectiles or disabled for voxel projectiles. In "
+"addition to defaulting to `true` for `Voxel=true` projectiles, it also "
+"now defaults to true for any `Vertical=true` projectile."
+msgstr ""
+"先前拥有 `Voxel=true` 的抛射体被硬编码为初始向下的弹道。现在该行为可以为其他类型抛射体开启或为 Voxel 抛射体关闭。除了对 "
+"`Voxel=true` 的抛射体默认为 `true` 外，现对所有 `Vertical=true` 的抛射体也同样设为 `true`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1195
+msgid ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"VerticalInitialFacing=  ; boolean\n"
+msgstr ""
+"[SOMEPROJECTILE]        ; Projectile\n"
+"VerticalInitialFacing=  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1200
+msgid "FlakScatter distance customization"
+msgstr "自定义 FlakScatter 距离"
+
+#: ../../Fixed-or-Improved-Logics.md:1202
+msgid ""
+"By default `FlakScatter=true` makes `Inviso=true` projectiles scatter "
+"within a distance range calculated as `[Minimum * 2, Maximum * 2]` in "
+"cells, where the Minimum is 0 and Maximum is `[CombatDamage] -> "
+"BallisticScatter`, resulting in a range of `0` to `2 * BallisticScatter` "
+"cells. This behavior can now be customized using `BallisticScatter.Min` "
+"to set the Minimum value and `BallisticScatter.Max` to set the Maximum "
+"value. If not set, the default values are used. When estimating the "
+"actual scatter range, remember that the original `*2` multiplier "
+"mechanism still applies."
+msgstr ""
+"默认情况下 `FlakScatter=true` 会使 `Inviso=true` 的抛射体在按公式 `[最小值 * 2, 最大值 * "
+"2]`计算出来的单元格距离范围内散布，其中 `最小值` 为 0，`最大值` 为 `[CombatDamage] -> "
+"BallisticScatter`，最终散布范围为 `[0, 2 * BallisticScatter]` 格。此行为现已可以通过 "
+"`BallisticScatter.Min` 设置 `最小值` 和 通过 `BallisticScatter.Max` 设置 `最大值` "
+"来实现自定义。如果没有设置则使用原有的行为作为默认值。注意在估算实际范围时原有算法中的 `*2` 计算仍然存在。"
+
+#: ../../Fixed-or-Improved-Logics.md:1205
+msgid ""
+"[SOMEPROJECTILE]      ; Projectile\n"
+"BallisticScatter.Min= ; floating point value, distance in cells\n"
+"BallisticScatter.Max= ; floating point value, distance in cells\n"
+msgstr ""
+"[SOMEPROJECTILE]      ; Projectile\n"
+"BallisticScatter.Min= ; floating point value, distance in cells\n"
+"BallisticScatter.Max= ; floating point value, distance in cells\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1211
+msgid "Shrapnel enhancements"
+msgstr "溅射增强"
+
+#: ../../Fixed-or-Improved-Logics.md:1213
+msgid ""
+"![image](_static/images/shrapnel.gif) *Shrapnel appearing against ground "
+"& buildings in [Project Phantom](https://www.moddb.com/mods/project-"
+"phantom)*"
+msgstr ""
+"![image](_static/images/shrapnel.gif) *[幽灵计划](https://www.moddb.com/mods"
+"/project-phantom) 中击中地面和建筑的溅射*"
+
+#: ../../Fixed-or-Improved-Logics.md:1216
+msgid ""
+"`ShrapnelWeapon` can now be triggered against ground & buildings via "
+"`Shrapnel.AffectsGround` and `Shrapnel.AffectsBuildings`."
+msgstr "现在可以通过 `Shrapnel.AffectsGround` 和 `Shrapnel.AffectsBuildings` 触发对地面和建筑的溅射。"
+
+#: ../../Fixed-or-Improved-Logics.md:1217
+msgid ""
+"Setting `Shrapnel.UseWeaponTargeting` now allows weapon target filtering "
+"to be enabled for `ShrapnelWeapon`. Target's `LegalTarget` setting, "
+"Warhead `Verses` against `Armor` as well as `ShrapnelWeapon` [weapon "
+"targeting filters](#weapon-targeting-filter) & [AttachEffect filters"
+"](#attached-effects) will be checked."
+msgstr ""
+"设置 `Shrapnel.UseWeaponTargeting` 现在允许为 `ShrapnelWeapon` 启用武器目标过滤。目标的 "
+"`LegalTarget` 设置、弹头的 `Verses` 对 `Armor` 以及 `ShrapnelWeapon` [武器目标筛选"
+"](#weapon-targeting-filter) 和 [AE 武器过滤](#attached-effects) 将被检查。"
+
+#: ../../Fixed-or-Improved-Logics.md:1218
+msgid ""
+"Do note that this overrides the normal check of only allowing shrapnels "
+"to hit non-allied objects. Use `CanTargetHouses=enemies` to manually "
+"enable this behaviour again."
+msgstr "注意这会覆盖允许溅射武器选择非盟友对象的默认检查。使用 `CanTargetHouses=enemies` 可手动重新启用此行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1221
+msgid ""
+"[SOMEPROJECTILE]                   ; Projectile\n"
+"Shrapnel.AffectsGround=false       ; boolean\n"
+"Shrapnel.AffectsBuildings=false    ; boolean\n"
+"Shrapnel.UseWeaponTargeting=false  ; boolean\n"
+msgstr ""
+"[SOMEPROJECTILE]                   ; Projectile\n"
+"Shrapnel.AffectsGround=false       ; boolean\n"
+"Shrapnel.AffectsBuildings=false    ; boolean\n"
+"Shrapnel.UseWeaponTargeting=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1228
+msgid "Technos"
+msgstr "科技类型"
+
+#: ../../Fixed-or-Improved-Logics.md:1230
+msgid "Airstrike flare visual customizations"
+msgstr "自定义空袭引导效果"
+
+#: ../../Fixed-or-Improved-Logics.md:1232
+msgid ""
+"It is now possible to customize color of airstrike flare tint on target "
+"on the TechnoType calling in the airstrike as well as customize the color"
+" of the line drawn to target."
+msgstr "现在可以在召唤空袭的单位上自定义目标染色效果及引导激光颜色。"
+
+#: ../../Fixed-or-Improved-Logics.md:1233
+msgid ""
+"`LaserTargetColor` can be used to set the index of color from "
+"`[ColorAdd]`."
+msgstr "`LaserTargetColor` 用于填写颜色在 `[ColorAdd]` 中的索引序号。"
+
+#: ../../Fixed-or-Improved-Logics.md:1234
+msgid ""
+"`AirstrikeLineColor` sets the color of the line and dot drawn from firer "
+"to target."
+msgstr "`AirstrikeLineColor` 用于填写引导激光的颜色。"
+
+#: ../../Fixed-or-Improved-Logics.md:1237
+msgid ""
+"[AudioVisual]\n"
+"AirstrikeLineColor=255,0,0  ; integer - Red,Green,Blue\n"
+"\n"
+"[SOMETECHNO]                ; TechnoType\n"
+"LaserTargetColor=           ; integer - [ColorAdd] index, default to "
+"[AudioVisual] -> LaserTargetColor\n"
+"AirstrikeLineColor=         ; integer - Red,Green,Blue, default to "
+"[AudioVisual] -> AirstrikeLineColor\n"
+msgstr ""
+"[AudioVisual]\n"
+"AirstrikeLineColor=255,0,0  ; integer - Red,Green,Blue\n"
+"\n"
+"[SOMETECHNO]                ; TechnoType\n"
+"LaserTargetColor=           ; integer - [ColorAdd] index, default to "
+"[AudioVisual] -> LaserTargetColor\n"
+"AirstrikeLineColor=         ; integer - Red,Green,Blue, default to "
+"[AudioVisual] -> AirstrikeLineColor\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1246
+msgid "Airstrike target eligibility"
+msgstr "空袭目标筛选"
+
+#: ../../Fixed-or-Improved-Logics.md:1248
+msgid ""
+"By default whether or not a building can be targeted by airstrikes "
+"(`Airstrike=true` Warhead) depends on value of `CanC4`, which also "
+"affects other things. This can now be changed independently by setting "
+"`AllowAirstrike`. If not set, defaults to value of `CanC4`. For non-"
+"building targets, the default value is true."
+msgstr ""
+"默认情况下建筑能否被空袭武器（弹头 `Airstrike=true`）作为目标取决于 `CanC4` 的值，这也会影响其他方面。现在可以通过设置 "
+"`AllowAirstrike` 来独立更改这一点，如果未设置，默认为 `CanC4` 的值。对于非建筑类单位这默认为 true。"
+
+#: ../../Fixed-or-Improved-Logics.md:1249
+msgid ""
+"`AirstrikeTargets` determines what types of targets are valid airstrike "
+"targets for this Warhead."
+msgstr "`AirstrikeTargets` 决定了哪些目标是该弹头的有效空袭目标。"
+
+#: ../../Fixed-or-Improved-Logics.md:1250
+msgid ""
+"The airstrike aircraft will now aim at the target itself rather than the "
+"cell beneath its feet, therefore it is possible to properly designate air"
+" strikes against non-building targets."
+msgstr "现在空袭的战机会将目标设为单位自身而不再是单位脚下的单元格，因此可以对非建筑类目标正常地进行空袭引导。"
+
+#: ../../Fixed-or-Improved-Logics.md:1253
+msgid ""
+"[SOMETECHNO]                ; TechnoType\n"
+"AllowAirstrike=             ; boolean\n"
+"\n"
+"[SOMEWARHEAD]               ; WarheadType\n"
+"AirstrikeTargets=buildings  ; List of Affected Target Enumeration "
+"(none|infantry|units|buildings|all)\n"
+msgstr ""
+"[SOMETECHNO]                ; TechnoType\n"
+"AllowAirstrike=             ; boolean\n"
+"\n"
+"[SOMEWARHEAD]               ; WarheadType\n"
+"AirstrikeTargets=buildings  ; List of Affected Target Enumeration "
+"(none|infantry|units|buildings|all)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1261
+msgid "Alternate FLH customizations"
+msgstr "跟随炮塔旋转的 `AlternateFLH`"
+
+#: ../../Fixed-or-Improved-Logics.md:1263
+msgid ""
+"`AlternateFLH.OnTurret` can be used to customize whether or not "
+"`AlternateFLH` used for `OpenTopped` transport firing coordinates, "
+"multiple mind control link offsets etc. is calculated relative to the "
+"unit's turret if available or body."
+msgstr ""
+"`AlternateFLH.OnTurret` 可自定义 `AlternateFLH` 用于 `OpenTopped` "
+"运输工具的开火坐标、多重心控链接偏移等逻辑时其位置是否相对于炮塔而非车体。"
+
+#: ../../Fixed-or-Improved-Logics.md:1264
+msgid ""
+"`AlternateFLH.ApplyVehicle` can be used to customize whether or not a "
+"transport applies its `AlternateFLH` to passengers of the VehicleType, "
+"who by default use their own FLH, as opposed to passengers of the "
+"InfantryType who adhere to `AlternateFLH`."
+msgstr ""
+"`AlternateFLH.ApplyVehicle` 可用于自定义运输工具的 `AlternateFLH` "
+"是否作用于载具类载员，它们默认使用自身的 FLH 而不像步兵类载员那样遵照 `AlternateFLH`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1267
+msgid ""
+"[SOMETECHNO]                     ; TechnoType\n"
+"AlternateFLH.OnTurret=true       ; boolean\n"
+"AlternateFLH.ApplyVehicle=false  ; boolean\n"
+msgstr ""
+"[SOMETECHNO]                     ; TechnoType\n"
+"AlternateFLH.OnTurret=true       ; boolean\n"
+"AlternateFLH.ApplyVehicle=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1273
+msgid "Building-provided self-healing customization"
+msgstr "自定义建筑提供的自愈"
+
+#: ../../Fixed-or-Improved-Logics.md:1275
+msgid ""
+"It is now possible to set a global cap for the effects of "
+"`InfantryGainSelfHeal` and `UnitsGainSelfHeal` by setting "
+"`InfantryGainSelfHealCap` & `UnitsGainSelfHealCap` under `[General]`, "
+"respectively."
+msgstr ""
+"现在可以通过分别在 `[General]` 中设置 `InfantryGainSelfHealCap` 与 "
+"`UnitsGainSelfHealCap` 来为 `InfantryGainSelfHeal` 和 `UnitsGainSelfHeal` "
+"的效果设置全局上限。"
+
+#: ../../Fixed-or-Improved-Logics.md:1276
+msgid ""
+"Whether or not `MultiplayPassive=true` houses benefit from these effects "
+"can be controlled via `GainSelfHealAllowMultiplayPassive`."
+msgstr ""
+"`MultiplayPassive=true` 的所属方是否受益于这些效果可以通过 "
+"`GainSelfHealAllowMultiplayPassive` 加以控制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1277
+msgid ""
+"In campaign, whether or not these effects for player can be benefited by "
+"houses with `PlayerControl=true` can be controlled via "
+"`GainSelfHealFromPlayerControl`."
+msgstr ""
+"玩家能否通过带有 `PlayerControl=true` 的所属方获得这些受益可以通过 "
+"`GainSelfHealFromPlayerControl` 控制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1278
+msgid ""
+"Whether or not these effects can be benefited by allied houses can be "
+"controlled via `GainSelfHealFromAllies`."
+msgstr "玩家能否通过盟友所属获得这些受益效果可以由 `GainSelfHealFromAllies` 控制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1279
+msgid ""
+"It is also possible to change the pip frames displayed from `pips.shp` "
+"individually for infantry, units and buildings by setting the frames for "
+"infantry & unit self-healing on "
+"`Pips.SelfHeal.(Infantry/Units/Buildings)` under `[AudioVisual]`, "
+"respectively."
+msgstr ""
+"还可以分别为步兵、载具和建筑在 `[AudioVisual]` 中使用 "
+"`Pips.SelfHeal.(Infantry/Units/Buildings)` 设置各自 `pips.shp` 中用于显示的 pip 帧。"
+
+#: ../../Fixed-or-Improved-Logics.md:1280
+msgid ""
+"`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` can be used to "
+"customize the pixel offsets for the displayed pips, individually for "
+"infantry, units and buildings."
+msgstr ""
+"`Pips.SelfHeal.(Infantry/Units/Buildings).Offset` 可以被用于分别自定义步兵、载具和建筑显示 "
+"pip 使用的像素偏移量。"
+
+#: ../../Fixed-or-Improved-Logics.md:1281
+msgid ""
+"Whether or not a TechnoType benefits from effects of "
+"`InfantryGainSelfHeal` or `UnitsGainSelfHeal` buildings or neither can "
+"now be controlled by setting `SelfHealGainType`."
+msgstr ""
+"通过设置 `SelfHealGainType` 可以控制科技类型是否受到 `InfantryGainSelfHeal` 或 "
+"`UnitsGainSelfHeal` 建筑的增益效果或者对两者都不享有。"
+
+#: ../../Fixed-or-Improved-Logics.md:1282
+msgid ""
+"If `SelfHealGainType` is not set, InfantryTypes and VehicleTypes with "
+"`Organic` set to true gain self-healing from `InfantryGainSelfHeal`, "
+"other VehicleTypes from `UnitsGainSelfHeal` and AircraftTypes & "
+"BuildingTypes never gain self-healing."
+msgstr ""
+"如果未设置 `SelfHealGainType`，那么步兵类型和 `Organic` 设置为 true 载具类型将从 "
+"`InfantryGainSelfHeal` 获得自愈，其他载具类型从 `UnitsGainSelfHeal` "
+"获得以及战机类型和建筑类型永远不会获得自愈。"
+
+#: ../../Fixed-or-Improved-Logics.md:1285
+msgid ""
+"[General]\n"
+"InfantryGainSelfHealCap=                ; integer, maximum amount of "
+"InfantryGainSelfHeal that can be in effect at once, must be 1 or higher\n"
+"UnitsGainSelfHealCap=                   ; integer, maximum amount of "
+"UnitsGainSelfHeal that can be in effect at once, must be 1 or higher\n"
+"GainSelfHealAllowMultiplayPassive=true  ; boolean\n"
+"GainSelfHealFromPlayerControl=false     ; boolean\n"
+"GainSelfHealFromAllies=false            ; boolean\n"
+"\n"
+"[AudioVisual]\n"
+"Pips.SelfHeal.Infantry=13,20            ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Units=13,20               ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Buildings=13,20           ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Infantry.Offset=25,-35    ; X,Y, pixels relative to default"
+"\n"
+"Pips.SelfHeal.Units.Offset=33,-32       ; X,Y, pixels relative to default"
+"\n"
+"Pips.SelfHeal.Buildings.Offset=15,10    ; X,Y, pixels relative to default"
+"\n"
+"\n"
+"[SOMETECHNO]                            ; TechnoType\n"
+"SelfHealGainType=                       ; Self-Heal Gain Type Enumeration"
+" (noheal|infantry|units)\n"
+msgstr ""
+"[General]\n"
+"InfantryGainSelfHealCap=                ; integer, maximum amount of "
+"InfantryGainSelfHeal that can be in effect at once, must be 1 or higher\n"
+"UnitsGainSelfHealCap=                   ; integer, maximum amount of "
+"UnitsGainSelfHeal that can be in effect at once, must be 1 or higher\n"
+"GainSelfHealAllowMultiplayPassive=true  ; boolean\n"
+"GainSelfHealFromPlayerControl=false     ; boolean\n"
+"GainSelfHealFromAllies=false            ; boolean\n"
+"\n"
+"[AudioVisual]\n"
+"Pips.SelfHeal.Infantry=13,20            ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Units=13,20               ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Buildings=13,20           ; integer, frames of pips.shp for"
+" infantry & unit-self healing pips, respectively\n"
+"Pips.SelfHeal.Infantry.Offset=25,-35    ; X,Y, pixels relative to default"
+"\n"
+"Pips.SelfHeal.Units.Offset=33,-32       ; X,Y, pixels relative to default"
+"\n"
+"Pips.SelfHeal.Buildings.Offset=15,10    ; X,Y, pixels relative to default"
+"\n"
+"\n"
+"[SOMETECHNO]                            ; TechnoType\n"
+"SelfHealGainType=                       ; Self-Heal Gain Type Enumeration"
+" (noheal|infantry|units)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1305
+msgid "Chrono sparkle animation customization & improvements"
+msgstr "超时空闪光动画的自定义与改进"
+
+#: ../../Fixed-or-Improved-Logics.md:1307
+msgid ""
+"It is now possible to customize the frame delay between instances of "
+"`[General] -> ChronoSparkle1` animations created on objects being warped "
+"by setting `[General] -> ChronoSparkleDisplayDelay`."
+msgstr ""
+"现在可以通过设置 `[General] -> ChronoSparkleDisplayDelay` 来自定义被冻结的对象上创建 "
+"`[General] -> ChronoSparkle1` 动画之间的帧间隔。"
+
+#: ../../Fixed-or-Improved-Logics.md:1308
+msgid ""
+"By default on buildings with `MaxNumberOccupants` higher than 0, chrono "
+"sparkle animation would be shown at each of the `MuzzleFlashX` "
+"coordinates. This behaviour is now customizable, and supports "
+"`MuzzleFlashX` indices higher than 10."
+msgstr ""
+"默认情况下对于 `MaxNumberOccupants` 大于 0 的建筑，超时空闪烁动画会在每个 `MuzzleFlashX` "
+"坐标处显示。现在这种行为可以自定义，并且支持大于 10 的 `MuzzleFlashX` 索引。"
+
+#: ../../Fixed-or-Improved-Logics.md:1309
+msgid ""
+"`[General] -> ChronoSparkleBuildingDisplayPositions` can be set to show "
+"the sparkle animation on the building (`building`), muzzle flash "
+"coordinates of current occupants (`occupants`), muzzle flash coordinates "
+"of all occupant slots (`occupantslots`) or any combination of these."
+msgstr ""
+"`[General] -> ChronoSparkleBuildingDisplayPositions` 可以设置闪烁动画为在建筑上闪烁 "
+"(`building`)、在当前驻军的枪口坐标闪烁 (`occupants`)、所有驻军的枪口闪烁坐标 (`occupantslots`) "
+"或这些中任意组合的情况下显示。"
+
+#: ../../Fixed-or-Improved-Logics.md:1310
+msgid ""
+"If `occupants` or `occupantslots` is listed without `building`, a single "
+"chrono sparkle animation is still displayed on building if it doesn't "
+"have any occupants or it has `MaxNumberOccupants` value less than 1, "
+"respectively."
+msgstr ""
+"如果列出了 `occupants` 或 `occupantslots` 而没有 `building`，那么在建筑没有任何驻军或其 "
+"`MaxNumberOccupants` 小于 1 的情况下仍会在建筑上显示一个超时空闪烁动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:1311
+msgid ""
+"The chrono sparkle animation that is displayed on building itself is also"
+" now displayed at the center of it rather than at center of its topmost "
+"cell."
+msgstr "现在显示在建筑自身的超时空闪烁动画位于其正中心而不再是其最顶端单元格的中心。"
+
+#: ../../Fixed-or-Improved-Logics.md:1314
+msgid ""
+"[General]\n"
+"ChronoSparkleDisplayDelay=24                         ; integer, game "
+"frames\n"
+"ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono "
+"sparkle position enum (building | occupants | occupantslots | all)\n"
+msgstr ""
+"[General]\n"
+"ChronoSparkleDisplayDelay=24                         ; integer, game "
+"frames\n"
+"ChronoSparkleBuildingDisplayPositions=occupantslots  ; List of chrono "
+"sparkle position enum (building | occupants | occupantslots | all)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1320
+msgid "Customizable ChronoSphere teleport delays for units"
+msgstr "单位自定义 ChronoSphere 传送延迟"
+
+#: ../../Fixed-or-Improved-Logics.md:1322
+msgid ""
+"It is now possible to customize (globally and per TechnoType) the warp-in"
+" delay for units teleporting through `Type=ChronoSphere/Warp` "
+"Superweapon, both before and after the jump."
+msgstr "现在可以自定义（全局和所有科技类型）单位通过 `Type=ChronoSphere/Warp` 超级武器传送前后的延迟。"
+
+#: ../../Fixed-or-Improved-Logics.md:1325
+msgid ""
+"[General]\n"
+"ChronoSphereDelay=0     ; integer, game frames\n"
+"ChronoSpherePreDelay=60 ; integer, game frames\n"
+"\n"
+"[SOMETECHNO]            ; TechnoType\n"
+"ChronoSphereDelay=      ; integer, game frames, default to [General] -> "
+"ChronoSphereDelay\n"
+"ChronoSpherePreDelay=   ; integer, game frames, default to [General] -> "
+"ChronoSpherePreDelay\n"
+msgstr ""
+"[General]\n"
+"ChronoSphereDelay=0     ; integer, game frames\n"
+"ChronoSpherePreDelay=60 ; integer, game frames\n"
+"\n"
+"[SOMETECHNO]            ; TechnoType\n"
+"ChronoSphereDelay=      ; integer, game frames, default to [General] -> "
+"ChronoSphereDelay\n"
+"ChronoSpherePreDelay=   ; integer, game frames, default to [General] -> "
+"ChronoSpherePreDelay\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1336
+msgid ""
+"Due to technical constraints, these settings do not apply to buildings "
+"teleported by Ares' customizable ChronoSphere SW. They only have a pre-"
+"teleport delay equal to `[General] -> ChronoDelay`."
+msgstr ""
+"由于技术限制，这些设置不适用于 Ares 的自定义 ChronoSphere 超级武器传送的建筑。它们仅有一个共用的 `[General] -> "
+"ChronoDelay`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1339
+msgid "Customizable harvester ore gathering animation"
+msgstr "自定义采矿动画"
+
+#: ../../Fixed-or-Improved-Logics.md:1341
+msgid ""
+"![image](_static/images/oregath.gif) *Custom ore gathering anims in "
+"[Project Phantom](https://www.moddb.com/mods/project-phantom)*"
+msgstr ""
+"![image](_static/images/oregath.gif) *在 [幽灵计划](https://www.moddb.com/mods"
+"/project-phantom) 中的自定义矿石采集动画*"
+
+#: ../../Fixed-or-Improved-Logics.md:1344
+msgid ""
+"You can now specify which anim should be drawn when a harvester of "
+"specified type is gathering specified type of ore."
+msgstr "现在你可以在设定特定矿车在采集特定类型的矿石时哪些动画应当被绘制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1347
+msgid ""
+"[SOMETECHNO]                     ; TechnoType\n"
+"OreGathering.Anims=              ; List of AnimationTypes\n"
+"OreGathering.FramesPerDir=15     ; List of integers\n"
+"OreGathering.Tiberiums=0         ; List of Tiberium IDs\n"
+msgstr ""
+"[SOMETECHNO]                     ; TechnoType\n"
+"OreGathering.Anims=              ; List of AnimationTypes\n"
+"OreGathering.FramesPerDir=15     ; List of integers\n"
+"OreGathering.Tiberiums=0         ; List of Tiberium IDs\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1354
+msgid "Customizable target evaluation map zone check behaviour"
+msgstr "自定义目标评估地图区域检查行为"
+
+#: ../../Fixed-or-Improved-Logics.md:1356
+msgid ""
+"By default, any non-AircraftType units seeking targets via ScriptType "
+"team mission (action) `0 Attack Target Type` or any [attack team missions"
+" introduced in Phobos](AI-Scripting-and-Mapping.md#attack-actions) check "
+"if the potential target is in same map zone as the attacking unit to be "
+"able to pick it as a target. This can now be customized to allow objects "
+"from any map zone with no constraints (`TargetZoneScanType=any`) or only "
+"if they are within weapon range (`TargetZoneScanType=inrange`)."
+msgstr ""
+"默认情况下，任何非战机类类型单位通过脚本动作 `0 攻击目标类型` 或任何 [Phobos 引入的小队攻击任务](AI-Scripting-"
+"and-Mapping.md#10000-10049-attack-actions) "
+"寻找目标时都会检查潜在目标与攻击单位是否处于同一区域，以便将其选为攻击目标。现在这可以被自定义为允许选择来自任何地图区域的对象且不受限制 "
+"(`TargetZoneScanType=any`) 或者仅当目标在武器射程内时才允许选择 "
+"(`TargetZoneScanType=inrange`)。"
+
+#: ../../Fixed-or-Improved-Logics.md:1359
+msgid ""
+"[SOMETECHNO]             ; TechnoType\n"
+"TargetZoneScanType=same  ; target zone scan enumeration "
+"(same|any|inrange)\n"
+msgstr ""
+"[SOMETECHNO]             ; TechnoType\n"
+"TargetZoneScanType=same  ; target zone scan enumeration "
+"(same|any|inrange)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1364
+msgid "Customizable Teleport/Chrono Locomotor settings per TechnoType"
+msgstr "自定义超时空运动设置"
+
+#: ../../Fixed-or-Improved-Logics.md:1366
+msgid ""
+"![image](_static/images/cust-Chrono.gif) *Chrono Legionnaire and Ronco "
+"using different teleportation settings in [YR: New "
+"War](https://www.moddb.com/mods/yuris-revenge-new-war)*"
+msgstr ""
+"![image](_static/images/cust-Chrono.gif) *[YR: New "
+"War](https://www.moddb.com/mods/yuris-revenge-new-war) 中的超时空军团兵与 Ronco "
+"使用不同的超时空设置*"
+
+#: ../../Fixed-or-Improved-Logics.md:1369
+msgid ""
+"You can now specify Teleport/Chrono Locomotor settings per TechnoType to "
+"override default rules values. Unfilled values default to values in "
+"`[General]`."
+msgstr "现在你可以为每个科技类型指定其超时空运动方式设置以覆盖默认规则的值。未填充值则默认使用 `[General]` 中的值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1370
+msgid ""
+"Applicable to Techno that have Teleport/Chrono Locomotor attached, or "
+"being chronowarped by chronosphere."
+msgstr "对使用超时空运动方式或者被超时空传送超武移动的科技类型有效。"
+
+#: ../../Fixed-or-Improved-Logics.md:1371
+msgid ""
+"`Chronoshift.WarpOut` and `Chronoshift.WarpIn` will override `WarpOut` "
+"and `WarpIn` respectively when the techno is being chronowarped by "
+"chronosphere, if set."
+msgstr ""
+"当单位被 `Type=ChronoSphere` 的超级武器传送时 `Chronoshift.WarpOut` 和 "
+"`Chronoshift.WarpIn` 会分别替代 `WarpOut` 和  `WarpIn` 使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1372
+msgid ""
+"`WarpAway` specify the anim when the techno is being erased by "
+"`Temporal=yes` warhead. Will override Ares' `Temporal.WarpAway` tag on "
+"warhead, if set."
+msgstr ""
+"单位上的 `[TechnoType] -> WarpAway` 会在其被 `Temporal=yes` 的弹头抹除时覆盖 Ares 引入的 "
+"`[WarheadType] -> Temporal.WarpAway=` 生效。"
+
+#: ../../Fixed-or-Improved-Logics.md:1373
+msgid ""
+"If more than one animation is listed in `WarpOut`, `WarpIn` or "
+"`WarpAway`, a random one is selected."
+msgstr "如果 `WarpOut`、`WarpIn` 或 `WarpAway` 中列出了多个动画，则将随机选择一个。"
+
+#: ../../Fixed-or-Improved-Logics.md:1376
+msgid ""
+"[SOMETECHNO]            ; TechnoType\n"
+"WarpOut=                ; List of AnimationTypes (played when Techno "
+"warping out), default to [General] -> WarpOut\n"
+"WarpIn=                 ; List of AnimationTypes (played when Techno "
+"warping in), default to [General] -> WarpIn\n"
+"Chronoshift.WarpOut=    ; List of AnimationTypes (played when Techno "
+"warping out by chronosphere), default to [TechnoType] -> WarpOut\n"
+"Chronoshift.WarpIn=     ; List of AnimationTypes (played when Techno "
+"warping in by chronosphere), default to [TechnoType] -> WarpIn\n"
+"WarpAway=               ; List of AnimationTypes (played when Techno "
+"being erased by Temporal=yes warhead), default to [General] -> WarpAway\n"
+"ChronoTrigger=          ; boolean, if yes then delay varies by distance, "
+"if no it is a constant\n"
+"ChronoDistanceFactor=   ; integer, amount to divide the distance to "
+"destination by to get the warped out delay\n"
+"ChronoMinimumDelay=     ; integer, the minimum delay for teleporting, no "
+"matter how short the distance\n"
+"ChronoRangeMinimum=     ; integer, can be used to set a small range "
+"within which the delay is constant\n"
+"ChronoDelay=            ; integer, delay after teleport for chronosphere\n"
+msgstr ""
+"[SOMETECHNO]            ; TechnoType\n"
+"WarpOut=                ; List of AnimationTypes (played when Techno "
+"warping out), default to [General] -> WarpOut\n"
+"WarpIn=                 ; List of AnimationTypes (played when Techno "
+"warping in), default to [General] -> WarpIn\n"
+"Chronoshift.WarpOut=    ; List of AnimationTypes (played when Techno "
+"warping out by chronosphere), default to [TechnoType] -> WarpOut\n"
+"Chronoshift.WarpIn=     ; List of AnimationTypes (played when Techno "
+"warping in by chronosphere), default to [TechnoType] -> WarpIn\n"
+"WarpAway=               ; List of AnimationTypes (played when Techno "
+"being erased by Temporal=yes warhead), default to [General] -> WarpAway\n"
+"ChronoTrigger=          ; boolean, if yes then delay varies by distance, "
+"if no it is a constant\n"
+"ChronoDistanceFactor=   ; integer, amount to divide the distance to "
+"destination by to get the warped out delay\n"
+"ChronoMinimumDelay=     ; integer, the minimum delay for teleporting, no "
+"matter how short the distance\n"
+"ChronoRangeMinimum=     ; integer, can be used to set a small range "
+"within which the delay is constant\n"
+"ChronoDelay=            ; integer, delay after teleport for chronosphere\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1390
+msgid "Customizable veterancy insignias"
+msgstr "自定义等级军衔"
+
+#: ../../Fixed-or-Improved-Logics.md:1392
+msgid "You can now customize veterancy insignia of TechnoTypes."
+msgstr "现在可以自定义科技类型的等级军衔。"
+
+#: ../../Fixed-or-Improved-Logics.md:1393
+msgid ""
+"`Insignia.(Rookie|Veteran|Elite)` can be used to set a custom insignia "
+"file, optionally for each veterancy stage. Like the original / default "
+"file, `pips.shp`, they are drawn using `palette.pal` as palette."
+msgstr ""
+"`Insignia.(Rookie|Veteran|Elite)` 可用于为每个等级设置一个自定义军衔文件。与原本／默认的文件 "
+"`pips.shp` 一样，它们使用 `palette.pal` 作为色盘进行绘制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1394
+msgid ""
+"`InsigniaFrame(.Rookie|Veteran|Elite)` can be used to set (zero-based) "
+"frame index of the insignia to display, optionally for each veterancy "
+"stage. Using -1 uses the default setting. Default settings are -1 (none) "
+"for rookie, 14 for veteran and 15 for elite."
+msgstr ""
+"`InsigniaFrame(.Rookie|Veteran|Elite)` 可用于为每个等级阶段设置军衔的（从 0 开始的）帧索引。使用 -1 "
+"表示使用默认设置。默认设置对新兵为 -1（无），对老兵为 14，对精英为 15。"
+
+#: ../../Fixed-or-Improved-Logics.md:1395
+msgid ""
+"A shorthand `InsigniaFrames` can be used to list them in order from "
+"rookie, veteran and elite instead as well. "
+"`InsigniaFrame(.Rookie|Veteran|Elite)` takes priority over this."
+msgstr ""
+"也可以使用简写 `InsigniaFrames` "
+"按顺序列出新兵、老兵和精英的帧索引。`InsigniaFrame(.Rookie|Veteran|Elite)` 的优先级高于此。"
+
+#: ../../Fixed-or-Improved-Logics.md:1396
+msgid ""
+"These settings will be overriden by the properties set in "
+"[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType` is set."
+msgstr ""
+"如果设置了 `InsigniaType` 则上述设置会被 [InsigniaType](Miscellanous.md#insignia-"
+"type) 中定义的属性覆盖。"
+
+#: ../../Fixed-or-Improved-Logics.md:1397
+msgid ""
+"Normal insignia can be overridden for specific weapon modes of "
+"`Gunner=true` units by setting `Insignia(.Frame/.Frames).WeaponN` where "
+"`N` stands for 1-based weapon mode index. If not set, defaults to non-"
+"mode specific insignia settings."
+msgstr ""
+"可以通过设置 `Insignia(.Frame/.Frames).WeaponN` 来为 `Gunner=true` "
+"的单位使用不同武器时换成不同的军衔，其中 `N` 表示基于 1 的武器模式索引。如果不设置，默认使用非特定模式的军衔设置。"
+
+#: ../../Fixed-or-Improved-Logics.md:1398
+msgid ""
+"These settings will be overriden by the properties set in "
+"[InsigniaType](Miscellanous.md#insignia-type), if `InsigniaType.WeaponN` "
+"is set."
+msgstr ""
+"如果设置了 `InsigniaType.WeaponN` 则上述设置会被 [InsigniaType](Miscellanous.md"
+"#insignia-type) 中定义的属性覆盖。"
+
+#: ../../Fixed-or-Improved-Logics.md:1399
+msgid ""
+"Normal insignia can be overridden when its current passenger size reaches"
+" a certain amount by setting `Insignia(.Frame/.Frames).PassengersN` where"
+" `N` stands for the current passenger size amount (from 0 to `Passengers`"
+" of the transport). If not set, defaults to non-passenger specific "
+"insignia settings. Will be overridden by weapon mode insignia settings, "
+"if set."
+msgstr ""
+"可以通过设置 `Insignia(.Frame/.Frames).PassengersN` 来为运输工具在拥有不同的载员数量时换成不同的军衔，其中"
+" `N` 表示当前载员数量（从 0 到运输工具 `Passengers` 的值）。如果不设置，默认无载员模式的军衔设置。如果已经设置了 "
+"`Insignia(.Frame/.Frames).WeaponN` 则覆盖该语句的效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:1400
+msgid ""
+"These settings will be overriden by the properties set in "
+"[InsigniaType](Miscellanous.md#insignia-type), if "
+"`InsigniaType.PassengersN` is set."
+msgstr ""
+"如果设置了 `InsigniaType.PassengersN` 则上述设置会被 [InsigniaType](Miscellanous.md"
+"#insignia-type) 中定义的属性覆盖。"
+
+#: ../../Fixed-or-Improved-Logics.md:1401
+msgid ""
+"`Insignia.ShowEnemy` controls whether or not the insignia is shown to "
+"enemy players."
+msgstr "`Insignia.ShowEnemy` 控制军衔是否对敌方玩家可见。"
+
+#: ../../Fixed-or-Improved-Logics.md:1402
+msgid ""
+"You can make insignias appear only on selected units using "
+"`DrawInsignia.OnlyOnSelected`."
+msgstr "你可以使用 `DrawInsignia.OnlyOnSelected` 来使军衔仅出现在被选中的单位上。"
+
+#: ../../Fixed-or-Improved-Logics.md:1403
+msgid ""
+"Position for insignias can be adjusted by setting "
+"`DrawInsignia.AdjustPos.Infantry` for infantry, "
+"`DrawInsignia.AdjustPos.Buildings` for buildings, and "
+"`DrawInsignia.AdjustPos.Units` for others."
+msgstr ""
+"可以通过为步兵设置 `DrawInsignia.AdjustPos.Infantry`、为建筑设置 "
+"`DrawInsignia.AdjustPos.Buildings`、为其他单位设置 `DrawInsignia.AdjustPos.Units`"
+" 来调整军衔的位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:1404
+msgid ""
+"`DrawInsignia.AdjustPos.BuildingsAnchor` can be set to an anchor point to"
+" anchor the insignia position relative to the building's selection "
+"bracket. By default the insignia position is not anchored to the "
+"selection bracket."
+msgstr ""
+"`DrawInsignia.AdjustPos.BuildingsAnchor` "
+"可以设置一个锚点，用于相对建筑选择框锚定军衔位置。默认情况下军衔位置未锚定到选择框。"
+
+#: ../../Fixed-or-Improved-Logics.md:1405
+msgid ""
+"`DrawInsignia.UsePixelSelectionBracketDelta` can be set to use techno's "
+"`PixelSelectionBracketDelta` to additionally adjust insignias vertically."
+msgstr ""
+"`DrawInsignia.UsePixelSelectionBracketDelta` 可以让军衔位置根据单位的 "
+"`PixelSelectionBracketDelta` 在竖直方向上调整位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:1408
+msgid ""
+"[General]\n"
+"EnemyInsignia=true                                          ; boolean\n"
+"\n"
+"[AudioVisual]\n"
+"DrawInsignia.OnlyOnSelected=false                           ; boolean\n"
+"DrawInsignia.UsePixelSelectionBracketDelta=false            ; boolean\n"
+"DrawInsignia.AdjustPos.Infantry=5,2                         ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.Units=10,6                           ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.Buildings=10,6                       ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.BuildingsAnchor=                     ; Hexagon "
+"vertex enumeration (top|lefttop|leftbottom|bottom|rightbottom|righttop)\n"
+"\n"
+"[SOMETECHNO]                                                ; TechnoType\n"
+"Insignia=                                                   ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Rookie=                                            ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Veteran=                                           ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Elite=                                             ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame=-1                                            ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Rookie=-1                                     ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Veteran=-1                                    ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Elite=-1                                      ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames=-1,-1,-1                                     ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.WeaponN=                                           ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Rookie=                                    ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Veteran=                                   ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Elite=                                     ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame.WeaponN=-1                                    ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Rookie=-1                             ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Veteran=-1                            ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Elite=-1                              ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames.WeaponN=-1,-1,-1                             ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.PassengersN=                                       ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Rookie=                                ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Veteran=                               ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Elite=                                 ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame.PassengersN=-1                                ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Rookie=-1                         ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Veteran=-1                        ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Elite=-1                          ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames.PassengersN=-1,-1,-1                         ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.ShowEnemy=                                         ; boolean, "
+"defaults to [General] -> EnemyInsignia\n"
+msgstr ""
+"[General]\n"
+"EnemyInsignia=true                                          ; boolean\n"
+"\n"
+"[AudioVisual]\n"
+"DrawInsignia.OnlyOnSelected=false                           ; boolean\n"
+"DrawInsignia.UsePixelSelectionBracketDelta=false            ; boolean\n"
+"DrawInsignia.AdjustPos.Infantry=5,2                         ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.Units=10,6                           ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.Buildings=10,6                       ; X,Y, "
+"position offset from default\n"
+"DrawInsignia.AdjustPos.BuildingsAnchor=                     ; Hexagon "
+"vertex enumeration (top|lefttop|leftbottom|bottom|rightbottom|righttop)\n"
+"\n"
+"[SOMETECHNO]                                                ; TechnoType\n"
+"Insignia=                                                   ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Rookie=                                            ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Veteran=                                           ; filename - "
+"excluding the .shp extension\n"
+"Insignia.Elite=                                             ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame=-1                                            ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Rookie=-1                                     ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Veteran=-1                                    ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.Elite=-1                                      ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames=-1,-1,-1                                     ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.WeaponN=                                           ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Rookie=                                    ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Veteran=                                   ; filename - "
+"excluding the .shp extension\n"
+"Insignia.WeaponN.Elite=                                     ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame.WeaponN=-1                                    ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Rookie=-1                             ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Veteran=-1                            ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.WeaponN.Elite=-1                              ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames.WeaponN=-1,-1,-1                             ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.PassengersN=                                       ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Rookie=                                ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Veteran=                               ; filename - "
+"excluding the .shp extension\n"
+"Insignia.PassengersN.Elite=                                 ; filename - "
+"excluding the .shp extension\n"
+"InsigniaFrame.PassengersN=-1                                ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Rookie=-1                         ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Veteran=-1                        ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrame.PassengersN.Elite=-1                          ; int, frame "
+"of insignia shp (zero-based) or -1 for default\n"
+"InsigniaFrames.PassengersN=-1,-1,-1                         ; int, frames"
+" of insignia shp (zero-based) or -1 for default\n"
+"Insignia.ShowEnemy=                                         ; boolean, "
+"defaults to [General] -> EnemyInsignia\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1452
+msgid ""
+"Insignia customization besides the `InsigniaFrames` shorthand should "
+"function similarly to the equivalent feature introduced by Ares and takes"
+" precedence over it if Phobos is used together with Ares."
+msgstr ""
+"除了使用 `InsigniaFrames` 简写外，自定义军衔功能类似于 Ares 引入的相应功能，并且如果 Phobos 与 Ares "
+"一起使用则优先于 Ares 的。"
+
+#: ../../Fixed-or-Improved-Logics.md:1455
+msgid "Customizable wake anim"
+msgstr "自定义水波动画"
+
+#: ../../Fixed-or-Improved-Logics.md:1457
+msgid ""
+"You can now specify the `Wake` anim per TechnoType to override default "
+"rules value."
+msgstr "现在你可以为每个科技类型指定 `Wake` 动画以覆盖默认规则值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1458
+msgid ""
+"`Wake.Grapple` and `Wake.Sinking` can be used to further customize wake "
+"anim when the techno is being parasited or sunken."
+msgstr "`Wake.Grapple` 和 `Wake.Sinking` 可用于在科技类型被寄生或沉没时进一步自定义水波动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:1461
+msgid ""
+"[SOMETECHNO]         ; TechnoType\n"
+"Wake=                ; Anim (played when Techno moving on the water), "
+"default to [General] -> Wake\n"
+"Wake.Grapple=        ; Anim (played when Techno being parasited on the "
+"water), defaults to [TechnoType] -> Wake\n"
+"Wake.Sinking=        ; Anim (played when Techno sinking), defaults to "
+"[TechnoType] -> Wake\n"
+msgstr ""
+"[SOMETECHNO]         ; TechnoType\n"
+"Wake=                ; Anim (played when Techno moving on the water), "
+"default to [General] -> Wake\n"
+"Wake.Grapple=        ; Anim (played when Techno being parasited on the "
+"water), defaults to [TechnoType] -> Wake\n"
+"Wake.Sinking=        ; Anim (played when Techno sinking), defaults to "
+"[TechnoType] -> Wake\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1468
+msgid "Customize bridge falling down damage"
+msgstr "自定义桥上坠落伤害"
+
+#: ../../Fixed-or-Improved-Logics.md:1470
+msgid ""
+"![image](_static/images/fallingdowndamage.gif) *Use different fall damage"
+" depending on whether it lands in water in **Zero Boundary** by "
+"@[Stormsulfur](https://space.bilibili.com/11638715/lists/5358986)*"
+msgstr ""
+"![image](_static/images/fallingdowndamage.gif) "
+"*@[暴风硫](https://space.bilibili.com/11638715/lists/5358986) 在 **零点界限** "
+"中根据是否落入水中使用不同的坠落伤害*"
+
+#: ../../Fixed-or-Improved-Logics.md:1473
+msgid ""
+"Now you can customize the damage a unit receives when it falls from a "
+"bridge."
+msgstr "现在你可以自定义单位从桥上坠落时受到的伤害。"
+
+#: ../../Fixed-or-Improved-Logics.md:1474
+msgid ""
+"`FallingDownDamage` customizes the damage a unit receives at the end of a"
+" fall. It can be a percentage or an integer."
+msgstr "`FallingDownDamage` 用于自定义单位坠落触底时所受到的伤害值，可以是比率或固定整数值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1475
+msgid ""
+"`FallingDownDamage.Water` customizes the damage a unit receives when it "
+"falls onto the water. Defaults to `FallingDownDamage`."
+msgstr "`FallingDownDamage.Water` 用于自定义单位坠落到水中时所受的伤害值，默认同 `FallingDownDamage`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1476
+msgid ""
+"If it is a negative percentage, corresponding damage will be dealt based "
+"on the current health of the unit."
+msgstr "若设置负百分比则会根据单位当前生命值按比例造成对应伤害。"
+
+#: ../../Fixed-or-Improved-Logics.md:1479
+msgid ""
+"[SOMETECHNO]                    ; TechnoType\n"
+"FallingDownDamage=              ; integer / percentage\n"
+"FallingDownDamage.Water=        ; integer / percentage\n"
+msgstr ""
+"[SOMETECHNO]                    ; TechnoType\n"
+"FallingDownDamage=              ; integer / percentage\n"
+"FallingDownDamage.Water=        ; integer / percentage\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1485
+msgid "Damaged speed customization"
+msgstr "自定义伤残速度"
+
+#: ../../Fixed-or-Improved-Logics.md:1487
+msgid ""
+"In vanilla, units using drive/ship loco will has hardcoded speed "
+"multiplier when damaged. Now you can customize it."
+msgstr "原版中 `Locomotor` 使用 `Drive`／`Ship` 的单位在伤残时有一个硬编码的速度倍率。现在你可以自由定义了。"
+
+#: ../../Fixed-or-Improved-Logics.md:1488
+msgid ""
+"The max valuebale value is 1.0, you cannot make unit get faster on yellow"
+" condition by it."
+msgstr "最大有效值为 1.0，你无法凭借这个逻辑让单位在黄血时变得更快。"
+
+#: ../../Fixed-or-Improved-Logics.md:1491
+msgid ""
+"[General]\n"
+"DamagedSpeed=0.75        ; floating point value, multiplier\n"
+"\n"
+"[SOMETECHNO]             ; TechnoType\n"
+"DamagedSpeed=            ; floating point value, multiplier\n"
+msgstr ""
+"[General]\n"
+"DamagedSpeed=0.75        ; floating point value, multiplier\n"
+"\n"
+"[SOMETECHNO]             ; TechnoType\n"
+"DamagedSpeed=            ; floating point value, multiplier\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1499
+msgid "Debris voxel animations limitation"
+msgstr "Voxel 碎片数量限制"
+
+#: ../../Fixed-or-Improved-Logics.md:1501
+#: ../../Fixed-or-Improved-Logics.md:2310
+msgid ""
+"Now, the original `DebrisMaximums` can be used in conjunction with new "
+"`DebrisMinimums` to limit the quantity of `DebrisTypes` when "
+"`DebrisTypes.Limit` is enabled."
+msgstr ""
+"当启用 `DebrisTypes.Limit` 时可通过原有的 `DebrisMaximums` 结合新增的 `DebrisMinimums` "
+"共同限制 `DebrisTypes` 的数量。"
+
+#: ../../Fixed-or-Improved-Logics.md:1502
+#: ../../Fixed-or-Improved-Logics.md:2311
+msgid ""
+"The default value of `DebrisTypes.Limit` is whether the number of "
+"`DebrisMaximums` is greater than (not equal to) 1 (for compatibility "
+"reasons)."
+msgstr "出于兼容目的，若 `DebrisMaximums` 大于（不包括等于）1 则默认启用 `DebrisTypes.Limit`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1505
+msgid ""
+"[SOMETECHNO]        ; TechnoType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+msgstr ""
+"[SOMETECHNO]        ; TechnoType\n"
+"DebrisTypes.Limit=  ; boolean\n"
+"DebrisMaximums=     ; List of integers\n"
+"DebrisMinimums=     ; List of integers\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1513
+msgid "How to generate `DebrisTypes` in the game:"
+msgstr "游戏如何生成 `DebrisTypes`："
+
+#: ../../Fixed-or-Improved-Logics.md:1514
+msgid ""
+"Generate the total number of debris through `MaxDebris` and `MinDebris` "
+"first."
+msgstr "首先通过 `MaxDebris` 与 `MinDebris` 确定所要生成碎片的总量。"
+
+#: ../../Fixed-or-Improved-Logics.md:1515
+msgid ""
+"Traverse `DebrisTypes` and limit the quantity range through "
+"`DebrisMaximums` and `DebrisMinimums`."
+msgstr "遍历 `DebrisTypes` 列表并通过 `DebrisMaximums` 和 `DebrisMinimums` 限制数量范围。"
+
+#: ../../Fixed-or-Improved-Logics.md:1516
+msgid ""
+"When the number of generated debris will exceeds the total number, limit "
+"the quantity and end the traversal."
+msgstr "当已生成碎片数量将要超过总量时限制数量并停止遍历。"
+
+#: ../../Fixed-or-Improved-Logics.md:1517
+msgid ""
+"When the number of debris generated after a single traversal is not "
+"enough to exceed the total number, it will end if `DebrisTypes.Limit` is "
+"enabled, otherwise the traversal will restart like vanilla game do."
+msgstr "当遍历完成但碎片的数量并未达到总量时，若启用 `DebrisTypes.Limit` 则直接结束，否则按原版游戏机制重新进行遍历。"
+
+#: ../../Fixed-or-Improved-Logics.md:1520
+msgid "DropPod"
+msgstr "空降仓"
+
+#: ../../Fixed-or-Improved-Logics.md:1522
+msgid ""
+"DropPod properties can now be customized on a per-TechnoType (non-"
+"building) basis."
+msgstr "现在可以在每个非建筑类单位上微观定义 DropPod 属性。"
+
+#: ../../Fixed-or-Improved-Logics.md:1523
+msgid ""
+"If you want to attach the trailer animation to the pod, set "
+"`DropPod.Trailer.Attached` to yes."
+msgstr "如果你要将尾烟动画附加到空降仓上，请将 `DropPod.Trailer.Attached` 设为 yes。"
+
+#: ../../Fixed-or-Improved-Logics.md:1524
+msgid ""
+"By default LaserTrails that are attached to the infantry will not be "
+"drawn if it's on DropPod."
+msgstr "默认情况下附加到步兵上的激光尾焰如果处于 DropPod 状态将不会绘制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1525
+msgid ""
+"If you really want to use it, set `DropPodOnly` on the LaserTrail's type "
+"entry in art."
+msgstr "如果你实在想要使用它，那么请在 art 中的激光尾焰条目下设置 `DropPodOnly`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1526
+msgid ""
+"If you want `DropPod.Weapon` to be fired only upon hard landing, set "
+"`DropPod.Weapon.HitLandOnly` to true."
+msgstr "如果要在着陆时才发射 `DropPod.Weapon`，请将 `DropPod.Weapon.HitLandOnly` 设为 true。"
+
+#: ../../Fixed-or-Improved-Logics.md:1527
+msgid ""
+"The landing speed is not smaller than it's current height /10 + 2 for "
+"unknown reason. A small `DropPod.Speed` value therefore results in "
+"exponential deceleration."
+msgstr "由于某些未知原因着陆速度不小于其当前高度 / 20 + 2 的值。因此较小的 `DropPod.Speed` 值会导致指数级减速。"
+
+#: ../../Fixed-or-Improved-Logics.md:1530
+msgid ""
+"Due to technical constraints `DropPod.AirImage` is only drawn for "
+"InfantryTypes (as the DropPod is the infantry itself with its image "
+"swapped). This may change in future."
+msgstr "由于技术限制，`DropPod.AirImage` 仅在步兵类单位上绘制（因为空降仓本身就是替换了图像的步兵自身）。未来可能会进行更改。"
+
+#: ../../Fixed-or-Improved-Logics.md:1534
+msgid ""
+"[SOMETECHNO]                  ; TechnoType\n"
+"DropPod.Angle=                ; double, default to [General] -> "
+"DropPodAngle, measured in radians\n"
+"DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> "
+"AtmosphereEntry\n"
+"DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod\n"
+"DropPod.AirImage=             ; SHP file, the pod's shape, default to POD"
+"\n"
+"DropPod.Height=               ; int, default to [General] -> "
+"DropPodHeight\n"
+"DropPod.Puff=                 ; anim, default to [AudioVisual] -> "
+"DropPodPuff\n"
+"DropPod.Speed=                ; int, default to [General] -> DropPodSpeed"
+"\n"
+"DropPod.Trailer=              ; anim, default to [General] -> "
+"DropPodTrailer, which by default is SMOKEY\n"
+"DropPod.Trailer.Attached=     ; boolean, default to no\n"
+"DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn "
+"of DropPod.Trailer, default to 6\n"
+"DropPod.Weapon=               ; weapon, default to [General] -> "
+"DropPodWeapon\n"
+"DropPod.Weapon.HitLandOnly=   ; boolean, default to no\n"
+msgstr ""
+"[SOMETECHNO]                  ; TechnoType\n"
+"DropPod.Angle=                ; double, default to [General] -> "
+"DropPodAngle, measured in radians\n"
+"DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> "
+"AtmosphereEntry\n"
+"DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod\n"
+"DropPod.AirImage=             ; SHP file, the pod's shape, default to POD"
+"\n"
+"DropPod.Height=               ; int, default to [General] -> "
+"DropPodHeight\n"
+"DropPod.Puff=                 ; anim, default to [AudioVisual] -> "
+"DropPodPuff\n"
+"DropPod.Speed=                ; int, default to [General] -> DropPodSpeed"
+"\n"
+"DropPod.Trailer=              ; anim, default to [General] -> "
+"DropPodTrailer, which by default is SMOKEY\n"
+"DropPod.Trailer.Attached=     ; boolean, default to no\n"
+"DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn "
+"of DropPod.Trailer, default to 6\n"
+"DropPod.Weapon=               ; weapon, default to [General] -> "
+"DropPodWeapon\n"
+"DropPod.Weapon.HitLandOnly=   ; boolean, default to no\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1551
+msgid ""
+"`[General] -> DropPodTrailer` is [Ares feature](https://ares-"
+"developers.github.io/Ares-docs/new/droppod.html)."
+msgstr ""
+"`[General] -> DropPodTrailer` 是一个 [Ares 功能](https://ares-"
+"developers.github.io/Ares-docs/new/droppod.html)。"
+
+#: ../../Fixed-or-Improved-Logics.md:1554
+msgid "Exploding object customizations"
+msgstr "爆炸对象的自定义"
+
+#: ../../Fixed-or-Improved-Logics.md:1556
+msgid ""
+"By default `Explodes=true` TechnoTypes have all of their passengers "
+"killed when they are destroyed. This behaviour can now be disabled by "
+"setting `Explodes.KillPassengers=false`."
+msgstr ""
+"默认情况下 `Explodes=true` 的科技类型被摧毁时它们的所有乘客都会被击杀。现在可以通过设置 "
+"`Explodes.KillPassengers=false` 禁用此行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1557
+msgid ""
+"BuildingTypes with `Explodes=true` can by default explode even when they "
+"are still being built or sold. This can be disabled by setting "
+"`Explodes.DuringBuildup` to false. This causes them to behave as if "
+"`Explodes` was set to false while being built up or sold."
+msgstr ""
+"默认情况下拥有 `Explodes=true` 的建筑即使处于建造或出售过程中也可以引爆。可以通过设置 "
+"`Explodes.DuringBuildup` 为 false 来禁用。这样它们在建造或出售过程中会表现得像是 `Explodes` 被设为 "
+"false 一样。"
+
+#: ../../Fixed-or-Improved-Logics.md:1560
+msgid ""
+"[SOMETECHNO]                 ; TechnoType\n"
+"Explodes.KillPassengers=true ; boolean\n"
+"\n"
+"[SOMEBUILDING]               ; BuildingType\n"
+"Explodes.DuringBuildup=true  ; boolean\n"
+msgstr ""
+"[SOMETECHNO]                 ; TechnoType\n"
+"Explodes.KillPassengers=true ; boolean\n"
+"\n"
+"[SOMEBUILDING]               ; BuildingType\n"
+"Explodes.DuringBuildup=true  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1568
+msgid "Forbid parallel AI queues"
+msgstr "禁止 AI 并行生产队列"
+
+#: ../../Fixed-or-Improved-Logics.md:1570
+msgid ""
+"You can now set if specific types of factories do not have AI production "
+"cloning issue instead of Ares' indiscriminate behavior of "
+"`AllowParallelAIQueues=no`."
+msgstr "现在你可以设置特定类型的工厂是否禁用 AI 克隆生产而不是 Ares 的 `AllowParallelAIQueues=no` 那样全部禁用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1571
+msgid ""
+"If `AllowParallelAIQueues=no` *(Ares feature)* is set, the tags have no "
+"effect."
+msgstr "如果 `AllowParallelAIQueues=no`（*Ares 功能*）被设置，该标签无效。"
+
+#: ../../Fixed-or-Improved-Logics.md:1572
+msgid ""
+"You can also exclude specific TechnoTypes from being built in parallel by"
+" AI by setting `ForbidParallelAIQueues` to true on a TechnoType."
+msgstr "你还可以通过在科技类型上将 `ForbidParallelAIQueues` 设为 true 来禁止特定科技类型被 AI 克隆生产。"
+
+#: ../../Fixed-or-Improved-Logics.md:1575
+msgid ""
+"[GlobalControls]\n"
+"AllowParallelAIQueues=yes           ; must be set yes/true unless you "
+"don't use Ares\n"
+"ForbidParallelAIQueues.Infantry=no  ; boolean\n"
+"ForbidParallelAIQueues.Vehicle=no   ; boolean\n"
+"ForbidParallelAIQueues.Navy=no      ; boolean\n"
+"ForbidParallelAIQueues.Aircraft=no  ; boolean\n"
+"ForbidParallelAIQueues.Building=no  ; boolean\n"
+"\n"
+"[SOMETECHNO]                        ; TechnoType\n"
+"ForbidParallelAIQueues=false        ; boolean\n"
+msgstr ""
+"[GlobalControls]\n"
+"AllowParallelAIQueues=yes           ; must be set yes/true unless you "
+"don't use Ares\n"
+"ForbidParallelAIQueues.Infantry=no  ; boolean\n"
+"ForbidParallelAIQueues.Vehicle=no   ; boolean\n"
+"ForbidParallelAIQueues.Navy=no      ; boolean\n"
+"ForbidParallelAIQueues.Aircraft=no  ; boolean\n"
+"ForbidParallelAIQueues.Building=no  ; boolean\n"
+"\n"
+"[SOMETECHNO]                        ; TechnoType\n"
+"ForbidParallelAIQueues=false        ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1588
+msgid "Force techno targeting in distributed frames to improve performance"
+msgstr "强制单位索敌行为分散到不同帧以提升性能"
+
+#: ../../Fixed-or-Improved-Logics.md:1590
+msgid ""
+"When you create many technos in a same frame (i.e. starting the game with"
+" a campaign map that initially has a large number of technos), they will "
+"always scan for targets in a synchronous period, causing game lag. "
+"Increasing targeting delay alone will not make things better, as their "
+"targeting is still synchronized."
+msgstr "当你在同一帧内创建大量单位（例如进入一个初始预置了大量单位的战役地图）时它们总是会同时扫描目标从而导致游戏卡顿。仅通过增大索敌间隔并不能改善这点，因为它们仍会同时索敌。"
+
+#: ../../Fixed-or-Improved-Logics.md:1591
+msgid ""
+"It is now possible to force them to seek targets separately. If "
+"`DistributeTargetingFrame=true` is set, techno's targeting timer will be "
+"initiated with a random delay, ranging in \\[0,15\\]. This can distribute"
+" their targeting timing within 15 frames, thus alleviating the above-"
+"mentioned lag."
+msgstr ""
+"现在可以强制它们分别寻找目标。如果设置 "
+"`DistributeTargetingFrame=true`，单位的瞄准计时器将在随机延迟后启动，延迟范围在 `[0,15]` "
+"之间。这可以将它们的瞄准时间分散在 15 帧内，从而缓解上述卡顿问题。"
+
+#: ../../Fixed-or-Improved-Logics.md:1592
+msgid ""
+"You can use `DistributeTargetingFrame.AIOnly` to make it only work for AI"
+" (Players are not likely to have so many technos.)"
+msgstr "你可以使用 `DistributeTargetingFrame.AIOnly` 使其仅对 AI 生效（人类玩家通常不太可能有那么多单位）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1595
+msgid ""
+"[General]\n"
+"DistributeTargetingFrame=false         ; boolean\n"
+"DistributeTargetingFrame.AIOnly=true   ; boolean\n"
+"\n"
+"[SOMETECHNO]                           ; TechnoType\n"
+"DistributeTargetingFrame=              ; boolean\n"
+msgstr ""
+"[General]\n"
+"DistributeTargetingFrame=false         ; boolean\n"
+"DistributeTargetingFrame.AIOnly=true   ; boolean\n"
+"\n"
+"[SOMETECHNO]                           ; TechnoType\n"
+"DistributeTargetingFrame=              ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1604
+msgid "Iron Curtain & Force Shield effects on organics customization"
+msgstr "铁幕和力场护盾对有机体效果的自定义"
+
+#: ../../Fixed-or-Improved-Logics.md:1606
+msgid ""
+"In vanilla game, when Iron Curtain is applied on `Organic=true` units "
+"like squids or infantry, they could only get killed instantly by "
+"`C4Warhead`. This behavior is now unhardcoded and can be set with "
+"`IronCurtain.EffectOnOrganics` globally and on per-TechnoType basis with "
+"`IronCurtain.Effect`. Following values are respected:"
+msgstr ""
+"在原本的游戏中，当铁幕效果应用于例如巨型乌贼和步兵这种 `Organic=true` 的单位时，它们只能被 `C4Warhead` "
+"瞬间击杀。现在此行为已被解除硬编码，并且可以通过全局的 `IronCurtain.EffectOnOrganics` 和每个科技类型的 "
+"`IronCurtain.Effect` 属性来自定义。可接受的值如下："
+
+#: ../../Fixed-or-Improved-Logics.md:1607
+msgid ""
+"`kill` : Iron Curtain kills the organic object with a specifc warhead. "
+"This is the default value for `Organic=true` units and infantry if not "
+"otherwise specified."
+msgstr "`kill`：铁幕会用特定的弹头杀死有机体，这是 `Organic=true` 单位和步兵的默认值，除非专门指定。"
+
+#: ../../Fixed-or-Improved-Logics.md:1608
+msgid ""
+"`invulnerable` : Iron Curtain makes the organic object invulnerable like "
+"buildings and vehicles."
+msgstr "`invulnerable`：铁幕会使有机体像建筑和载具一样获得无敌效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:1609
+msgid "`ignore` : Iron Curtain doesn't give any effect on the organic object."
+msgstr "`ignore`：铁幕不会对有机体造成任何影响。"
+
+#: ../../Fixed-or-Improved-Logics.md:1610
+msgid "Identical controls are available for Force Shield as well."
+msgstr "力场护盾也有相同的控制选项。"
+
+#: ../../Fixed-or-Improved-Logics.md:1613
+msgid ""
+"[CombatDamage]\n"
+"IronCurtain.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
+"(kill | invulnerable | ignore)\n"
+"IronCurtain.KillOrganicsWarhead=   ; WarheadType, default to "
+"[CombatDamage] -> C4Warhead\n"
+"ForceShield.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
+"(kill | invulnerable | ignore)\n"
+"ForceShield.KillOrganicsWarhead=   ; WarheadType, default to "
+"[CombatDamage] -> C4Warhead\n"
+"\n"
+"[SOMETECHNO]                       ; TechnoType with Organic=true\n"
+"IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill"
+" | invulnerable | ignore)\n"
+"IronCurtain.KillWarhead=           ; WarheadType, default to "
+"[CombatDamage] -> IronCurtain.KillOrganicsWarhead\n"
+"ForceShield.Effect=                ; IronCurtain effect Enumeration (kill"
+" | invulnerable | ignore)\n"
+"ForceShield.KillWarhead=           ; WarheadType, default to "
+"[CombatDamage] -> ForceShield.KillOrganicsWarhead\n"
+msgstr ""
+"[CombatDamage]\n"
+"IronCurtain.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
+"(kill | invulnerable | ignore)\n"
+"IronCurtain.KillOrganicsWarhead=   ; WarheadType, default to "
+"[CombatDamage] -> C4Warhead\n"
+"ForceShield.EffectOnOrganics=kill  ; Iron Curtain effect Enumeration "
+"(kill | invulnerable | ignore)\n"
+"ForceShield.KillOrganicsWarhead=   ; WarheadType, default to "
+"[CombatDamage] -> C4Warhead\n"
+"\n"
+"[SOMETECHNO]                       ; TechnoType with Organic=true\n"
+"IronCurtain.Effect=                ; IronCurtain effect Enumeration (kill"
+" | invulnerable | ignore)\n"
+"IronCurtain.KillWarhead=           ; WarheadType, default to "
+"[CombatDamage] -> IronCurtain.KillOrganicsWarhead\n"
+"ForceShield.Effect=                ; IronCurtain effect Enumeration (kill"
+" | invulnerable | ignore)\n"
+"ForceShield.KillWarhead=           ; WarheadType, default to "
+"[CombatDamage] -> ForceShield.KillOrganicsWarhead\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1627
+msgid "Jumpjet climbing logic enhancement"
+msgstr "Jumpjet 爬升逻辑增强"
+
+#: ../../Fixed-or-Improved-Logics.md:1629
+msgid ""
+"You can now let the jumpjets increase their height earlier by set "
+"`JumpjetClimbPredictHeight` to true. The jumpjet will raise its height 5 "
+"cells in advance, instead of only raising its height when encountering "
+"cliffs or buildings in front of it."
+msgstr ""
+"现在你可以通过将 `JumpjetClimbPredictHeight` 设为 true 来使 Jumpjet "
+"单位提前增加飞行高度。Jumpjet 将会提前 5 个单元格开始抬升而非仅在悬崖和建筑马上贴脸了才抬升高度。"
+
+#: ../../Fixed-or-Improved-Logics.md:1630
+msgid ""
+"You can also let them simply skip the stop check by set "
+"`JumpjetClimbWithoutCutOut` to true. The jumpjet will not stop moving "
+"horizontally when encountering cliffs or buildings in front of it, but "
+"will continue to move forward while raising its altitude."
+msgstr ""
+"你还可以通过将 `JumpjetClimbWithoutCutOut` 设为 true 来跳过停止移动检查。Jumpjet "
+"在已经抵近悬崖或建筑时将不会停止水平方向上的移动，而是在抬升高度的同时继续前行。"
+
+#: ../../Fixed-or-Improved-Logics.md:1631
+msgid ""
+"When `JumpjetClimbPredictHeight` is enabled, if the height raised five "
+"grids in advance is still not enough to cross cliffs or buildings, it "
+"will stop and move horizontally as before, unless "
+"`JumpjetClimbWithoutCutOut` is also enabled."
+msgstr ""
+"当启用 `JumpjetClimbPredictHeight` 时，若提前 5 个单元格后的高度仍然不足以越过悬崖或建筑，Jumpjet "
+"将会像原先那样停止水平方向上的移动，除非还启用了 `JumpjetClimbWithoutCutOut`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1634
+msgid ""
+"[General]\n"
+"JumpjetClimbPredictHeight=false  ; boolean\n"
+"JumpjetClimbWithoutCutOut=false  ; boolean\n"
+msgstr ""
+"[General]\n"
+"JumpjetClimbPredictHeight=false  ; boolean\n"
+"JumpjetClimbWithoutCutOut=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1640
+msgid "Jumpjet rotating on crashing toggle"
+msgstr "Jumpjet 旋转着坠毁的开关"
+
+#: ../../Fixed-or-Improved-Logics.md:1642
+msgid ""
+"Jumpjet that is going to crash starts to change its facing "
+"uncontrollably, this can now be turned off."
+msgstr "即将坠毁的 Jumpjet 会开始不可控地改变其朝向，现在可以将其关闭。"
+
+#: ../../Fixed-or-Improved-Logics.md:1645
+msgid ""
+"[SOMETECHNO]               ; TechnoType\n"
+"JumpjetRotateOnCrash=true  ; boolean\n"
+msgstr ""
+"[SOMETECHNO]               ; TechnoType\n"
+"JumpjetRotateOnCrash=true  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1651
+msgid "This may subject to further changes."
+msgstr "这可能会在未来进一步更改。"
+
+#: ../../Fixed-or-Improved-Logics.md:1654
+msgid "Kill spawns on low power"
+msgstr "断电时击杀子机"
+
+#: ../../Fixed-or-Improved-Logics.md:1656
+msgid ""
+"`Powered=yes` structures that spawn aircraft like Aircraft Carriers will "
+"stop targeting the enemy if low power."
+msgstr "拥有 `Powered=yes` 的建筑航母在断电时将会停止攻击敌人。"
+
+#: ../../Fixed-or-Improved-Logics.md:1657
+msgid "Spawned aircraft self-destruct if they are flying."
+msgstr "被生成的战机如果正在飞行那么会自毁。"
+
+#: ../../Fixed-or-Improved-Logics.md:1660
+msgid ""
+"[SOMESTRUCTURE]          ; BuildingType\n"
+"Powered.KillSpawns=false ; boolean\n"
+msgstr ""
+"[SOMESTRUCTURE]          ; BuildingType\n"
+"Powered.KillSpawns=false ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1665
+msgid "PipScale pip customizations"
+msgstr "自定义 PipScale"
+
+#: ../../Fixed-or-Improved-Logics.md:1667
+msgid ""
+"It is now possible to change the size of pips (or more accurately the "
+"pixel increment to the next pip drawn) displayed on `PipScale`."
+msgstr "现在可以更改在 `PipScale` 中显示的 pip 的大小（或者更确切的说是绘制下一个 pip 的像素增量）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1668
+msgid ""
+"`Pips.Generic.(Buildings.)Size` is for non-ammo pips on non-building "
+"TechnoTypes / buildings, accordingly, and `Pips.Ammo.(Buildings.)Size` is"
+" in turn for ammo pips, split similarly between non-building technos and "
+"buildings."
+msgstr ""
+"`Pips.Generic.(Buildings.)Size` 用于非建筑科技类型／建筑的非弹药 "
+"pip，相应的，`Pips.Ammo.(Buildings.)Size` 则是针对弹药 pip，同样分别对应非建筑科技类型／建筑。"
+
+#: ../../Fixed-or-Improved-Logics.md:1669
+msgid ""
+"Ammo pip size can also be overridden on per TechnoType-basis using "
+"`AmmoPipSize`."
+msgstr "还可以通过 `AmmoPipSize` 为每个科技类型重写弹药 pip 的大小。"
+
+#: ../../Fixed-or-Improved-Logics.md:1670
+msgid "Ammo pip frames can now also be customized."
+msgstr "现在也可以自定义弹药  pip 的帧。"
+
+#: ../../Fixed-or-Improved-Logics.md:1671
+msgid ""
+"`AmmoPipFrame` and `EmptyAmmoPipFrame` are frames (zero-based) of "
+"`pips2.shp` used for ammo pip and empty ammo pip (this is not set by "
+"default) for when `PipWrap=0` (this is the default)."
+msgstr ""
+"`AmmoPipFrame` 和 `EmptyAmmoPipFrame` 是在 `PipWrap=0`（这是默认行为）时使用的 "
+"`pips2.shp` 中（从 0 开始的）帧，用于弹药 pip 和空弹药 pip。"
+
+#: ../../Fixed-or-Improved-Logics.md:1672
+msgid ""
+"`AmmoPipWrapStartFrame` is used as start frame (zero-based, from "
+"`pips2.shp`) for when `PipWrap` is above 0. The start frame is the empty "
+"frame and up to `Ammo` divided by `PipWrap` frames after it are used for "
+"the different reload stages."
+msgstr ""
+"`AmmoPipWrapStartFrame` 用作 `PipWrap` 大于 0 时将 `pips2.shp` 中（从 0 "
+"开始的）帧设为起始帧。起始帧是空帧，从起始帧之后最多有 `Ammo` 除以 `PipWrap` 个帧用于不同的装填阶段。"
+
+#: ../../Fixed-or-Improved-Logics.md:1673
+msgid "`AmmoPipOffset` can be used to shift the starting position of ammo pips."
+msgstr "`AmmoPipOffset` 可用于移动弹药 pip 的起始位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:1674
+msgid "Pips for TechnoTypes with `Spawns` can now also be customized."
+msgstr "现在带有 `Spawns` 的科技类型的 pip 也可以进行自定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:1675
+msgid ""
+"`ShowSpawnsPips` determines whether or not these pips are shown at all, "
+"as they are independent from `PipScale` setting."
+msgstr "`ShowSpawnsPips` 决定这些 pip 是否显示，因为它们与 `PipScale` 设置无关。"
+
+#: ../../Fixed-or-Improved-Logics.md:1676
+msgid ""
+"`SpawnsPipFrame` and `EmptySpawnsPipFrame` are frames (zero-based) of "
+"`pips.shp` (for buildings) or `pips2.shp` (for others) used for a spawnee"
+" pip and empty spawnee pip, respectively."
+msgstr ""
+"`SpawnsPipFrame` 和 `EmptySpawnsPipFrame` 分别是 `pips.shp`（对于建筑）或 "
+"`pips2.shp`（对于其他）中（从 0 开始的）帧，用于子机 pip 和空子机 pip。"
+
+#: ../../Fixed-or-Improved-Logics.md:1677
+msgid ""
+"`SpawnsPipSize` determines the pixel increment to the next pip drawn. "
+"Defaults to `[AudioVisual] -> Pips.Generic.(Buildings.)Size` if not set."
+msgstr ""
+"`SpawnsPipSize` 决定了到下一个 pip 绘制的像素增量。若未设置则默认为 `[AudioVisual] -> "
+"Pips.Generic.(Buildings.)Size`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1678
+msgid ""
+"`SpawnsPipoffset` can be used to shift the starting position of spawnee "
+"pips."
+msgstr "`SpawnsPipoffset` 可以被用于移动子机 pip 的起始位置。"
+
+#: ../../Fixed-or-Improved-Logics.md:1679
+msgid ""
+"Pips for `Storage` can now also be customized via new keys in "
+"`[AudioVisual]`."
+msgstr "现在可以通过 `[AudioVisual]` 中的新标签来自定义 `Storage` 的 pip。"
+
+#: ../../Fixed-or-Improved-Logics.md:1680
+msgid ""
+"`Pips.Tiberiums.Frames` can be used to list frames (zero-based) of "
+"`pips.shp` (for buildings) or `pips2.shp` (for others) used for tiberium "
+"types, in the listed order corresponding to tiberium type index. Defaults"
+" to 5 for tiberium type index 1, otherwise 2."
+msgstr ""
+"`Pips.Tiberiums.Frames` 可用于列出用于泰伯利亚类型的 `pips.shp`（用于建筑）或 "
+"`pips2.shp`（用于其他）中（从 0 开始的）帧，按与泰伯利亚类型序数对应的列表排列顺序，泰伯利亚类型为 1 时默认为 5，否则为 2。"
+
+#: ../../Fixed-or-Improved-Logics.md:1681
+msgid ""
+"`Pips.Tiberiums.EmptyFrame` can be used to set the frame for empty slots,"
+" defaults to 0."
+msgstr "`Pips.Tiberiums.EmptyFrame` 可用于设置空槽的帧，默认为 0。"
+
+#: ../../Fixed-or-Improved-Logics.md:1682
+msgid ""
+"`Pips.Tiberiums.DisplayOrder` controls in which order the tiberium type "
+"pips are displayed, takes a list of tiberium type indices. Any tiberium "
+"type not listed will be displayed in sequential order after the listed "
+"ones."
+msgstr ""
+"`Pips.Tiberiums.DisplayOrder` 控制泰伯利亚类型 pip "
+"显示的顺序，取一个泰伯利亚类型索引列表。任何未列出的将在列出后按顺序显示。"
+
+#: ../../Fixed-or-Improved-Logics.md:1683
+msgid ""
+"`Pips.Tiberiums.WeedFrame` controls which frame is displayed on Technos "
+"with `Weeder=yes`, takes a (zero-based) index of a frame in `pips.shp` "
+"(for buildings) or `pips2.shp` (for others). Defaults to 1."
+msgstr ""
+"`Pips.Tiberiums.WeedFrame` 控制在 `Weeder=yes` 科技类型上显示的帧，使用 "
+"`pips.shp`（用于建筑）或 `pips2.shp`（用于其他）中（从 0 开始的）索引，默认为 1。"
+
+#: ../../Fixed-or-Improved-Logics.md:1684
+msgid ""
+"`Pips.Tiberiums.WeedEmptyFrame` can be used to set the frame for empty "
+"weed slots, defaults to 0."
+msgstr "`Pips.Tiberiums.WeedEmptyFrame` 可用于设置空置废矿槽的帧，默认为 0。"
+
+#: ../../Fixed-or-Improved-Logics.md:1687
+msgid ""
+"[AudioVisual]\n"
+"Pips.Generic.Size=4,0                ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Generic.Buildings.Size=4,2      ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Ammo.Size=4,0                   ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Ammo.Buildings.Size=4,2         ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Tiberiums.EmptyFrame=0          ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.Frames=2,5,2,2        ; List of integers, frames of "
+"pips.shp (buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.DisplayOrder=0,2,3,1  ; List of integers, tiberium type "
+"indices\n"
+"Pips.Tiberiums.WeedEmptyFrame=0      ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.WeedFrame=1           ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"\n"
+"[SOMETECHNO]                         ; TechnoType\n"
+"AmmoPipFrame=13                      ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"EmptyAmmoPipFrame=-1                 ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"AmmoPipWrapStartFrame=14             ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"AmmoPipSize=                         ; X,Y, increment in pixels to next "
+"pip\n"
+"AmmoPipOffset=0,0                    ; X,Y, position offset from default\n"
+"ShowSpawnsPips=true                  ; boolean\n"
+"SpawnsPipFrame=1                     ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"EmptySpawnsPipFrame=0                ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"SpawnsPipSize=                       ; X,Y, increment in pixels to next "
+"pip\n"
+"SpawnsPipOffset=0,0                  ; X,Y, position offset from default\n"
+msgstr ""
+"[AudioVisual]\n"
+"Pips.Generic.Size=4,0                ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Generic.Buildings.Size=4,2      ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Ammo.Size=4,0                   ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Ammo.Buildings.Size=4,2         ; X,Y, increment in pixels to next "
+"pip\n"
+"Pips.Tiberiums.EmptyFrame=0          ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.Frames=2,5,2,2        ; List of integers, frames of "
+"pips.shp (buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.DisplayOrder=0,2,3,1  ; List of integers, tiberium type "
+"indices\n"
+"Pips.Tiberiums.WeedEmptyFrame=0      ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"Pips.Tiberiums.WeedFrame=1           ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"\n"
+"[SOMETECHNO]                         ; TechnoType\n"
+"AmmoPipFrame=13                      ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"EmptyAmmoPipFrame=-1                 ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"AmmoPipWrapStartFrame=14             ; integer, frame of pips2.shp (zero-"
+"based)\n"
+"AmmoPipSize=                         ; X,Y, increment in pixels to next "
+"pip\n"
+"AmmoPipOffset=0,0                    ; X,Y, position offset from default\n"
+"ShowSpawnsPips=true                  ; boolean\n"
+"SpawnsPipFrame=1                     ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"EmptySpawnsPipFrame=0                ; integer, frame of pips.shp "
+"(buildings) or pips2.shp (others) (zero-based)\n"
+"SpawnsPipSize=                       ; X,Y, increment in pixels to next "
+"pip\n"
+"SpawnsPipOffset=0,0                  ; X,Y, position offset from default\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1712
+msgid "Power drain for units"
+msgstr "单位消耗电力"
+
+#: ../../Fixed-or-Improved-Logics.md:1714
+msgid ""
+"Infantry, vehicles and aircraft can now drain or provide `Power` if "
+"`UnitPowerDrain=true` is set."
+msgstr "如果设置了 `UnitPowerDrain=true`，步兵、载具和战机现在都将可以消耗或提供 `Power`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1717
+msgid ""
+"[General]\n"
+"UnitPowerDrain=false  ; boolean\n"
+"\n"
+"[SOMETECHNO]          ; TechnoType\n"
+"Power=0               ; integer, positive means output, negative means "
+"drain\n"
+msgstr ""
+"[General]\n"
+"UnitPowerDrain=false  ; boolean\n"
+"\n"
+"[SOMETECHNO]          ; TechnoType\n"
+"Power=0               ; integer, positive means output, negative means "
+"drain\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1725
+msgid "RadarInvisible for non-enemy house"
+msgstr "不仅限于敌方的 `RadarInvisible`"
+
+#: ../../Fixed-or-Improved-Logics.md:1727
+msgid ""
+"In vanilla, `RadarInvisible` is ignored if the techno is allied with the "
+"current player. Now you can change this behavior."
+msgstr "在原版游戏中 `RadarInvisible` 仅对当前非友军的玩家有效，现在你可以更改这一行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1730
+msgid ""
+"[SOMETECHNO]                         ; TechnoType\n"
+"RadarInvisibleToHouse=               ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if"
+" RadarInvisible=true, none otherwise\n"
+msgstr ""
+"[SOMETECHNO]                         ; TechnoType\n"
+"RadarInvisibleToHouse=               ; Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all), default to enemy if"
+" RadarInvisible=true, none otherwise\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1735
+msgid "Subterranean unit travel height and speed"
+msgstr "潜地单位移动高度和速度"
+
+#: ../../Fixed-or-Improved-Logics.md:1737
+msgid ""
+"It is now possible to control the height at which units with subterranean"
+" (Tunnel) `Locomotor` travel, globally or per TechnoType."
+msgstr "现在可以控制拥有潜地（Tunnel）`Locomotor` 的单位移动的高度，可以在全局和每个科技类型上定义。"
+
+#: ../../Fixed-or-Improved-Logics.md:1738
+msgid ""
+"Subterranean movement speed is now also customizable, both globally and "
+"per TechnoType. If per-TechnoType value is negative, global value is "
+"used. This does not affect the speed at which the unit moves vertically "
+"when burrowing which is determined by `Speed` multiplied by `[General] ->"
+" TunnelSpeed`."
+msgstr ""
+"潜地移动速度现在也可以自定义，同样拥有全局和微观标签。如果微观标签的值为负数则使用全局值。这不会影响单位在潜地时的垂直移动速度。该速度由 "
+"`Speed` * `[General] -> TunnelSpeed` 决定。"
+
+#: ../../Fixed-or-Improved-Logics.md:1741
+msgid ""
+"[General]\n"
+"SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)"
+"\n"
+"SubterraneanSpeed=19     ; floating point value\n"
+"\n"
+"[SOMETECHNO]             ; TechnoType\n"
+"SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)"
+"\n"
+"SubterraneanSpeed=-1     ; floating point value\n"
+msgstr ""
+"[General]\n"
+"SubterraneanHeight=-256  ; integer, height in leptons (1/256th of a cell)"
+"\n"
+"SubterraneanSpeed=19     ; floating point value\n"
+"\n"
+"[SOMETECHNO]             ; TechnoType\n"
+"SubterraneanHeight=      ; integer, height in leptons (1/256th of a cell)"
+"\n"
+"SubterraneanSpeed=-1     ; floating point value\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1752
+msgid ""
+"`SubterraneanHeight` expects negative values to be used and may behave "
+"erratically if set to above -50."
+msgstr "`SubterraneanHeight` 最好使用一个负值并且如果设置为大于 -50 的值可能会出现异常行为。"
+
+#: ../../Fixed-or-Improved-Logics.md:1755
+msgid "Target scanning delay optimization"
+msgstr "索敌间隔优化"
+
+#: ../../Fixed-or-Improved-Logics.md:1757
+msgid ""
+"In vanilla, the game used `NormalTargetingDelay` and "
+"`GuardAreaTargetingDelay` to globally control the target searching "
+"intervals. Increasing these values would make units stupid, while "
+"decreasing them would cause game lag."
+msgstr ""
+"原版中游戏使用 `NormalTargetingDelay` 和 `GuardAreaTargetingDelay` "
+"来全局控制单位的索敌间隔。增大这些值会导致单位反应迟钝，减小这些值则可能导致游戏卡顿。"
+
+#: ../../Fixed-or-Improved-Logics.md:1758
+msgid ""
+"Now, you can define them per techno, also allowing different values for "
+"AI and players. The default values are the same as those originally "
+"defined by the vanilla flags."
+msgstr "现在可以在每种单位上微观定义这些参数，且可为 AI 玩家和人类玩家分离设置。默认值取自原版全局。"
+
+#: ../../Fixed-or-Improved-Logics.md:1759
+msgid ""
+"You can also specific this delay for attack move mission. The default "
+"value is `NormalTargetingDelay`."
+msgstr "你还可以为移动攻击指令单独设定间隔。默认使用 `NormalTargetingDelay` 的值。"
+
+#: ../../Fixed-or-Improved-Logics.md:1762
+msgid ""
+"[General]\n"
+"AINormalTargetingDelay=              ; integer, game frames\n"
+"PlayerNormalTargetingDelay=          ; integer, game frames\n"
+"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
+"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
+"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
+"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
+"\n"
+"[SOMETECHNO]                         ; TechnoType\n"
+"AINormalTargetingDelay=              ; integer, game frames\n"
+"PlayerNormalTargetingDelay=          ; integer, game frames\n"
+"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
+"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
+"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
+"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
+msgstr ""
+"[General]\n"
+"AINormalTargetingDelay=              ; integer, game frames\n"
+"PlayerNormalTargetingDelay=          ; integer, game frames\n"
+"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
+"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
+"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
+"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
+"\n"
+"[SOMETECHNO]                         ; TechnoType\n"
+"AINormalTargetingDelay=              ; integer, game frames\n"
+"PlayerNormalTargetingDelay=          ; integer, game frames\n"
+"AIGuardAreaTargetingDelay=           ; integer, game frames\n"
+"PlayerGuardAreaTargetingDelay=       ; integer, game frames\n"
+"AIAttackMoveTargetingDelay=          ; integer, game frames\n"
+"PlayerAttackMoveTargetingDelay=      ; integer, game frames\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1780
+msgid "Voxel body multi-section shadows"
+msgstr "Voxel 主体多组件阴影"
+
+#: ../../Fixed-or-Improved-Logics.md:1782
+msgid ""
+"![image](_static/images/uh0-be.gif) *UH-0 helicopter with dynamic "
+"propeller and its shadow in [Bellum "
+"Æternum](https://ra2be.com/download.html)*"
+msgstr ""
+"![image](_static/images/uh0-be.gif) "
+"*[万世之战](https://ra2be.com/zh/download.html) 中拥有可动螺旋桨及其影子的 UH-0 直升机*"
+
+#: ../../Fixed-or-Improved-Logics.md:1785
+msgid ""
+"It is also now possible for vehicles and aircraft to display shadows for "
+"multiple sections of the voxel body at once, instead of just one section "
+"specified by `ShadowIndex`, by specifying the section indices in "
+"`ShadowIndices` (which defaults to `ShadowIndex`) in unit's `artmd.ini` "
+"entry."
+msgstr ""
+"现在载具和战机可以通过在单位的 `artmd.ini` 条目中使用 `ShadowIndices`（默认为 "
+"`ShadowIndex`）指定多个组件索引来一性次显示出 Voxel 主体中多个组件的影子，而不再仅限于绘制 `ShadowIndex` "
+"所指定的单个组件。"
+
+#: ../../Fixed-or-Improved-Logics.md:1786
+msgid ""
+"`ShadowIndex.Frame` and `ShadowIndices.Frame` can be used to customize "
+"which frame of the HVA animation for the section from `ShadowIndex` and "
+"`ShadowIndices` is used to display the shadow, respectively. -1 is "
+"special value which means currently shown frame is used, and "
+"`ShadowIndices.Frame` defaults to this."
+msgstr ""
+"`ShadowIndex.Frame` 和 `ShadowIndices.Frame` 可以分别用于自定义从 `ShadowIndex` 和 "
+"`ShadowIndices` 所指定组件的 HVA 动画中显示影子时所使用的帧。-1 是一个用于表示使用当前帧的特殊值，并且 "
+"`ShadowIndices.Frame` 默认如此。"
+
+#: ../../Fixed-or-Improved-Logics.md:1789
+msgid ""
+"[SOMETECHNO]          ; TechnoType\n"
+"ShadowIndices=        ; List of integers (voxel section indices)\n"
+"ShadowIndex.Frame=0   ; integer (HVA animation frame index)\n"
+"ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)\n"
+msgstr ""
+"[SOMETECHNO]          ; TechnoType\n"
+"ShadowIndices=        ; List of integers (voxel section indices)\n"
+"ShadowIndex.Frame=0   ; integer (HVA animation frame index)\n"
+"ShadowIndices.Frame=  ; List of integers (HVA animation frame indices)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1796
+msgid "Voxel shadow scaling in air"
+msgstr "Voxel 在空中时的影子缩放"
+
+#: ../../Fixed-or-Improved-Logics.md:1798
+msgid ""
+"It is now possible to adjust how voxel air units (`VehicleType` & "
+"`AircraftType`) shadows scale in air. By default the shadows scale by "
+"`AirShadowBaseScale` (defaults to 0.5) amount if unit is "
+"`ConsideredAircraft=true`."
+msgstr ""
+"现在可以调整 Voxel 空中单位（载具和战机）的影子如何缩放。默认情况下如果单位拥有 `ConsideredAircraft=true` "
+"那么影子会按 `AirShadowBaseScale` （默认为 0.5）进行缩放"
+
+#: ../../Fixed-or-Improved-Logics.md:1799
+msgid ""
+"If `HeightShadowScaling=true`, the shadow is scaled by amount that is "
+"determined by following formula: `Max(AirShadowBaseScale ^ (currentHeight"
+" / ShadowSizeCharacteristicHeight), HeightShadowScaling.MinScale)`, where"
+" `currentHeight` is unit's current height in leptons, "
+"`ShadowSizeCharacteristicHeight` overrideable value that defaults to the "
+"maximum cruise height (`JumpjetHeight`, `FlightLevel` etc) and "
+"`HeightShadowScaling.MinScale` sets a floor for the scale."
+msgstr ""
+"如果 `HeightShadowScaling=true`，影子会根据以下公式缩放： `Max(AirShadowBaseScale ^ "
+"(currentHeight / ShadowSizeCharacteristicHeight), "
+"HeightShadowScaling.MinScale)`，这里的 `currentHeight` 是单位当前高度（单位 "
+"lepton），`ShadowSizeCharacteristicHeight` "
+"是一个可覆盖的值，默认为最大巡航高度（`JumpjetHeight`、`FlightLevel` 等），而 "
+"`HeightShadowScaling.MinScale` 设置了缩放的下限。"
+
+#: ../../Fixed-or-Improved-Logics.md:1802
+msgid ""
+"[AudioVisual]\n"
+"AirShadowBaseScale=0.5            ; floating point value\n"
+"HeightShadowScaling=false         ; boolean\n"
+"HeightShadowScaling.MinScale=0.0  ; floating point value\n"
+"\n"
+"[SOMETECHNO]                      ; TechnoType\n"
+"ShadowSizeCharacteristicHeight=   ; integer, height in leptons\n"
+msgstr ""
+"[AudioVisual]\n"
+"AirShadowBaseScale=0.5            ; floating point value\n"
+"HeightShadowScaling=false         ; boolean\n"
+"HeightShadowScaling.MinScale=0.0  ; floating point value\n"
+"\n"
+"[SOMETECHNO]                      ; TechnoType\n"
+"ShadowSizeCharacteristicHeight=   ; integer, height in leptons\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1812
+msgid "Terrains"
+msgstr "地形对象"
+
+#: ../../Fixed-or-Improved-Logics.md:1814
+msgid "Animated TerrainTypes"
+msgstr "动画化地形对象"
+
+#: ../../Fixed-or-Improved-Logics.md:1816
+msgid ""
+"![Waving trees](_static/images/tree-shake.gif) *Animated trees used in "
+"[Ion Shock](https://www.moddb.com/mods/tiberian-war-ionshock)*"
+msgstr ""
+"![Waving trees](_static/images/tree-shake.gif) *[Ion "
+"Shock](https://www.moddb.com/mods/tiberian-war-ionshock) 中会动的树*"
+
+#: ../../Fixed-or-Improved-Logics.md:1816
+msgid "Waving trees"
+msgstr "会动的树"
+
+#: ../../Fixed-or-Improved-Logics.md:1819
+msgid ""
+"By default `IsAnimated`, `AnimationRate` and `AnimationProbability` only "
+"work on TerrainTypes with `SpawnsTiberium` set to true. This restriction "
+"has now been lifted."
+msgstr ""
+"默认情况下 `IsAnimated`、`AnimationRate` 和 `AnimationProbability` 仅适用于 "
+"`SpawnsTiberium` 设置为 true 的地形对象。这一限制已被解除。"
+
+#: ../../Fixed-or-Improved-Logics.md:1820
+msgid ""
+"Length of the animation can now be customized by setting "
+"`AnimationLength` as well, defaulting to half (or quarter if [damaged "
+"frames](#damaged-frames-and-crumbling-animation) are enabled) the number "
+"of frames in TerrainType's image."
+msgstr ""
+"现在动画的长度可以通过设置 `AnimationLength` 来自定义，默认为地形对象图像帧数的一半（如果启用了[破损帧](#damaged-"
+"frames-and-crumbling-animation)则为四分之一）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1823
+msgid ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"AnimationLength=   ; integer, number of frames\n"
+msgstr ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"AnimationLength=   ; integer, number of frames\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1828
+msgid "Custom palette"
+msgstr "自定义色盘"
+
+#: ../../Fixed-or-Improved-Logics.md:1830
+msgid ""
+"You can now specify custom palette for TerrainTypes in similar manner as "
+"TechnoTypes can."
+msgstr "现在你可以像为科技类型那样为地形对象指定自定义色盘。"
+
+#: ../../Fixed-or-Improved-Logics.md:1833
+msgid ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"Palette=           ; filename - excluding .pal extension and three-"
+"character theater-specific suffix\n"
+msgstr ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"Palette=           ; filename - excluding .pal extension and three-"
+"character theater-specific suffix\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1839
+msgid ""
+"This palette behaves like an object palette and does not use tint etc. "
+"that have been applied to the tile the TerrainType resides on like a "
+"TerrainType using tile palette would."
+msgstr "此色盘的行为就像原有的对象色盘那样不受光效影响。也就是地形对象将不会同步使用应用于地形对象所在地块上的色调。"
+
+#: ../../Fixed-or-Improved-Logics.md:1842
+msgid "Customizable ore spawners"
+msgstr "自定义矿柱"
+
+#: ../../Fixed-or-Improved-Logics.md:1844
+msgid ""
+"![image](_static/images/ore-01.png) *Different ore spawners in [Rise of "
+"the East](https://www.moddb.com/mods/riseoftheeast)*"
+msgstr ""
+"![image](_static/images/ore-01.png) "
+"*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中不同的矿柱*"
+
+#: ../../Fixed-or-Improved-Logics.md:1847
+msgid "You can now specify which type of ore certain TerrainType would generate."
+msgstr "现在你可以指定地形对象将会生成哪种矿石。"
+
+#: ../../Fixed-or-Improved-Logics.md:1848
+msgid ""
+"It's also now possible to specify a range value for an ore generation "
+"area different compared to standard 3x3 rectangle. Ore will be uniformly "
+"distributed across all affected cells in a spread range."
+msgstr "现在还可以指定与标准 3x3 矩形不同的矿石生成区域范围值。矿石将均匀地分布在扩散范围内所有受影响的单元格中。"
+
+#: ../../Fixed-or-Improved-Logics.md:1849
+msgid ""
+"You can specify which ore growth stage will be spawned and how many cells"
+" will be filled with ore per ore generation animation. Corresponding tags"
+" accept either a single integer value or two comma-separated values to "
+"allow randomized growth stages from the range (inclusive)."
+msgstr "此外也可以指定将生成哪个矿石生长阶段以及每次播放矿石生成动画将会填充多少个单元格。相对应的标签接受单个整数值或两个逗号分隔的值以允许范围内（含）随机化的生长阶段。"
+
+#: ../../Fixed-or-Improved-Logics.md:1852
+msgid ""
+"[SOMETERRAINTYPE]             ; TerrainType\n"
+"SpawnsTiberium.Type=0         ; tiberium/ore type index\n"
+"SpawnsTiberium.Range=1        ; integer, radius in cells\n"
+"SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range\n"
+"SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range\n"
+msgstr ""
+"[SOMETERRAINTYPE]             ; TerrainType\n"
+"SpawnsTiberium.Type=0         ; tiberium/ore type index\n"
+"SpawnsTiberium.Range=1        ; integer, radius in cells\n"
+"SpawnsTiberium.GrowthStage=3  ; integer - single or comma-sep. range\n"
+"SpawnsTiberium.CellsPerAnim=1 ; integer - single or comma-sep. range\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1860
+msgid "Damaged frames and crumbling animation"
+msgstr "伤残和倒坍动画"
+
+#: ../../Fixed-or-Improved-Logics.md:1862
+msgid ""
+"By default game shows damage frame only for TerrainTypes alive at only 1 "
+"point of health left. Because none of the original game TerrainType "
+"assets were made with this in mind, the logic is now locked behind a new "
+"key `HasDamagedFrames`."
+msgstr ""
+"默认情况下游戏在地形对象仅 1 点血时显示破损帧。由于原本游戏中的地形对象资源文件并未考虑这一点因此目前该逻辑仅限添加了 "
+"`HasDamagedFrames` 的情况下使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1863
+msgid ""
+"Instead of showing at 1 point of HP left, TerrainTypes switch to damaged "
+"frames once their health reaches `[AudioVisual] -> "
+"ConditionYellow.Terrain` percentage of their maximum health."
+msgstr ""
+"地形对象不再在仅剩 1 点血时显示破损帧，而是在其血量达到 `[AudioVisual] -> ConditionYellow.Terrain` "
+"的百分比时才进行切换。"
+
+#: ../../Fixed-or-Improved-Logics.md:1864
+msgid ""
+"In addition, TerrainTypes can now show 'crumbling' animation after their "
+"health has reached zero and before they are deleted from the map by "
+"setting `HasCrumblingFrames` to true."
+msgstr ""
+"此外，地形对象现在可以在其血量归 0 后到从地图中删除前的这段时间中通过设置 `HasCrumblingFrames` 为 true 来显示一个 "
+"“倒坍” 动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:1865
+msgid ""
+"Crumbling frames start from first frame after both regular & damaged "
+"frames and ends at halfway point of the frames in TerrainType's image."
+msgstr "倒坍所用的帧从紧随于常规帧和破损帧之后的第一帧开始直到地形对象图像帧的一半处中止（另一半是影子）。"
+
+#: ../../Fixed-or-Improved-Logics.md:1866
+msgid ""
+"Sound event from `CrumblingSound` (if set) is played when crumbling "
+"animation starts playing."
+msgstr "当倒坍动画开始播放时将会播放 `CrumblingSound`（如果设置）指定的音效。"
+
+#: ../../Fixed-or-Improved-Logics.md:1867
+msgid ""
+"[Destroy animation & sound](New-or-Enhanced-Logics.md#destroy-animation--"
+"sound) only play after crumbling animation has finished."
+msgstr "[摧毁动画和音效](New-or-Enhanced-Logics.md#destroy-animation--sound) 仅在倒坍动画结束后播放。"
+
+#: ../../Fixed-or-Improved-Logics.md:1870
+msgid ""
+"[AudioVisual]\n"
+"ConditionYellow.Terrain=  ; floating-point value, default to "
+"[AudioVisual] -> ConditionYellow\n"
+"\n"
+"[SOMETERRAINTYPE]         ; TerrainType\n"
+"HasDamagedFrames=false    ; boolean\n"
+"HasCrumblingFrames=false  ; boolean\n"
+"CrumblingSound=           ; Sound entry\n"
+msgstr ""
+"[AudioVisual]\n"
+"ConditionYellow.Terrain=  ; floating-point value, default to "
+"[AudioVisual] -> ConditionYellow\n"
+"\n"
+"[SOMETERRAINTYPE]         ; TerrainType\n"
+"HasDamagedFrames=false    ; boolean\n"
+"HasCrumblingFrames=false  ; boolean\n"
+"CrumblingSound=           ; Sound entry\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1881
+msgid ""
+"The number of regular & damage frames considered for this depends on "
+"value of `HasDamagedFrames` and for `IsAnimated` TerrainTypes, "
+"`AnimationLength` (see [Animated TerrainTypes](#animated-terraintypes)). "
+"Exercise caution and ensure there are correct amount of frames to "
+"display."
+msgstr ""
+"此处考虑的常规帧和破损帧数量取决于 `HasDamagedFrames` 的值，对于 `IsAnimated` 的地形对象则取决于 "
+"`AnimationLength` 的值（见 [动画化地形对象](#animated-"
+"terraintypes)）。请谨慎操作以确保显示的帧数正确。"
+
+#: ../../Fixed-or-Improved-Logics.md:1884
+#: ../../Fixed-or-Improved-Logics.md:1909
+msgid "Minimap color customization"
+msgstr "自定义小地图颜色"
+
+#: ../../Fixed-or-Improved-Logics.md:1886
+msgid ""
+"TerrainTypes can now be made to display on minimap with different colors "
+"by setting `MinimapColor`."
+msgstr "现在地形对象可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
+
+#: ../../Fixed-or-Improved-Logics.md:1889
+msgid ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"MinimapColor=      ; integer - Red,Green,Blue\n"
+msgstr ""
+"[SOMETERRAINTYPE]  ; TerrainType\n"
+"MinimapColor=      ; integer - Red,Green,Blue\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1894
+msgid "Passable & buildable-upon TerrainTypes"
+msgstr "可通行和可建造于其上的地形对象"
+
+#: ../../Fixed-or-Improved-Logics.md:1896
+msgid ""
+"TerrainTypes can now be made passable or buildable upon by setting "
+"`IsPassable` or `CanBeBuiltOn`, respectively."
+msgstr "现在可以分别通过设置 `IsPassable` 或 `CanBeBuiltOn` 来让地形对象可通行或可以将建筑建造于其上。"
+
+#: ../../Fixed-or-Improved-Logics.md:1897
+msgid ""
+"Movement cursor is displayed on `IsPassable` TerrainTypes unless force-"
+"firing."
+msgstr "除非使用强制开火否则 `IsPassable` 的地形对象上会显示移动光标。"
+
+#: ../../Fixed-or-Improved-Logics.md:1898
+msgid ""
+"`CanBeBuiltOn=true` terrain objects are removed when building is placed "
+"on them."
+msgstr "`CanBeBuiltOn=true` 的地形对象在建筑建造于其上时会被移除。"
+
+#: ../../Fixed-or-Improved-Logics.md:1901
+msgid ""
+"[SOMETERRAINTYPE]   ; TerrainType\n"
+"IsPassable=false    ; boolean\n"
+"CanBeBuiltOn=false  ; boolean\n"
+msgstr ""
+"[SOMETERRAINTYPE]   ; TerrainType\n"
+"IsPassable=false    ; boolean\n"
+"CanBeBuiltOn=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1907
+msgid "Tiberiums (ores)"
+msgstr "泰伯利亚（矿石）"
+
+#: ../../Fixed-or-Improved-Logics.md:1911
+msgid ""
+"Ore can now be made to display on minimap with different colors by "
+"setting `MinimapColor` on Tiberiums."
+msgstr "矿石现在可以通过设置 `MinimapColor` 使用不同的颜色显示在小地图上。"
+
+#: ../../Fixed-or-Improved-Logics.md:1914
+msgid ""
+"[SOMEORE]      ; Tiberium\n"
+"MinimapColor=  ; integer - Red,Green,Blue\n"
+msgstr ""
+"[SOMEORE]      ; Tiberium\n"
+"MinimapColor=  ; integer - Red,Green,Blue\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1919
+msgid "Vehicles"
+msgstr "载具类型"
+
+#: ../../Fixed-or-Improved-Logics.md:1921
+msgid "Allow miners do area guard"
+msgstr "允许矿车区域警戒"
+
+#: ../../Fixed-or-Improved-Logics.md:1923
+msgid ""
+"In vanilla, when miners enter area guard mission, they immediately switch"
+" to harvest mission. Now you can make them perform area guard mission "
+"normally like other technos."
+msgstr ""
+"在原版中当一个矿车进入 `Area Guard` 任务时会立即切换为 `Havrest` 任务。现在你可以让它们像其他单位那样正常执行 `Area"
+" Guard` 任务了。"
+
+#: ../../Fixed-or-Improved-Logics.md:1924
+msgid ""
+"We made it work only for miners controlled by the player, because this "
+"will prevent AI's miners from going work."
+msgstr "这仅对玩家控制的矿车有效，因为这会阻断 AI 矿车正常工作。"
+
+#: ../../Fixed-or-Improved-Logics.md:1927
+msgid ""
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"Harvester.CanGuardArea=no          ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"Harvester.CanGuardArea=no          ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1932
+msgid "Bunker entering check dehardcode"
+msgstr "去除坦克碉堡准入检查的硬编码"
+
+#: ../../Fixed-or-Improved-Logics.md:1934
+msgid ""
+"In vanilla, vehicles entering tank bunkers are subject to a series of "
+"hardcoding restrictions, including having to have turrets, having to have"
+" weapons, and not having Hover speed types. Now you can skip these "
+"restrictions."
+msgstr ""
+"在原版，载具进入坦克碉堡时受到一系列硬编码限制，包括必须拥有炮塔、必须拥有武器以及速度类型不能为 "
+"`SpeedType=Hover`。现在你可以跳过这些限制。"
+
+#: ../../Fixed-or-Improved-Logics.md:1935
+msgid "This needs to be used with `Bunkerable=yes`."
+msgstr "这需要与 `Bunkerable=yes` 共同使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1936
+msgid ""
+"This flag only skips the static check, that is, the check on the unit "
+"type. The dynamic check (cannot be parasitized) remains unchanged."
+msgstr "这个标签仅跳过静态检查，即对单位类型的检查。动态检查（不能处于被寄生状态）保持不变。"
+
+#: ../../Fixed-or-Improved-Logics.md:1939
+msgid ""
+"[SOMEVEHICLE]              ; VehicleType\n"
+"BunkerableAnyway=false     ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]              ; VehicleType\n"
+"BunkerableAnyway=false     ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1945
+msgid ""
+"Skipping checks with this feature doesn't mean that vehicles and tank "
+"bunkers will interact correctly. Following the simple checks performed by"
+" the provider of this feature, bunkerability is mainly determined by "
+"Locomotor. The details about locomotors' bunkerability can be found on "
+"[ModEnc](https://modenc.renegadeprojects.com/Bunkerable)."
+msgstr ""
+"使用此功能跳过检查并不就意味着载具和坦克碉堡可以正确的交互。根据次功能提供者的简单检查，坦克碉堡的效果主要受到运动模式影响。不同运动模式进入坦克碉堡的详细信息可以在"
+" [MODENC](https://modenc.renegadeprojects.com/Bunkerable) 上找到。"
+
+#: ../../Fixed-or-Improved-Logics.md:1948
+msgid "Custom Unit Crate Reroll Chance"
+msgstr ""
+
+#: ../../Fixed-or-Improved-Logics.md:1950
+msgid ""
+"It is possible to influence weighting of units given from crates "
+"(`CrateGoodie=true`) via `CrateGoodie.RerollChance`, which determines the"
+" chance that if this type of unit is rolled, it will reroll again for "
+"another type of unit."
+msgstr ""
+"现在可以通过 `CrateGoodie.RerollChance` 来影响从升级工具箱 (`CrateGoodie=true`) "
+"中获得一个单位的权重，该值决定了如果随机到这种类型的单位，那么它将重新随机另一种单位的概率。"
+
+#: ../../Fixed-or-Improved-Logics.md:1953
+msgid ""
+"[SOMEVEHICLE]                  ; VehicleType\n"
+"CrateGoodie.RerollChance=0.0   ; floating point value, percents or "
+"absolute (0.0-1.0)\n"
+msgstr ""
+"[SOMEVEHICLE]                  ; VehicleType\n"
+"CrateGoodie.RerollChance=0.0   ; floating point value, percents or "
+"absolute (0.0-1.0)\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1958
+msgid "Customize harvester dump amount"
+msgstr "自定义矿车单次倒矿量"
+
+#: ../../Fixed-or-Improved-Logics.md:1960
+msgid ""
+"Now you can limit how much ore the harvester can dump out per time, like "
+"it in Tiberium Sun."
+msgstr "现在你可以限制矿车每次倒矿时卸载的矿石量，就像《泰伯利亚之日》中的设定"
+
+#: ../../Fixed-or-Improved-Logics.md:1961
+msgid ""
+"Less than or equal to 0 means no limit, it will always dump out all at "
+"one time."
+msgstr "若该值小于等于 0 则表示一次倒完，就像《红色警戒2》中原本的行为"
+
+#: ../../Fixed-or-Improved-Logics.md:1964
+msgid ""
+"[General]\n"
+"HarvesterDumpAmount=0.0               ; float point value\n"
+"\n"
+"[SOMEVEHICLE]                         ; VehicleType\n"
+"HarvesterDumpAmount=                  ; float point value\n"
+msgstr ""
+"[General]\n"
+"HarvesterDumpAmount=0.0               ; float point value\n"
+"\n"
+"[SOMEVEHICLE]                         ; VehicleType\n"
+"HarvesterDumpAmount=                  ; float point value\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1972
+msgid "Customizing crushing tilt and slowdown"
+msgstr "自定义碾压倾斜和减速"
+
+#: ../../Fixed-or-Improved-Logics.md:1974
+msgid ""
+"Vehicles with `Crusher=true` and `OmniCrusher=true` / "
+"`MovementZone=CrusherAll` were hardcoded to tilt when crushing vehicles /"
+" walls respectively. This now obeys `TiltsWhenCrushes` but can be "
+"customized individually for these two scenarios using "
+"`TiltsWhenCrusher.Vehicles` and `TiltsWhenCrusher.Overlays`, which both "
+"default to `TiltsWhenCrushes`."
+msgstr ""
+"拥有 `Crusher=true` 和 `OmniCrusher=true` / `MovementZone=CrusherAll` "
+"的载具在碾压载具／围墙时原版被硬编码进行倾斜。现在这遵守 `TiltsWhenCrushes`，并且可以对 "
+"`TiltsWhenCrusher.Vehicles` 和 `TiltsWhenCrusher.Overlays` "
+"对两种情况分别进行定义，它们都默认为 `TiltsWhenCrushes`。"
+
+#: ../../Fixed-or-Improved-Logics.md:1975
+msgid ""
+"`CrushForwardTiltPerFrame` determines how much the forward tilt is "
+"adjusted per frame when crushing overlays or vehicles. Defaults to -0.02 "
+"for vehicles using Ship locomotor crushing overlays, -0.050000001 for all"
+" other cases."
+msgstr ""
+"`CrushForwardTiltPerFrame` 决定在碾压覆盖物或载具时每帧前倾的幅度。对于 `Locomotor=Ship` "
+"的载具碾压覆盖物的时默认为 -0.02，其他情况默认为 -0.050000001。"
+
+#: ../../Fixed-or-Improved-Logics.md:1976
+msgid ""
+"`CrushOverlayExtraForwardTilt` is additional forward tilt applied after "
+"an overlay has been crushed by the vehicle."
+msgstr "`CrushOverlayExtraForwardTilt` 是载具碾压覆盖物后额外的向前倾斜量"
+
+#: ../../Fixed-or-Improved-Logics.md:1977
+msgid ""
+"It is possible to customize the movement speed slowdown when "
+"`MovementZone=CrusherAll` vehicle crushes walls by setting "
+"`CrushSlowdownMultiplier`."
+msgstr ""
+"可以通过设置 `CrushSlowdownMultiplier` 来自定义 `MovementZone=CrusherAll` "
+"的载具碾压围墙时移动速度的减速幅度。"
+
+#: ../../Fixed-or-Improved-Logics.md:1978
+msgid ""
+"You can also disable the slowdown completely by using the flag "
+"`SkipCrushSlowdown`. This is not the same as "
+"`CrushSlowdownMultiplier=1.0`. Used to avoid a bug where the vehicle "
+"sometimes loses speed when `Accelerates=true` and `MovementZone=CrushAll`"
+" are set."
+msgstr ""
+"你还可以使用 `SkipCrushSlowdown` 来完全禁用这一减速效果。这不同于 "
+"`CrushSlowdownMultiplier=1.0`。它可以避免 `Accelerates=true` 与 "
+"`MovementZone=CrushAll` 共用时单位有时会减速的 Bug。"
+
+#: ../../Fixed-or-Improved-Logics.md:1981
+msgid ""
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"TiltsWhenCrushes.Vehicles=         ; boolean\n"
+"TiltsWhenCrushes.Overlays=         ; boolean\n"
+"CrushForwardTiltPerFrame=          ; floating point value\n"
+"CrushOverlayExtraForwardTilt=0.02  ; floating point value\n"
+"CrushSlowdownMultiplier=0.2        ; floating point value\n"
+"SkipCrushSlowdown=false            ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"TiltsWhenCrushes.Vehicles=         ; boolean\n"
+"TiltsWhenCrushes.Overlays=         ; boolean\n"
+"CrushForwardTiltPerFrame=          ; floating point value\n"
+"CrushOverlayExtraForwardTilt=0.02  ; floating point value\n"
+"CrushSlowdownMultiplier=0.2        ; floating point value\n"
+"SkipCrushSlowdown=false            ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:1991
+msgid "Destroy animations"
+msgstr "摧毁动画"
+
+#: ../../Fixed-or-Improved-Logics.md:1993
+msgid ""
+"`DestroyAnim` has been extended to work with VehicleTypes, with option to"
+" pick random animation if `DestroyAnim.Random` is set to true. These "
+"animations store owner and facing information for use with [CreateUnit "
+"logic](New-or-Enhanced-Logics.md#anim-to-unit)."
+msgstr ""
+"`DestroyAnim` 已扩展至载具类型，并且如果 `DestroyAnim.Random` 设为 true "
+"那么可以随机选取其中一个动画。这些动画存储了所属方和朝向信息以供[生成单位](New-or-Enhanced-Logics.md#anim-to-"
+"unit)逻辑使用。"
+
+#: ../../Fixed-or-Improved-Logics.md:1996
+msgid ""
+"[SOMEVEHICLE]                          ; VehicleType\n"
+"DestroyAnim=                           ; List of AnimationTypes\n"
+"DestroyAnim.Random=true                ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]                          ; VehicleType\n"
+"DestroyAnim=                           ; List of AnimationTypes\n"
+"DestroyAnim.Random=true                ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2002
+msgid "`IsSimpleDeployer` vehicle ammo change on deploy"
+msgstr "`IsSimpleDeployer` 载具在部署时更改弹药"
+
+#: ../../Fixed-or-Improved-Logics.md:2004
+msgid ""
+"`Ammo.AddOnDeploy` determines the number of ammo added or subtracted "
+"after the vehicle has deployed or undeployed."
+msgstr "`Ammo.AddOnDeploy` 决定载具部署或反部署后增加或减少的弹药量。"
+
+#: ../../Fixed-or-Improved-Logics.md:2005
+msgid ""
+"Ammo count cannot go below 0 or above the maximum ammo for vehicle's type"
+" (in case the deploy results in type conversion, type is the one after "
+"the conversion)."
+msgstr "弹药数不得低于 0 或高于该载具类型的最大弹药量（若部署操作导致单位转换则以转换后的量为准）。"
+
+#: ../../Fixed-or-Improved-Logics.md:2008
+msgid ""
+"[SOMEVEHICLE]       ; VehicleType\n"
+"Ammo.AddOnDeploy=0  ; integer\n"
+msgstr ""
+"[SOMEVEHICLE]       ; VehicleType\n"
+"Ammo.AddOnDeploy=0  ; integer\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2013
+msgid "IsSimpleDeployer customizations"
+msgstr "自定义 IsSimpleDeployer"
+
+#: ../../Fixed-or-Improved-Logics.md:2015
+msgid ""
+"It is possible to enable checking if the deployed unit (if type "
+"conversion is in use, the conversion result will be used for these "
+"checks) is allowed to deploy on the cell which will also affect deploy "
+"cursor availability by setting `IsSimpleDeployer.ConsiderPathfinding` to "
+"true."
+msgstr ""
+"现在可以通过 `IsSimpleDeployer.ConsiderPathfinding=true` "
+"来开启对将部署的单位（若使用单位转换则检查作为转换目标的单位）是否允许在当前单元格上部署的检查，部署光标也会跟随变化。"
+
+#: ../../Fixed-or-Improved-Logics.md:2016
+msgid ""
+"You can explicitly disable deploying on cells of specified land types "
+"using `IsSimpleDeployer.DisallowedLandTypes`. Defaults to `water,beach` "
+"for units with Jumpjet or Hover locomotor with `DeployToLand=true`, "
+"`none` for others."
+msgstr ""
+"你可以使用 `IsSimpleDeployer.DisallowedLandTypes` 来指定单位不能在哪些土地类型上部署。对于 "
+"`Locomotor=Jumpjet` 或 `Locomotor=Hover` 且拥有 `DeployToLand=true` 的单位默认为 "
+"`water,beach`；对于其他单位则默认为 `none`。"
+
+#: ../../Fixed-or-Improved-Logics.md:2017
+msgid ""
+"In vanilla game only units with `DeployingAnim` were constrained to a "
+"specific deploy facing and it was not customizable per unit. `DeployDir` "
+"can be set to override this per unit (defaults to `[AudioVisual] -> "
+"DeployDir` for units with `DeployingAnim`, -1 otherwise), including using"
+" value of -1 to disable the facing restriction."
+msgstr ""
+"在原版游戏中仅拥有 `DeployingAnim` 的单位会被限制使用特定的部署朝向且无法为每个单位自定义。Ares 允许通过 "
+"`DeployDir`（对于拥有 `DeployingAnim` 的单位默认为 `[AudioVisual] -> DeployDir`，否则为 "
+"-1）来为每个单位单独设定，Phobos 允许使用特殊值 -1 来解除朝向限制。"
+
+#: ../../Fixed-or-Improved-Logics.md:2018
+msgid "Multiple new options for deploy animations:"
+msgstr "部署动画相关的多个新增选项："
+
+#: ../../Fixed-or-Improved-Logics.md:2019
+msgid ""
+"`DeployingAnims` can be used instead of `DeployingAnim` (if both are set,"
+" `DeployingAnims` takes precedence) to define a list of direction-"
+"specific deploy animations to play. Largest power of 2 the number of "
+"listed animations falls to is used as number of directions/animations. "
+"Less than 8 animations listed results in only first listed one being "
+"used."
+msgstr ""
+"可使用 `DeployingAnims` 代替 "
+"`DeployingAnim`（当都被设置时优先使用前者）来定义一组与方向对应的部署动画。根据所列动画的最大数量取 2 "
+"的幂值作为方向数／动画数。若少于 8 个则仅适用列出的第一个动画。"
+
+#: ../../Fixed-or-Improved-Logics.md:2020
+msgid ""
+"`DeployingAnim.KeepUnitVisible` determines if the unit is **not** hidden "
+"while the animation is playing."
+msgstr "`DeployingAnim.KeepUnitVisible` 决定单位是否在动画播放期间**不**被隐藏。"
+
+#: ../../Fixed-or-Improved-Logics.md:2021
+msgid ""
+"`DeployingAnim.ReverseForUndeploy` controls whether or not the animation "
+"is played in reverse for undeploying."
+msgstr "`DeployingAnim.ReverseForUndeploy` 控制反部署时是否使动画反向播放。"
+
+#: ../../Fixed-or-Improved-Logics.md:2022
+msgid ""
+"`DeployingAnim.UseUnitDrawer` controls whether or not the animation is "
+"displayed in the unit's palette and team colours or regular animation "
+"palette, including a potential custom palette."
+msgstr "`DeployingAnim.UseUnitDrawer` 控制动画使用 unit 色盘以及所属色还是常规动画色盘，包括潜在的自定义色盘。"
+
+#: ../../Fixed-or-Improved-Logics.md:2025
+msgid ""
+"[SOMEVEHICLE]                               ; VehicleType\n"
+"IsSimpleDeployer.ConsiderPathfinding=false  ; boolean\n"
+"IsSimpleDeployer.DisallowedLandTypes=       ; List of LandTypes (none | "
+"clear | road | water | rock | wall | tiberium | beach | rough | ice | "
+"railroad | tunnel | weeds)\n"
+"DeployDir=                                  ; Facing type (integers from "
+"0-7 or -1)\n"
+"DeployingAnims=                             ; List of AnimationTypes\n"
+"DeployingAnim.KeepUnitVisible=false         ; boolean\n"
+"DeployingAnim.ReverseForUndeploy=true       ; boolean\n"
+"DeployingAnim.UseUnitDrawer=true            ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]                               ; VehicleType\n"
+"IsSimpleDeployer.ConsiderPathfinding=false  ; boolean\n"
+"IsSimpleDeployer.DisallowedLandTypes=       ; List of LandTypes (none | "
+"clear | road | water | rock | wall | tiberium | beach | rough | ice | "
+"railroad | tunnel | weeds)\n"
+"DeployDir=                                  ; Facing type (integers from "
+"0-7 or -1)\n"
+"DeployingAnims=                             ; List of AnimationTypes\n"
+"DeployingAnim.KeepUnitVisible=false         ; boolean\n"
+"DeployingAnim.ReverseForUndeploy=true       ; boolean\n"
+"DeployingAnim.UseUnitDrawer=true            ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2036
+msgid "Make harvesters do addtional scan after unload"
+msgstr "使矿车卸载后重新扫描较近的矿区"
+
+#: ../../Fixed-or-Improved-Logics.md:2038
+msgid ""
+"In vanilla, miners will remember their current location when they reach "
+"full load and move to that location after unloading. This makes miners to"
+" gradually move deeper into the mine and ignore the closer minerals."
+msgstr "在原版中矿车在满载时会记录当前位置并在卸载后返回该坐标。这一机制会让矿车逐渐向原矿区深处探索但却容易忽略距离更近的矿区。"
+
+#: ../../Fixed-or-Improved-Logics.md:2039
+msgid ""
+"Now you can have the miner search for the nearest mineral again after "
+"unloading. If a closer mineral is found, the miner will go to that "
+"location instead of the previously recorded location."
+msgstr "现在你可以让矿车在卸载后重新搜索最近的矿区。如果发现了更近的矿区那么矿车会优先前往它而不是返回先前记录的坐标。"
+
+#: ../../Fixed-or-Improved-Logics.md:2042
+msgid ""
+"[General]\n"
+"HarvesterScanAfterUnload=false     ; boolean\n"
+"\n"
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
+"HarvesterScanAfterUnload\n"
+msgstr ""
+"[General]\n"
+"HarvesterScanAfterUnload=false     ; boolean\n"
+"\n"
+"[SOMEVEHICLE]                      ; VehicleType\n"
+"HarvesterScanAfterUnload=          ; boolean, default to [General] -> "
+"HarvesterScanAfterUnload\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2050
+msgid "Preserve Iron Curtain / Force Shield status on type conversion"
+msgstr "在单位转换时保留铁幕／力场护盾状态"
+
+#: ../../Fixed-or-Improved-Logics.md:2052
+msgid "![image](_static/images/preserve-ic.gif) *Bugfix in action*"
+msgstr "![image](_static/images/preserve-ic.gif) *Bug 修复后的行为*"
+
+#: ../../Fixed-or-Improved-Logics.md:2055
+msgid ""
+"Iron Curtain status is now preserved by default when converting between "
+"TechnoTypes via `DeploysInto` / `UndeploysInto`. Force Shield status "
+"preservation is turned off by default."
+msgstr "通过 `DeploysInto`／`UndeploysInto` 在科技类型之间的转换现在默认保留铁幕状态。力场护盾则默认不保留。"
+
+#: ../../Fixed-or-Improved-Logics.md:2056
+msgid "This behavior can be turned on/off per-TechnoType and on global basis."
+msgstr "这一行为可以对每个科技类型和全局进行开启／关闭。"
+
+#: ../../Fixed-or-Improved-Logics.md:2057
+msgid ""
+"`IronCurtain.Modifier` / `ForceShield.Modifier` (whichever is applicable)"
+" is re-applied upon type conversion."
+msgstr "`IronCurtain.Modifier`／`ForceShield.Modifier`（视情况而定）将在单位转换时刷新。"
+
+#: ../../Fixed-or-Improved-Logics.md:2060
+msgid ""
+"[CombatDamage]\n"
+"IronCurtain.KeptOnDeploy=true   ; boolean\n"
+"ForceShield.KeptOnDeploy=false  ; boolean\n"
+"\n"
+"[SOMETECHNO]                    ; VehicleType with DeploysInto or "
+"BuildingType with UndeploysInto\n"
+"IronCurtain.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
+"IronCurtain.KeptOnDeploy\n"
+"ForceShield.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
+"ForceShield.KeptOnDeploy\n"
+msgstr ""
+"[CombatDamage]\n"
+"IronCurtain.KeptOnDeploy=true   ; boolean\n"
+"ForceShield.KeptOnDeploy=false  ; boolean\n"
+"\n"
+"[SOMETECHNO]                    ; VehicleType with DeploysInto or "
+"BuildingType with UndeploysInto\n"
+"IronCurtain.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
+"IronCurtain.KeptOnDeploy\n"
+"ForceShield.KeptOnDeploy=       ; boolean, default to [CombatDamage] -> "
+"ForceShield.KeptOnDeploy\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2070
+msgid "Retain target on movement command"
+msgstr "在命令移动后保留目标"
+
+#: ../../Fixed-or-Improved-Logics.md:2072
+msgid ""
+"It is now possible for vehicles to retain their target when issued "
+"movement command by setting `KeepTargetOnMove` to true."
+msgstr "现在可以通过设置 `KeepTargetOnMove` 为 true 来使载具在接收到移动命令时保留其目标。"
+
+#: ../../Fixed-or-Improved-Logics.md:2073
+msgid ""
+"Note that no check is done whether or not the vehicle or the weapon can "
+"actually fire while moving, this is on modder's discretion."
+msgstr "注意这不会检查载具或武器实际上能否在移动中开火，这由 modder 自行决定。"
+
+#: ../../Fixed-or-Improved-Logics.md:2074
+msgid ""
+"The target is automatically reset if the vehicle moves beyond the "
+"weapon's range from the target."
+msgstr "如果由于载具移动导致目标超出武器射程那么目标将自动重置。"
+
+#: ../../Fixed-or-Improved-Logics.md:2075
+msgid ""
+"`KeepTargetOnMove.Weapon` determines the weapon to be used for range "
+"check. If set to -1, the game will select the weapon against the target "
+"by default logic."
+msgstr "`KeepTargetOnMove.Weapon` 决定用于射程检查的武器。如果设为 -1，游戏将会根据默认武器选用规则针对目标对象选取。"
+
+#: ../../Fixed-or-Improved-Logics.md:2076
+msgid ""
+"It's recommended to set it to a specific weapon for better performance, "
+"unless there's a need to use multiple weapons for different targets."
+msgstr "建议将其设为特定武器以优化性能，除非需要针对不同目标使用多种武器。"
+
+#: ../../Fixed-or-Improved-Logics.md:2077
+msgid ""
+"`KeepTargetOnMove.NoMorePursuit` controls whether the unit will restart "
+"chasing the target for attack when it stops again, otherwise it will "
+"clear the target when it moves away."
+msgstr "`KeepTargetOnMove.NoMorePursuit` 控制单位是否会在再次停止后重新开始追击目标以发起攻击，否则会在移动时清除目标。"
+
+#: ../../Fixed-or-Improved-Logics.md:2078
+msgid ""
+"`KeepTargetOnMove.ExtraDistance` can be used to modify the distance "
+"considered 'out of range' from the target (it is added to weapon range), "
+"negative values work to reduce the distance."
+msgstr ""
+"`KeepTargetOnMove.ExtraDistance` 可以用来修改被认为 “超出射程” "
+"的范围（基于武器射程的修正值），负值会缩短判定距离。"
+
+#: ../../Fixed-or-Improved-Logics.md:2081
+msgid ""
+"[SOMEVEHICLE]                        ; VehicleType\n"
+"KeepTargetOnMove=false               ; boolean\n"
+"KeepTargetOnMove.Weapon=-1           ; integer, weapon slot index\n"
+"KeepTargetOnMove.NoMorePursuit=true  ; boolean\n"
+"KeepTargetOnMove.ExtraDistance=0     ; floating point value, distance in "
+"cells\n"
+msgstr ""
+"[SOMEVEHICLE]                        ; VehicleType\n"
+"KeepTargetOnMove=false               ; boolean\n"
+"KeepTargetOnMove.Weapon=-1           ; integer, weapon slot index\n"
+"KeepTargetOnMove.NoMorePursuit=true  ; boolean\n"
+"KeepTargetOnMove.ExtraDistance=0     ; floating point value, distance in "
+"cells\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2089
+msgid "Sinking behavior dehardcode"
+msgstr "自定义沉没行为"
+
+#: ../../Fixed-or-Improved-Logics.md:2091
+msgid ""
+"In vanilla, whether a ship sinks when it dies on the water is determined "
+"by multiple settings of hardcoding. The speed of the sinking is hardcoded"
+" to 5 Leptons per frame."
+msgstr "原版中一艘舰船在水上死亡是否会沉没由多个硬编码设置决定。沉没速度硬编码为每帧 5 leptons。"
+
+#: ../../Fixed-or-Improved-Logics.md:2092
+msgid ""
+"Now you can determine whether a ship sinks with a dedicated flag "
+"`Sinkable`, and use `SinkSpeed` to customize the speed at which the ship "
+"sinks."
+msgstr "现在你可以通过专门的标签 `Sinkable` 来决定一艘舰船是否会沉没，并且可以使用 `SinkSpeed` 来定义舰船的沉没速度。"
+
+#: ../../Fixed-or-Improved-Logics.md:2093
+msgid ""
+"`Sinkable.SquidGrab` controls the behavior of a ship when it is killed by"
+" a squid. Set it to `false` to cause the ship to take a lethal damage "
+"instead of sinking directly at that time (and thus obey `Sinkable` "
+"settings)."
+msgstr ""
+"`Sinkable.SquidGrab` 控制一艘船在被巨型乌贼击杀时的行为。将其设为 false "
+"会导致舰船受到致命伤害而非在此时直接沉没（从而遵循 `Sinkable` 的设置）。"
+
+#: ../../Fixed-or-Improved-Logics.md:2096
+msgid ""
+"[SOMEVEHICLE]              ; VehicleType\n"
+"Sinkable=                  ; boolean\n"
+"SinkSpeed=5                ; integer, leptons per frame\n"
+"Sinkable.SquidGrab=true    ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]              ; VehicleType\n"
+"Sinkable=                  ; boolean\n"
+"SinkSpeed=5                ; integer, leptons per frame\n"
+"Sinkable.SquidGrab=true    ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2103
+msgid "Stationary vehicles"
+msgstr "静止的载具"
+
+#: ../../Fixed-or-Improved-Logics.md:2105
+msgid ""
+"Setting VehicleType `Speed` to 0 now makes game treat them as stationary,"
+" behaving in very similar manner to deployed vehicles with "
+"`IsSimpleDeployer` set to true. Should not be used on buildable vehicles,"
+" as they won't be able to exit factories."
+msgstr ""
+"现在载具将在 `Speed` 设置为 0 时使游戏将它们视为静止，其行为方式非常类似于 `IsSimpleDeployer` 设置为 true "
+"的部署状态载具。不应用于可生产的载具，否则它们将无法退出工厂。"
+
+#: ../../Fixed-or-Improved-Logics.md:2107
+msgid "Turret recoil"
+msgstr "炮塔制退"
+
+#: ../../Fixed-or-Improved-Logics.md:2109
+msgid ""
+"Now you can use `TurretRecoil` to control units' turret/barrel recoil "
+"effect when firing."
+msgstr "现在你可以使用 `TurretRecoil` 来控制单位开火时的炮塔／炮管制退效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:2110
+msgid "`TurretTravel` and `BarrelTravel` control the maximum recoil distance."
+msgstr "`TurretTravel` 和 `BarrelTravel` 控制最大制退距离。"
+
+#: ../../Fixed-or-Improved-Logics.md:2111
+msgid ""
+"`TurretRecoil.Suppress` can prevent the weapon from producing this effect"
+" when firing."
+msgstr "`TurretRecoil.Suppress` 可以在特定武器上阻止其产生此效果。"
+
+#: ../../Fixed-or-Improved-Logics.md:2114
+msgid ""
+"[SOMEVEHICLE]             ; VehicleType\n"
+"TurretRecoil=no           ; boolean\n"
+"TurretTravel=2            ; integer, pixels\n"
+"TurretCompressFrames=1    ; integer, game frames\n"
+"TurretHoldFrames=1        ; integer, game frames\n"
+"TurretRecoverFrames=1     ; integer, game frames\n"
+"BarrelTravel=2            ; integer, pixels\n"
+"BarrelCompressFrames=1    ; integer, game frames\n"
+"BarrelHoldFrames=1        ; integer, game frames\n"
+"BarrelRecoverFrames=1     ; integer, game frames\n"
+"\n"
+"[SOMEWEAPON]              ; WeaponType\n"
+"TurretRecoil.Suppress=no  ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]             ; VehicleType\n"
+"TurretRecoil=no           ; boolean\n"
+"TurretTravel=2            ; integer, pixels\n"
+"TurretCompressFrames=1    ; integer, game frames\n"
+"TurretHoldFrames=1        ; integer, game frames\n"
+"TurretRecoverFrames=1     ; integer, game frames\n"
+"BarrelTravel=2            ; integer, pixels\n"
+"BarrelCompressFrames=1    ; integer, game frames\n"
+"BarrelHoldFrames=1        ; integer, game frames\n"
+"BarrelRecoverFrames=1     ; integer, game frames\n"
+"\n"
+"[SOMEWEAPON]              ; WeaponType\n"
+"TurretRecoil.Suppress=no  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2131
+msgid ""
+"The logic above was not reverse-engineered but reimplemented to achieve "
+"the same effect, hence there might be some differences in behavior "
+"compared to Tiberian Sun version."
+msgstr "上面的逻辑并非来自逆向工程复原而是模拟复刻效果，因此与《泰伯利亚之日》中的行为相比可能存在一些差异。"
+
+#: ../../Fixed-or-Improved-Logics.md:2134
+msgid "Unit Without Turret Always Turn To Target"
+msgstr "无炮塔单位始终面向目标"
+
+#: ../../Fixed-or-Improved-Logics.md:2136
+msgid ""
+"Now vehicles without turret will attempt to turn to the target while the "
+"weapon is cooling down, rather than after the weapon has cooled down, by "
+"setting `NoTurret.TrackTarget` to true."
+msgstr ""
+"现在可以通过将 `NoTurret.TrackTarget` 设为 true "
+"来让没有炮塔的载具在武器冷却期间就尝试更改朝向以面向目标而不是等到武器冷却完成后。"
+
+#: ../../Fixed-or-Improved-Logics.md:2139
+msgid ""
+"[General]\n"
+"NoTurret.TrackTarget=false   ; boolean\n"
+"\n"
+"[SOMEVEHICLE]                ; VehicleType\n"
+"NoTurret.TrackTarget=        ; boolean, defaults to [General] -> "
+"NoTurret.TrackTarget\n"
+msgstr ""
+"[General]\n"
+"NoTurret.TrackTarget=false   ; boolean\n"
+"\n"
+"[SOMEVEHICLE]                ; VehicleType\n"
+"NoTurret.TrackTarget=        ; boolean, defaults to [General] -> "
+"NoTurret.TrackTarget\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2148
+msgid ""
+"Jumpjet can also be affected by this if firing an `OmniFire` weapon with "
+"`OmniFire.TurnToTarget` set to true."
+msgstr ""
+"如果 Jumpjet 在 `OmniFire.TurnToTarget` 设为 true 的情况下发射一个 `OmniFire` "
+"武器那么也会受到影响。"
+
+#: ../../Fixed-or-Improved-Logics.md:2151
+msgid "Voxel turret shadow"
+msgstr "Voxel 炮塔影子"
+
+#: ../../Fixed-or-Improved-Logics.md:2153
+msgid ""
+"Vehicle voxel turrets can now draw shadows if `[AudioVisual] -> "
+"DrawTurretShadow` is set to true. This can be overridden per VehicleType "
+"by setting `TurretShadow` in the vehicle's `artmd.ini` section."
+msgstr ""
+"如果 `[AudioVisual] -> DrawTurretShadow` 被设为 true 那么载具的 Voxel "
+"炮塔现在可以绘制影子。这可以在载具的 `artmd.ini` 小节中设置 `TurretShadow` 来覆盖。"
+
+#: ../../Fixed-or-Improved-Logics.md:2156
+msgid ""
+"[AudioVisual]\n"
+"DrawTurretShadow=false  ; boolean\n"
+msgstr ""
+"[AudioVisual]\n"
+"DrawTurretShadow=false  ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2162
+msgid ""
+"[SOMEVEHICLE]   ; VehicleType\n"
+"TurretShadow=   ; boolean\n"
+msgstr ""
+"[SOMEVEHICLE]   ; VehicleType\n"
+"TurretShadow=   ; boolean\n"
+
+#: ../../Fixed-or-Improved-Logics.md:2250
 msgid "VoxelAnims"
 msgstr "Voxel 碎片"
 
-#: ../../Fixed-or-Improved-Logics.md:2048
+#: ../../Fixed-or-Improved-Logics.md:2254
 msgid ""
 "The INI keys and behaviour is mostly identical to the [equivalent "
 "behaviour available to regular animations](#customizable-debris--meteor-"
@@ -7069,17 +7343,17 @@ msgstr ""
 "detonation-behaviour)基本相同。主要区别是这些标签必须列在 `rulesmd.ini` 中的 Voxel 碎片条目中，而不是 "
 "`artmd.ini` 中。"
 
-#: ../../Fixed-or-Improved-Logics.md:2050
+#: ../../Fixed-or-Improved-Logics.md:2256
 msgid "Customizable debris trailer anim spawn delay"
 msgstr "自定义 Voxel 碎片尾烟动画生成间隔"
 
-#: ../../Fixed-or-Improved-Logics.md:2052
+#: ../../Fixed-or-Improved-Logics.md:2258
 msgid ""
 "You can now customize the generation interval of VoxelAnim's trailer "
 "animation."
 msgstr "现在你可以自定义 Voxel 碎片的尾烟动画生成间隔。"
 
-#: ../../Fixed-or-Improved-Logics.md:2055
+#: ../../Fixed-or-Improved-Logics.md:2261
 msgid ""
 "[SOMEVOXELANIM]       ; VoxelAnimType\n"
 "Trailer.SpawnDelay=2  ; integer, game frames\n"
@@ -7087,15 +7361,15 @@ msgstr ""
 "[SOMEVOXELANIM]       ; VoxelAnimType\n"
 "Trailer.SpawnDelay=2  ; integer, game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2060
+#: ../../Fixed-or-Improved-Logics.md:2266
 msgid "Warheads"
 msgstr "弹头"
 
-#: ../../Fixed-or-Improved-Logics.md:2062
+#: ../../Fixed-or-Improved-Logics.md:2268
 msgid "Allowing damage dealt to firer"
 msgstr "允许杀伤开火者"
 
-#: ../../Fixed-or-Improved-Logics.md:2064
+#: ../../Fixed-or-Improved-Logics.md:2270
 msgid ""
 "You can now allow warhead to deal damage (and apply damage-adjacent "
 "effects such as `KillDriver` and `DisableWeapons/Sonar/Flash.Duration` "
@@ -7105,14 +7379,14 @@ msgstr ""
 "现在即使对象没有 `DamageSelf=true` 你也可以允许弹头对被视为开火者的对象造成杀伤（并使用诸如 `KillDriver` 和 "
 "`DisableWeapons/Sonar/Flash.Duration`（*Ares 功能*）这些与杀伤相关的效果。）"
 
-#: ../../Fixed-or-Improved-Logics.md:2065
+#: ../../Fixed-or-Improved-Logics.md:2271
 msgid ""
 "Note that effect of `Psychedelic=true`, despite being tied to damage will"
 " still fail to apply on the firer as it does not affect any objects "
 "belonging to same house as the firer, including itself."
 msgstr "注意尽管 `Psychedelic=true` 的效果与杀伤相关但由于其不会影响任何包括开火者在内所有与开火者同一所属的对象因此仍然无法生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:2068
+#: ../../Fixed-or-Improved-Logics.md:2274
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "AllowDamageOnSelf=false  ; boolean\n"
@@ -7120,11 +7394,11 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "AllowDamageOnSelf=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2073
+#: ../../Fixed-or-Improved-Logics.md:2279
 msgid "Combat light customizations"
 msgstr "自定义战斗闪光"
 
-#: ../../Fixed-or-Improved-Logics.md:2075
+#: ../../Fixed-or-Improved-Logics.md:2281
 msgid ""
 "You can now set minimum detail level at which combat light effects are "
 "shown by setting `[AudioVisual] -> CombatLightDetailLevel` or "
@@ -7133,20 +7407,20 @@ msgstr ""
 "现在你可以通过设置 `[AudioVisual] -> CombatLightDetailLevel` 或在弹头上设置 "
 "`CombatLightDetailLevel` 来限定显示闪光效果的最小画质级别。"
 
-#: ../../Fixed-or-Improved-Logics.md:2076
+#: ../../Fixed-or-Improved-Logics.md:2282
 msgid ""
 "You can now set a percentage chance a combat light effect is shown on "
 "Warhead impact by setting `CombatLightChance`."
 msgstr "现在你可以通过设置 `CombatLightChance` 来限定弹头命中时显示战斗闪光效果的概率百分比。"
 
-#: ../../Fixed-or-Improved-Logics.md:2077
+#: ../../Fixed-or-Improved-Logics.md:2283
 msgid ""
 "Setting `CLIsBlack` to true on Warhead will now turn the flash black like"
 " on hitting an Iron Curtained object, irregardless of other color "
 "settings."
 msgstr "现在可以通过在弹头上设置 `CLIsBlack` 为 true 来让闪光就像击中在铁幕保护下的物体一样使用黑色，无视其他颜色设置。"
 
-#: ../../Fixed-or-Improved-Logics.md:2080
+#: ../../Fixed-or-Improved-Logics.md:2286
 msgid ""
 "[AudioVisual]\n"
 "CombatLightDetailLevel=0  ; integer\n"
@@ -7168,11 +7442,11 @@ msgstr ""
 "(0.0-1.0)\n"
 "CLIsBlack=false           ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2090
+#: ../../Fixed-or-Improved-Logics.md:2296
 msgid "Custom debris animations and additional debris spawn settings"
 msgstr "自定义碎片动画和额外的碎片生成设置"
 
-#: ../../Fixed-or-Improved-Logics.md:2092
+#: ../../Fixed-or-Improved-Logics.md:2298
 msgid ""
 "You can now use `DebrisAnims` to specify a list of debris animations to "
 "spawn instead of animations from `[General] -> MetallicDebris` when "
@@ -7182,7 +7456,7 @@ msgstr ""
 "现在可以使用 `DebrisAnims` 指定要生成的碎片动画列表，而不是仅能在引爆拥有 `MaxDebris` > 0 且没有 "
 "`DebrisTypes`（指定 Voxel 碎片）的弹头时使用 `[General] -> MetallicDebris` 列表中的动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:2093
+#: ../../Fixed-or-Improved-Logics.md:2299
 msgid ""
 "`Debris.Conventional`, if set to true, makes `DebrisTypes` or "
 "`DebrisAnims` only spawn if Warhead is fired on non-water cell."
@@ -7190,7 +7464,7 @@ msgstr ""
 "`Debris.Conventional` 如果设为 true，那么仅在弹头在非水面单元格上引爆时才会使用 `DebrisTypes` 或 "
 "`DebrisAnims`。"
 
-#: ../../Fixed-or-Improved-Logics.md:2096
+#: ../../Fixed-or-Improved-Logics.md:2302
 msgid ""
 "[SOMEWARHEAD]              ; WarheadType\n"
 "DebrisAnims=               ; List of AnimationTypes\n"
@@ -7200,11 +7474,11 @@ msgstr ""
 "DebrisAnims=               ; List of AnimationTypes\n"
 "Debris.Conventional=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2102
+#: ../../Fixed-or-Improved-Logics.md:2308
 msgid "Custom debris voxel animations limitation"
 msgstr "自定义 Voxel 碎片数量限制"
 
-#: ../../Fixed-or-Improved-Logics.md:2108
+#: ../../Fixed-or-Improved-Logics.md:2314
 msgid ""
 "[SOMEWARHEAD]       ; WarheadType\n"
 "DebrisTypes.Limit=  ; boolean\n"
@@ -7216,22 +7490,22 @@ msgstr ""
 "DebrisMaximums=     ; List of integers\n"
 "DebrisMinimums=     ; List of integers\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2115
+#: ../../Fixed-or-Improved-Logics.md:2321
 msgid "Customizable rocker amplitude"
 msgstr "自定义掀起幅度"
 
-#: ../../Fixed-or-Improved-Logics.md:2117
+#: ../../Fixed-or-Improved-Logics.md:2323
 msgid ""
 "The rocker amplitude of warheads with `Rocker=yes` used to be determined "
 "by `Damage` value of the weapon. You can now override it with fixed value"
 " and add a multiplier to it."
 msgstr "拥有 `Rocker=yes` 的弹头其气波掀起载具的幅度过去由武器的 `Damage` 值所决定。现在可以通过固定值覆盖它并添加一个倍率。"
 
-#: ../../Fixed-or-Improved-Logics.md:2118
+#: ../../Fixed-or-Improved-Logics.md:2324
 msgid "When both multiplier and override values are set - both are used."
 msgstr "当同时设置了倍率和覆盖值时两者都会被使用。"
 
-#: ../../Fixed-or-Improved-Logics.md:2121
+#: ../../Fixed-or-Improved-Logics.md:2327
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "Rocker.AmplitudeMultiplier=1.0  ; floating point value, multiplier\n"
@@ -7241,11 +7515,11 @@ msgstr ""
 "Rocker.AmplitudeMultiplier=1.0  ; floating point value, multiplier\n"
 "Rocker.AmplitudeOverride=       ; integer\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2127
+#: ../../Fixed-or-Improved-Logics.md:2333
 msgid "Customizable Warhead animation behaviour"
 msgstr "自定义弹头动画行为"
 
-#: ../../Fixed-or-Improved-Logics.md:2129
+#: ../../Fixed-or-Improved-Logics.md:2335
 msgid ""
 "It is possible to make game play random animation from `AnimList` by "
 "setting `AnimList.PickRandom` to true. The result is similar to what "
@@ -7257,7 +7531,7 @@ msgstr ""
 "`EMEffect=true` 时的效果，但它不会带来副作用（`EMEffect=true` 会影响 `Inviso=true` "
 "的抛射体锁定目标，导致它们无法击中移动目标）。"
 
-#: ../../Fixed-or-Improved-Logics.md:2130
+#: ../../Fixed-or-Improved-Logics.md:2336
 msgid ""
 "If `AnimList.CreateAll` is set to true, all animations from `AnimList` "
 "are created, instead of a single anim based on damage or random if "
@@ -7267,7 +7541,7 @@ msgstr ""
 "列表中的动画都将会被创建，而不再是只创建单个基于杀伤值计算或随机选取的动画，前提是 `AnimList.PickRandom` 没有被设为 "
 "true。"
 
-#: ../../Fixed-or-Improved-Logics.md:2131
+#: ../../Fixed-or-Improved-Logics.md:2337
 msgid ""
 "If `AnimList.CreationInterval` is set to a value higher than 0, there "
 "will be that number of detonations of the Warhead before animations from "
@@ -7282,20 +7556,20 @@ msgstr ""
 "中的动画前需要爆炸一定数量的该弹头。如果该弹头是由一个单位发射的，那么该单位只会检查它自己所发射该弹头的次数，否则会对全图所有同一弹头的引爆次数进行计数。如果你希望像"
 " `Airburst` 这种具有大范围扩散的效果其弹头动画可以均匀出现而不是每次引爆都出现的话那么这会非常有用。"
 
-#: ../../Fixed-or-Improved-Logics.md:2132
+#: ../../Fixed-or-Improved-Logics.md:2338
 msgid ""
 "`AnimList.ScatterMin` & `AnimList.ScatterMax` can be used to set a range "
 "in cells around which any created animations will randomly scatter around"
 " from the impact point."
 msgstr "`AnimList.ScatterMin` 和 `AnimList.ScatterMax` 可用于设置从爆炸中心点开始一定范围内的动画随机散布范围。"
 
-#: ../../Fixed-or-Improved-Logics.md:2133
+#: ../../Fixed-or-Improved-Logics.md:2339
 msgid ""
 "`SplashList` can be used to override animations displayed if the Warhead "
 "has `Conventional=true` and it hits water."
 msgstr "`SplashList` 可以在拥有 `Conventional=true` 的弹头击中水面时覆盖显示的动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:2134
+#: ../../Fixed-or-Improved-Logics.md:2340
 msgid ""
 "`SplashList.PickRandom`, `SplashList.CreateAll`, "
 "`SplashList.CreationInterval` and `SplashList.Scatter(Min/Max)` apply to "
@@ -7304,7 +7578,7 @@ msgstr ""
 "`SplashList.PickRandom`、`SplashList.CreateAll`、`SplashList.CreationInterval`"
 " 和 `SplashList.Scatter(Min/Max)` 与 `AnimList` 同类语句相同。"
 
-#: ../../Fixed-or-Improved-Logics.md:2135
+#: ../../Fixed-or-Improved-Logics.md:2341
 msgid ""
 "`CreateAnimsOnZeroDamage`, if set to true, makes it so that `AnimList` or"
 " `SplashList` animations are created even if the weapon that fired the "
@@ -7313,7 +7587,7 @@ msgstr ""
 "`CreateAnimsOnZeroDamage` 如果设为 true，即便发射该弹头的武器只会造成 0 点伤害也会正常创建 `AnimList`"
 " 或 `SplashList` 动画。"
 
-#: ../../Fixed-or-Improved-Logics.md:2136
+#: ../../Fixed-or-Improved-Logics.md:2342
 msgid ""
 "Setting `Conventional.IgnoreUnits` to true on Warhead with "
 "`Conventional=true` will make the Warhead detonate on non-underwater "
@@ -7325,7 +7599,7 @@ msgstr ""
 "会使弹头命中位于水中的非水下载具类型时视为在水中引爆而不是视为在陆地上引爆。这决定了命中水面舰船时使用 `AnimList` 还是 "
 "`SplashList`。"
 
-#: ../../Fixed-or-Improved-Logics.md:2139
+#: ../../Fixed-or-Improved-Logics.md:2345
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "AnimList.PickRandom=false       ; boolean\n"
@@ -7367,11 +7641,11 @@ msgstr ""
 "CreateAnimsOnZeroDamage=false   ; boolean\n"
 "Conventional.IgnoreUnits=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2156
+#: ../../Fixed-or-Improved-Logics.md:2362
 msgid "Customizable Warhead trigger conditions"
 msgstr "自定义弹头效果触发条件"
 
-#: ../../Fixed-or-Improved-Logics.md:2158
+#: ../../Fixed-or-Improved-Logics.md:2364
 msgid ""
 "`AffectsBelowPercent` and `AffectsAbovePercent` can be used to set the "
 "health percentage thresholds that target needs to be below/equal and/or "
@@ -7381,13 +7655,13 @@ msgstr ""
 "`AffectsBelowPercent` 和 `AffectsAbovePercent` "
 "可用于设置目标被弹头作用所需的血量百分比必须高于和／或低于／等于的限制。若目标血量为 0 则跳过该检查。"
 
-#: ../../Fixed-or-Improved-Logics.md:2159
+#: ../../Fixed-or-Improved-Logics.md:2365
 msgid ""
 "If set to `false`, `AffectsNeutral` makes the warhead can't damage or "
 "affect target that belongs to neutral house."
 msgstr "若设置 `AffectsNeutral=false` 那么弹头将无法杀伤或作用于所属于中立所属方的目标。"
 
-#: ../../Fixed-or-Improved-Logics.md:2160
+#: ../../Fixed-or-Improved-Logics.md:2366
 #, python-format
 msgid ""
 "If set to `false`, `EffectsRequireVerses` makes the Phobos-introduced "
@@ -7397,7 +7671,7 @@ msgstr ""
 "若设置 `EffectsRequireVerses=false` 那么即便由于目标当前装甲类型导致弹头无法对其造成杀伤（例如 "
 "`Verses=0%`）Phobos 所引入的弹头效果也仍会触发。"
 
-#: ../../Fixed-or-Improved-Logics.md:2163
+#: ../../Fixed-or-Improved-Logics.md:2369
 msgid ""
 "[SOMEWARHEAD]               ; WarheadType\n"
 "AffectsBelowPercent=1.0     ; floating point value, percents or absolute\n"
@@ -7411,17 +7685,17 @@ msgstr ""
 "AffectsNeutral=true         ; boolean\n"
 "EffectsRequireVerses=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2171
+#: ../../Fixed-or-Improved-Logics.md:2377
 msgid "Customizing decloak on damaging targets"
 msgstr "自定义被伤害目标解除隐形"
 
-#: ../../Fixed-or-Improved-Logics.md:2173
+#: ../../Fixed-or-Improved-Logics.md:2379
 msgid ""
 "You can now specify whether or not the warhead decloaks objects that are "
 "damaged by the warhead."
 msgstr "现在你可以指定被这个弹头杀伤的对象是否解除隐形。"
 
-#: ../../Fixed-or-Improved-Logics.md:2176
+#: ../../Fixed-or-Improved-Logics.md:2382
 msgid ""
 "[SOMEWARHEAD]               ; WarheadType\n"
 "DecloakDamagedTargets=true  ; boolean\n"
@@ -7429,21 +7703,21 @@ msgstr ""
 "[SOMEWARHEAD]               ; WarheadType\n"
 "DecloakDamagedTargets=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2181
+#: ../../Fixed-or-Improved-Logics.md:2387
 msgid "Customizing parasite"
 msgstr "自定义寄生"
 
-#: ../../Fixed-or-Improved-Logics.md:2183
+#: ../../Fixed-or-Improved-Logics.md:2389
 msgid "Now you can specify which targets the parasite will culling them."
 msgstr "现在你可以指定哪些目标会被寄生所秒杀"
 
-#: ../../Fixed-or-Improved-Logics.md:2184
+#: ../../Fixed-or-Improved-Logics.md:2390
 msgid ""
 "Squid grapple anim is hardcoded to use `SQDG` in vanilla, Now you can "
 "choose it."
 msgstr "在原版中乌贼拖拽的动画被硬编码为 `SQDG`，现在选择权归你了。"
 
-#: ../../Fixed-or-Improved-Logics.md:2187
+#: ../../Fixed-or-Improved-Logics.md:2393
 msgid ""
 "[AudioVisual]\n"
 "Parasite.GrappleAnim=             ; animation\n"
@@ -7461,23 +7735,23 @@ msgstr ""
 "(none|aircraft|infantry|units|all)\n"
 "Parasite.GrappleAnim=             ; animation\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2196
+#: ../../Fixed-or-Improved-Logics.md:2402
 msgid "Dehardcode the `ZAdjust` of warhead anim"
 msgstr "弹头动画 `ZAdjust` 去硬编码"
 
-#: ../../Fixed-or-Improved-Logics.md:2198
+#: ../../Fixed-or-Improved-Logics.md:2404
 msgid ""
 "In vanilla, the animations generated by `AnimList` have a hard-coded "
 "`ZAdjust=-15`. Now you can customize it in the following ways."
 msgstr "在原版中由 `AnimList` 生成的动画被硬编码为 `ZAdjust=-15`。现在你可以通过下述方式进行自定义。"
 
-#: ../../Fixed-or-Improved-Logics.md:2199
+#: ../../Fixed-or-Improved-Logics.md:2405
 msgid ""
 "If these flags are set to 0, the `ZAdjust` defined by the anim will be "
 "used."
 msgstr "若这些语句设为 0 则将会使用动画自身的 `ZAdjust` 值。"
 
-#: ../../Fixed-or-Improved-Logics.md:2202
+#: ../../Fixed-or-Improved-Logics.md:2408
 msgid ""
 "[AudioVisual]\n"
 "WarheadAnimZAdjust=-15           ; Integer\n"
@@ -7493,11 +7767,11 @@ msgstr ""
 "AnimZAdjust=                     ; Integer, default to [AudioVisual] -> "
 "WarheadAnimZAdjust\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2210
+#: ../../Fixed-or-Improved-Logics.md:2416
 msgid "Delay automatic attack on the controlled unit"
 msgstr "攻击被心控单位的延迟"
 
-#: ../../Fixed-or-Improved-Logics.md:2212
+#: ../../Fixed-or-Improved-Logics.md:2418
 msgid ""
 "Now you can make the techno that has just been mind controlled not be "
 "automatically attacked by its original friendly forces for a period of "
@@ -7506,13 +7780,13 @@ msgstr ""
 "现在你可以让刚被心灵控制的科技类型在一段时间内不会自动遭到来自原所属方友军的攻击，持续时间由心灵控制弹头的 "
 "`MindControl.ThreatDelay` 参数控制。"
 
-#: ../../Fixed-or-Improved-Logics.md:2213
+#: ../../Fixed-or-Improved-Logics.md:2419
 msgid ""
 "This will not affect the manual selection of attacks and is useless with "
 "permanent mind control."
 msgstr "这不会影响手动攻击，并且不（也没必要）作用于永久心控的情况。"
 
-#: ../../Fixed-or-Improved-Logics.md:2216
+#: ../../Fixed-or-Improved-Logics.md:2422
 msgid ""
 "[General]\n"
 "MindControl.ThreatDelay=0     ; integer, game frames\n"
@@ -7528,41 +7802,41 @@ msgstr ""
 "MindControl.ThreatDelay=      ; integer, game frames, default to "
 "[General] -> MindControl.ThreatDelay\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2224
+#: ../../Fixed-or-Improved-Logics.md:2430
 msgid "Nonprovocative Warheads"
 msgstr "非挑衅弹头"
 
-#: ../../Fixed-or-Improved-Logics.md:2226
+#: ../../Fixed-or-Improved-Logics.md:2432
 msgid ""
 "You can now make Warheads behave in nonprovocative fashion. Warheads with"
 " `Nonprovocative=true` exhibit following behaviours:"
 msgstr "现在你可以让弹头以非挑衅的方式表现。设置为 `Nonprovocative=true` 的弹头会表现出以下行为："
 
-#: ../../Fixed-or-Improved-Logics.md:2227
+#: ../../Fixed-or-Improved-Logics.md:2433
 msgid ""
 "They will not generate any EVA announcements upon hitting targets, be it "
 "for attacking ore miners, base buildings or ally base buildings."
 msgstr "当命中目标时无论是是矿车、基地建筑还是盟友的基地建筑都不会播放任何 EVA 通报。"
 
-#: ../../Fixed-or-Improved-Logics.md:2228
+#: ../../Fixed-or-Improved-Logics.md:2434
 msgid ""
 "They will not spring 'attacked' / 'attacked by' events. Note that if the "
 "Warhead deals actual damage, events that check for that can still be "
 "sprung."
 msgstr "它们不会触发 “受到攻击”／“被...攻击” 事件。注意如果弹头造成了实际杀伤那么检查杀伤的事件仍可能被触发。"
 
-#: ../../Fixed-or-Improved-Logics.md:2229
+#: ../../Fixed-or-Improved-Logics.md:2435
 msgid ""
 "They will not evoke defense response from AI players when used to attack "
 "base buildings, `ToProtect=true` TechnoTypes or members of TeamTypes with"
 " `Whiner=true`."
 msgstr "它们不会在攻击基地建筑、`ToProtect=true` 的科技类型或具有 `Whiner=true` 的小队的成员时引发 AI 玩家的防御反应。"
 
-#: ../../Fixed-or-Improved-Logics.md:2230
+#: ../../Fixed-or-Improved-Logics.md:2436
 msgid "They will not evoke retaliation from TechnoTypes hit by the Warhead."
 msgstr "它们不会引发弹头所命中科技类型的反击。"
 
-#: ../../Fixed-or-Improved-Logics.md:2233
+#: ../../Fixed-or-Improved-Logics.md:2439
 msgid ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "Nonprovocative=false  ; boolean\n"
@@ -7570,24 +7844,24 @@ msgstr ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "Nonprovocative=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2239
+#: ../../Fixed-or-Improved-Logics.md:2445
 msgid ""
 "Due to technical constraints, this does not suppress warnings from Ares' "
 "EMP effect."
 msgstr "由于技术限制，这不会去除 Ares 的 EMP 效果所产生的警告。"
 
-#: ../../Fixed-or-Improved-Logics.md:2242
+#: ../../Fixed-or-Improved-Logics.md:2448
 msgid "Restricting screen shaking to current view"
 msgstr "限制屏幕抖动于当前视角"
 
-#: ../../Fixed-or-Improved-Logics.md:2244
+#: ../../Fixed-or-Improved-Logics.md:2450
 msgid ""
 "You can now specify whether or not the warhead can only shake screen "
 "(`ShakeX/Ylo/hi`) if it is detonated while visible on current screen "
 "view."
 msgstr "现在你可以指定这个弹头是否只能在可视的当前屏幕可见区域内爆炸时才能抖动（`ShakeX/Ylo/hi`）屏幕"
 
-#: ../../Fixed-or-Improved-Logics.md:2247
+#: ../../Fixed-or-Improved-Logics.md:2453
 msgid ""
 "[SOMEWARHEAD]       ; WarheadType\n"
 "ShakeIsLocal=false  ; boolean\n"
@@ -7595,15 +7869,15 @@ msgstr ""
 "[SOMEWARHEAD]       ; WarheadType\n"
 "ShakeIsLocal=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2252
+#: ../../Fixed-or-Improved-Logics.md:2458
 msgid "Weapons"
 msgstr "武器"
 
-#: ../../Fixed-or-Improved-Logics.md:2254
+#: ../../Fixed-or-Improved-Logics.md:2460
 msgid "AmbientDamage customizations"
 msgstr "自定义穿透伤害"
 
-#: ../../Fixed-or-Improved-Logics.md:2256
+#: ../../Fixed-or-Improved-Logics.md:2462
 msgid ""
 "You can now specify separate Warhead used for `AmbientDamage` via "
 "`AmbientDamage.Warhead` or make it never apply to weapon's main target by"
@@ -7612,7 +7886,7 @@ msgstr ""
 "现在你可以通过 `AmbientDamage.Warhead` 指定用于 `AmbientDamage` 的弹头或通过将 "
 "`AmbientDamage.IgnoreTarget` 设为 true 使其永远不会对武器的直接目标生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:2259
+#: ../../Fixed-or-Improved-Logics.md:2465
 msgid ""
 "[SOMEWEAPON]                      ; WeaponType\n"
 "AmbientDamage.Warhead=            ; WarheadType\n"
@@ -7622,11 +7896,11 @@ msgstr ""
 "AmbientDamage.Warhead=            ; WarheadType\n"
 "AmbientDamage.IgnoreTarget=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2265
+#: ../../Fixed-or-Improved-Logics.md:2471
 msgid "Charge turret delays"
 msgstr "炮塔充能间隔"
 
-#: ../../Fixed-or-Improved-Logics.md:2267
+#: ../../Fixed-or-Improved-Logics.md:2473
 msgid ""
 "It is now possible to customize the delay of `IsChargeTurret=true` unit "
 "turret animation per weapon, per `Burst` shot instead of defaulting to "
@@ -7640,13 +7914,13 @@ msgstr ""
 "等）。使用列表中与 `Burst` 一一对应值的间隔，若当前连发的次数高于列表中值的数量那么使用列表中最后一个值。间隔为 0 "
 "或更小将不会被使用，并且不会重置先前的充能序列（目前仍会重置序列但不会重置充能动画播放时间）。"
 
-#: ../../Fixed-or-Improved-Logics.md:2268
+#: ../../Fixed-or-Improved-Logics.md:2474
 msgid ""
 "Note that unlike the default rearm timer that uses `ROF`, any modifiers "
 "are not applied to explicitly set charge turret delays."
 msgstr "注意与使用 `ROF` 的默认重新装填计时器不同，任何倍率都不会对明确指定的充能炮塔间隔生效。"
 
-#: ../../Fixed-or-Improved-Logics.md:2271
+#: ../../Fixed-or-Improved-Logics.md:2477
 msgid ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "ChargeTurret.Delays=  ; List of integers - game frames\n"
@@ -7654,19 +7928,19 @@ msgstr ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "ChargeTurret.Delays=  ; List of integers - game frames\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2276
+#: ../../Fixed-or-Improved-Logics.md:2482
 msgid "Customizable disk laser radius"
 msgstr "自定义飞碟激光半径"
 
-#: ../../Fixed-or-Improved-Logics.md:2278
+#: ../../Fixed-or-Improved-Logics.md:2484
 msgid "![image](_static/images/disklaser-radius-values-01.gif)"
 msgstr "![image](_static/images/disklaser-radius-values-01.gif)"
 
-#: ../../Fixed-or-Improved-Logics.md:2279
+#: ../../Fixed-or-Improved-Logics.md:2485
 msgid "You can now set disk laser animation radius using a new tag."
 msgstr "现在你可以通过一个新的标签来设置飞碟激光动画效果的半径。"
 
-#: ../../Fixed-or-Improved-Logics.md:2282
+#: ../../Fixed-or-Improved-Logics.md:2488
 msgid ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "DiskLaser.Radius=240  ; integer\n"
@@ -7676,18 +7950,18 @@ msgstr ""
 "DiskLaser.Radius=240  ; integer\n"
 "; 240 is the default saucer disk radius\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2288
+#: ../../Fixed-or-Improved-Logics.md:2494
 msgid "Customizable ROF random delay"
 msgstr "自定义 ROF 随机延迟"
 
-#: ../../Fixed-or-Improved-Logics.md:2290
+#: ../../Fixed-or-Improved-Logics.md:2496
 msgid ""
 "By default weapon `ROF` has a random delay of 0 to 2 frames added to it. "
 "This random delay is now customizable, globally and on per-WeaponType "
 "basis."
 msgstr "默认情况下武器的 `ROF` 会添加 0 到 2 的随机延迟。现在可以在全局和武器微观层面定义此随机延迟。"
 
-#: ../../Fixed-or-Improved-Logics.md:2293
+#: ../../Fixed-or-Improved-Logics.md:2499
 msgid ""
 "[CombatDamage]\n"
 "ROF.RandomDelay=0,2  ; integer - single or comma-sep. range (game frames)"
@@ -7705,17 +7979,17 @@ msgstr ""
 "ROF.RandomDelay=     ; integer - single or comma-sep. range (game "
 "frames), default to [CombatDamage] -> ROF.RandomDelay\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2301
+#: ../../Fixed-or-Improved-Logics.md:2507
 msgid "Customizing whether passengers are kicked out when an aircraft fires"
 msgstr "自定义战机开火时是否踢出乘客"
 
-#: ../../Fixed-or-Improved-Logics.md:2303
+#: ../../Fixed-or-Improved-Logics.md:2509
 msgid ""
 "You can now customize whether aircraft will forcefully eject passengers "
 "(vanilla behavior) or fire its weapon when attempting to fire."
 msgstr "现在你可以自定义战机在尝试开火时是强行踢出乘客（默认行为）还是发射这个武器。"
 
-#: ../../Fixed-or-Improved-Logics.md:2306
+#: ../../Fixed-or-Improved-Logics.md:2512
 msgid ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "KickOutPassengers=true  ; boolean\n"
@@ -7723,11 +7997,11 @@ msgstr ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "KickOutPassengers=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2311
+#: ../../Fixed-or-Improved-Logics.md:2517
 msgid "Disable FireOnce resetting infantry sequence"
 msgstr "禁止 FireOnce 重置步兵序列"
 
-#: ../../Fixed-or-Improved-Logics.md:2313
+#: ../../Fixed-or-Improved-Logics.md:2519
 msgid ""
 "It is now possible to disable `FireOnce=true` weapon resetting infantry "
 "sequences after firing via `FireOnce.ResetSequence`. Target will be "
@@ -7737,7 +8011,7 @@ msgstr ""
 "现在可以通过 `FireOnce.ResetSequence` 来禁用 `FireOnce=true` "
 "武器在开火后重置步兵序列的效果。目标将像以前一样被遗忘，如果开火后还有剩余帧，那么开火序列将简单地照常继续播放。"
 
-#: ../../Fixed-or-Improved-Logics.md:2316
+#: ../../Fixed-or-Improved-Logics.md:2522
 msgid ""
 "[SOMEWEAPON]                 ; WeaponType\n"
 "FireOnce.ResetSequence=true  ; boolean\n"
@@ -7745,11 +8019,11 @@ msgstr ""
 "[SOMEWEAPON]                 ; WeaponType\n"
 "FireOnce.ResetSequence=true  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2321
+#: ../../Fixed-or-Improved-Logics.md:2527
 msgid "Electric bolt customizations"
 msgstr "自定义 EBolt"
 
-#: ../../Fixed-or-Improved-Logics.md:2323
+#: ../../Fixed-or-Improved-Logics.md:2529
 msgid ""
 "![image](_static/images/ebolt.gif) *EBolt customization utilized for "
 "different Tesla bolt weapon usage ([RA2: "
@@ -7758,13 +8032,13 @@ msgstr ""
 "![image](_static/images/ebolt.gif) *[RA2: "
 "Reboot](https://www.moddb.com/mods/reboot) 中自定义用于不同磁爆电流武器的 EBolt 效果*"
 
-#: ../../Fixed-or-Improved-Logics.md:2326
+#: ../../Fixed-or-Improved-Logics.md:2532
 msgid ""
 "You can now specify individual bolts you want to disable for "
 "`IsElectricBolt=true` weapons. Note that this is only a visual change."
 msgstr "现在你可以为 `IsElectricBolt=true` 的武器指定你想要关闭的特定电流。注意这只是视觉变化。"
 
-#: ../../Fixed-or-Improved-Logics.md:2327
+#: ../../Fixed-or-Improved-Logics.md:2533
 msgid ""
 "By default `IsElectricBolt=true` effect draws a bolt with 8 arcs. This "
 "can now be customized per WeaponType with `Bolt.Arcs`. Value of 0 results"
@@ -7773,14 +8047,14 @@ msgstr ""
 "默认情况下，`IsElectricBolt=true` 效果会绘制带有 8 条电弧的电流。现在可以通过 `Bolt.Arcs` "
 "为每种武器自定义这一效果。值为 0 将会绘制一条直线。"
 
-#: ../../Fixed-or-Improved-Logics.md:2328
+#: ../../Fixed-or-Improved-Logics.md:2534
 msgid ""
 "`Bolt.Duration` can be specified to explicitly set the overall duration "
 "of the visual electric bolt effect. Only values in range of 1 to 31 are "
 "accepted, values outside this range are clamped into it."
 msgstr "`Bolt.Duration` 可用于明确指定 EBolt 视觉效果的总持续时间，仅支持 1 到 31 范围内的值，超出此范围将会写回该范围内。"
 
-#: ../../Fixed-or-Improved-Logics.md:2329
+#: ../../Fixed-or-Improved-Logics.md:2535
 msgid ""
 "`Bolt.FollowFLH` can be used to override the default behaviour where the "
 "electric bolt source coordinates change to match the unit's firing coord "
@@ -7790,7 +8064,7 @@ msgstr ""
 "`Bolt.FollowFLH` 可用于覆盖 EBolt 起始坐标跟随单位开火坐标每帧改变（时期跟随单位的移动、旋转等）的默认行为。载具默认为 "
 "true 其他所有情况默认为 false。"
 
-#: ../../Fixed-or-Improved-Logics.md:2332
+#: ../../Fixed-or-Improved-Logics.md:2538
 msgid ""
 "[SOMEWEAPON]           ; WeaponType\n"
 "Bolt.Disable1=false    ; boolean\n"
@@ -7808,7 +8082,7 @@ msgstr ""
 "Bolt.Duration=17       ; integer, game frames\n"
 "Bolt.FollowFLH=        ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2343
+#: ../../Fixed-or-Improved-Logics.md:2549
 msgid ""
 "Due to technical constraints, these features do not work with electric "
 "bolts created from support weapon of [Ares' Prism Forwarding](https"
@@ -7819,11 +8093,11 @@ msgstr ""
 "docs/new/buildings/prismforwarding.html) 或那些 `AirburstWeapon` 所创建的 EBolt "
 "效果。"
 
-#: ../../Fixed-or-Improved-Logics.md:2346
+#: ../../Fixed-or-Improved-Logics.md:2552
 msgid "Single-color lasers"
 msgstr "单色激光"
 
-#: ../../Fixed-or-Improved-Logics.md:2348
+#: ../../Fixed-or-Improved-Logics.md:2554
 msgid ""
 "![image](_static/images/issinglecolor.gif) *Comparison of "
 "`IsSingleColor=yes` lasers with higher thickness to regular ones ([RA2: "
@@ -7833,7 +8107,7 @@ msgstr ""
 "Reboot](https://www.moddb.com/mods/reboot) 中宽度更大的 `IsSingleColor=yes` "
 "激光与常规激光的比较*"
 
-#: ../../Fixed-or-Improved-Logics.md:2351
+#: ../../Fixed-or-Improved-Logics.md:2557
 msgid ""
 "You can now set laser to draw using only `LaserInnerColor` by setting "
 "`IsSingleColor`, in same manner as `IsHouseColor` lasers do using "
@@ -7843,7 +8117,7 @@ msgstr ""
 "现在你可以通过设置 `IsSingleColor` 使激光仅使用 `LaserInnerColor` 进行绘制，就像 `IsHouseColor`"
 " 的激光使用玩家所属方的颜色一样。这样的激光同样尊重激光宽度。注意这在光棱塔递光武器上并不可用。"
 
-#: ../../Fixed-or-Improved-Logics.md:2354
+#: ../../Fixed-or-Improved-Logics.md:2560
 msgid ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "IsSingleColor=false  ; boolean\n"
@@ -7851,17 +8125,17 @@ msgstr ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "IsSingleColor=false  ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2359
+#: ../../Fixed-or-Improved-Logics.md:2565
 msgid "Allow deploy controlled MCV"
 msgstr "允许部署被心控的 MCV"
 
-#: ../../Fixed-or-Improved-Logics.md:2361
+#: ../../Fixed-or-Improved-Logics.md:2567
 msgid ""
 "In vanilla, you cannot deploy a controlled vehicle to "
 "`ConstructionYard=true` building. Now you can customize it."
 msgstr "在原版中你不能将一个被心灵控制的载具部署为 `ConstructionYard=true` 的建筑。现在你可以自定义了。"
 
-#: ../../Fixed-or-Improved-Logics.md:2364
+#: ../../Fixed-or-Improved-Logics.md:2570
 msgid ""
 "[General]\n"
 "AllowDeployControlledMCV=false   ; boolean\n"
@@ -7869,50 +8143,47 @@ msgstr ""
 "[General]\n"
 "AllowDeployControlledMCV=false   ; boolean\n"
 
-#: ../../Fixed-or-Improved-Logics.md:2369
+#: ../../Fixed-or-Improved-Logics.md:2575
 msgid "Customize type selection for IFV"
 msgstr "自定义 IFV 的类型选择"
 
-#: ../../Fixed-or-Improved-Logics.md:2371
+#: ../../Fixed-or-Improved-Logics.md:2577
 msgid ""
 "In vanilla game, when using type selection command on IFVs, all of them "
 "will be selected regardless of their current modes, which is allowed to "
 "customize now."
-msgstr ""
-"在原文的游戏中，当对 IFV 使用类型选择命令时会直接选中所有 IFV 而无论其当前的模式，现在这可以自定义了。"
+msgstr "在原文的游戏中，当对 IFV 使用类型选择命令时会直接选中所有 IFV 而无论其当前的模式，现在这可以自定义了。"
 
-#: ../../Fixed-or-Improved-Logics.md:2372
+#: ../../Fixed-or-Improved-Logics.md:2578
 msgid ""
 "`WeaponGroupAsN` determines which group the IFV is in when enabling "
 "`WeaponN`, where N stands for 1-based weapon mode index. IFVs in the same"
 " group will be selected together during type a selection, while not "
 "included those in different groups."
 msgstr ""
-"`WeaponGroupAsN` 决定当 IFV 启用 `WeaponN` 时所属的组别，N 为从 1 开始的武器模式序号。进行类型选择时将会选中同组 IFV 而不会包含非同组的。"
+"`WeaponGroupAsN` 决定当 IFV 启用 `WeaponN` 时所属的组别，N 为从 1 "
+"开始的武器模式序号。进行类型选择时将会选中同组 IFV 而不会包含非同组的。"
 
-#: ../../Fixed-or-Improved-Logics.md:2373
+#: ../../Fixed-or-Improved-Logics.md:2579
 msgid ""
 "`TypeSelectUseIFVMode` determines whether all IFV modes will be "
 "considered as its own group by default during a type selection."
-msgstr ""
-"`TypeSelectUseIFVMode` 决定类型选择时所有 IFVMode 是否默认自成一组。"
+msgstr "`TypeSelectUseIFVMode` 决定类型选择时所有 IFVMode 是否默认自成一组。"
 
-#: ../../Fixed-or-Improved-Logics.md:2374
+#: ../../Fixed-or-Improved-Logics.md:2580
 msgid ""
 "If it's set to true, `WeaponGroupAsN` will be default to N for each "
 "`WeaponN`, which makes each of them become a standalone type during a "
 "type selection."
-msgstr ""
-"若设为 true 则 `WeaponGroupAsN` 默认为 N 的值以使每个模式都作为独立的组。"
+msgstr "若设为 true 则 `WeaponGroupAsN` 默认为 N 的值以使每个模式都作为独立的组。"
 
-#: ../../Fixed-or-Improved-Logics.md:2375
+#: ../../Fixed-or-Improved-Logics.md:2581
 msgid ""
 "If it's set to false, `WeaponGroupAsN` will be default to 0 for all "
 "weapons, which makes type selection on IFVs work the same as before."
-msgstr ""
-"若设为 false 则 `WeaponGroupAsN` 将默认为 0 以保持原有行为。"
+msgstr "若设为 false 则 `WeaponGroupAsN` 将默认为 0 以保持原有行为。"
 
-#: ../../Fixed-or-Improved-Logics.md:2378
+#: ../../Fixed-or-Improved-Logics.md:2584
 msgid ""
 "[General]\n"
 "TypeSelectUseIFVMode=false   ; boolean\n"
@@ -7927,209 +8198,6 @@ msgstr ""
 "[SOMEVEHICLE]                ; VehicleType\n"
 "WeaponGroupAsN=              ; string, default to N if [General] -> "
 "TypeSelectUseIFVMode=true, and 0 if false\n"
-
-#: ../../Fixed-or-Improved-Logics.md:2386
-msgid "RadialIndicator visibility"
-msgstr "范围指示环可见性"
-
-#: ../../Fixed-or-Improved-Logics.md:2388
-msgid ""
-"In vanilla game, a structure's radial indicator can be drawn only when it"
-" belongs to the player. Now it can also be visible to observer. On top of"
-" that, you can specify its visibility from other houses."
-msgstr "在原本的游戏中，建筑的范围指示环只有在玩家拥有时才绘制。现在它也对观察者可见。此外，你还可以指定其他所属方的可见性。"
-
-#: ../../Fixed-or-Improved-Logics.md:2392
-msgid ""
-"[AudioVisual]\n"
-"RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
-"(owner/self | allies/ally | enemies/enemy | all)\n"
-msgstr ""
-"[AudioVisual]\n"
-"RadialIndicatorVisibility=allies  ; List of Affected House Enumeration "
-"(owner/self | allies/ally | enemies/enemy | all)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:2397
-msgid "Crate improvements"
-msgstr "升级工具箱增强"
-
-#: ../../Fixed-or-Improved-Logics.md:2399
-msgid "There are some improvements on goodie crate logic:"
-msgstr "对升级工具箱逻辑提供了以下改进："
-
-#: ../../Fixed-or-Improved-Logics.md:2400
-msgid ""
-"The statistic distribution of the randomly generated crates is now more "
-"uniform within the visible map region by using an optimized sampling "
-"procedure."
-msgstr "优化了随机算法使得随机生成的升级工具箱在可见地图区域内的统计分布更加均匀。"
-
-#: ../../Fixed-or-Improved-Logics.md:2401
-msgid ""
-"You can now limit the crates' spawn region to land only by setting "
-"`[CrateRules] -> CreateOnlyOnLand` to true."
-msgstr "现在你可以通过将 `[CrateRules] -> CreateOnlyOnLand` 设为 true 来让升级工具箱的生成区域仅限陆地。"
-
-#: ../../Fixed-or-Improved-Logics.md:2402
-msgid ""
-"The limit of vehicles a player can own before unit crates start giving "
-"money instead can now be customized by setting `UnitCrateVehicleCap`. "
-"Negative numbers disable the cap entirely."
-msgstr ""
-"现在可以通过 `UnitCrateVehicleCap` "
-"来设置玩家在单位箱子转为给予金钱之前可以拥有的载具数量上限。负数将禁用上限也就是永久生成载具不会达到一定数目后转为金钱。"
-
-#: ../../Fixed-or-Improved-Logics.md:2403
-msgid ""
-"`FreeMCV` setting is now actually respected and can be used to disable "
-"the forced unit selected from `[General] -> BaseUnit` that is given if "
-"player picks a crate and has enough credits but no existing buildings or "
-"`BaseUnit` vehicles."
-msgstr ""
-"现在尊重 `FreeMCV` 设置并且可以用来禁止玩家拾取升级工具箱且拥有足够的资金单然而没有建筑或 `BaseUnit` 载具时强制将内容选择为"
-" `[General] -> BaseUnit` 中的单位。"
-
-#: ../../Fixed-or-Improved-Logics.md:2404
-msgid ""
-"The previously hardcoded credits threshold that must be passed can also "
-"now be customized via `FreeMCV.CreditsThreshold`."
-msgstr "现在可以通过 `FreeMCV.CreditsThreshold` 自定义先前硬编码需要高于的资金阈值。"
-
-#: ../../Fixed-or-Improved-Logics.md:2405
-msgid ""
-"It is possible to influence weighting of units given from crates "
-"(`CrateGoodie=true`) via `CrateGoodie.RerollChance`, which determines the"
-" chance that if this type of unit is rolled, it will reroll again for "
-"another type of unit."
-msgstr ""
-"现在可以通过 `CrateGoodie.RerollChance` 来影响从升级工具箱 (`CrateGoodie=true`) "
-"中获得一个单位的权重，该值决定了如果随机到这种类型的单位，那么它将重新随机另一种单位的概率。"
-
-#: ../../Fixed-or-Improved-Logics.md:2408
-msgid ""
-"[CrateRules]\n"
-"CrateOnlyOnLand=false          ; boolean\n"
-"UnitCrateVehicleCap=50         ; integer\n"
-"FreeMCV=true                   ; boolean\n"
-"FreeMCV.CreditsThreshold=1500  ; integer\n"
-"\n"
-"[SOMEVEHICLE]                  ; VehicleType\n"
-"CrateGoodie.RerollChance=0.0   ; floating point value, percents or "
-"absolute (0.0-1.0)\n"
-msgstr ""
-"[CrateRules]\n"
-"CrateOnlyOnLand=false          ; boolean\n"
-"UnitCrateVehicleCap=50         ; integer\n"
-"FreeMCV=true                   ; boolean\n"
-"FreeMCV.CreditsThreshold=1500  ; integer\n"
-"\n"
-"[SOMEVEHICLE]                  ; VehicleType\n"
-"CrateGoodie.RerollChance=0.0   ; floating point value, percents or "
-"absolute (0.0-1.0)\n"
-
-#: ../../Fixed-or-Improved-Logics.md:2419
-msgid "DropPod"
-msgstr "空降仓"
-
-#: ../../Fixed-or-Improved-Logics.md:2421
-msgid ""
-"DropPod properties can now be customized on a per-TechnoType (non-"
-"building) basis."
-msgstr "现在可以在每个非建筑类单位上微观定义 DropPod 属性。"
-
-#: ../../Fixed-or-Improved-Logics.md:2422
-msgid ""
-"If you want to attach the trailer animation to the pod, set "
-"`DropPod.Trailer.Attached` to yes."
-msgstr "如果你要将尾烟动画附加到空降仓上，请将 `DropPod.Trailer.Attached` 设为 yes。"
-
-#: ../../Fixed-or-Improved-Logics.md:2423
-msgid ""
-"By default LaserTrails that are attached to the infantry will not be "
-"drawn if it's on DropPod."
-msgstr "默认情况下附加到步兵上的激光尾焰如果处于 DropPod 状态将不会绘制。"
-
-#: ../../Fixed-or-Improved-Logics.md:2424
-msgid ""
-"If you really want to use it, set `DropPodOnly` on the LaserTrail's type "
-"entry in art."
-msgstr "如果你实在想要使用它，那么请在 art 中的激光尾焰条目下设置 `DropPodOnly`。"
-
-#: ../../Fixed-or-Improved-Logics.md:2425
-msgid ""
-"If you want `DropPod.Weapon` to be fired only upon hard landing, set "
-"`DropPod.Weapon.HitLandOnly` to true."
-msgstr "如果要在着陆时才发射 `DropPod.Weapon`，请将 `DropPod.Weapon.HitLandOnly` 设为 true。"
-
-#: ../../Fixed-or-Improved-Logics.md:2426
-msgid ""
-"The landing speed is not smaller than it's current height /10 + 2 for "
-"unknown reason. A small `DropPod.Speed` value therefore results in "
-"exponential deceleration."
-msgstr "由于某些未知原因着陆速度不小于其当前高度 / 20 + 2 的值。因此较小的 `DropPod.Speed` 值会导致指数级减速。"
-
-#: ../../Fixed-or-Improved-Logics.md:2429
-msgid ""
-"Due to technical constraints `DropPod.AirImage` is only drawn for "
-"InfantryTypes (as the DropPod is the infantry itself with its image "
-"swapped). This may change in future."
-msgstr "由于技术限制，`DropPod.AirImage` 仅在步兵类单位上绘制（因为空降仓本身就是替换了图像的步兵自身）。未来可能会进行更改。"
-
-#: ../../Fixed-or-Improved-Logics.md:2433
-msgid ""
-"[SOMETECHNO]                  ; TechnoType\n"
-"DropPod.Angle=                ; double, default to [General] -> "
-"DropPodAngle, measured in radians\n"
-"DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> "
-"AtmosphereEntry\n"
-"DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod\n"
-"DropPod.AirImage=             ; SHP file, the pod's shape, default to POD"
-"\n"
-"DropPod.Height=               ; int, default to [General] -> "
-"DropPodHeight\n"
-"DropPod.Puff=                 ; anim, default to [AudioVisual] -> "
-"DropPodPuff\n"
-"DropPod.Speed=                ; int, default to [General] -> DropPodSpeed"
-"\n"
-"DropPod.Trailer=              ; anim, default to [General] -> "
-"DropPodTrailer, which by default is SMOKEY\n"
-"DropPod.Trailer.Attached=     ; boolean, default to no\n"
-"DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn "
-"of DropPod.Trailer, default to 6\n"
-"DropPod.Weapon=               ; weapon, default to [General] -> "
-"DropPodWeapon\n"
-"DropPod.Weapon.HitLandOnly=   ; boolean, default to no\n"
-msgstr ""
-"[SOMETECHNO]                  ; TechnoType\n"
-"DropPod.Angle=                ; double, default to [General] -> "
-"DropPodAngle, measured in radians\n"
-"DropPod.AtmosphereEntry=      ; anim, default to [AudioVisual] -> "
-"AtmosphereEntry\n"
-"DropPod.GroundAnim=           ; 2 anims, default to [General] -> DropPod\n"
-"DropPod.AirImage=             ; SHP file, the pod's shape, default to POD"
-"\n"
-"DropPod.Height=               ; int, default to [General] -> "
-"DropPodHeight\n"
-"DropPod.Puff=                 ; anim, default to [AudioVisual] -> "
-"DropPodPuff\n"
-"DropPod.Speed=                ; int, default to [General] -> DropPodSpeed"
-"\n"
-"DropPod.Trailer=              ; anim, default to [General] -> "
-"DropPodTrailer, which by default is SMOKEY\n"
-"DropPod.Trailer.Attached=     ; boolean, default to no\n"
-"DropPod.Trailer.SpawnDelay=   ; int, number of frames between each spawn "
-"of DropPod.Trailer, default to 6\n"
-"DropPod.Weapon=               ; weapon, default to [General] -> "
-"DropPodWeapon\n"
-"DropPod.Weapon.HitLandOnly=   ; boolean, default to no\n"
-
-#: ../../Fixed-or-Improved-Logics.md:2450
-msgid ""
-"`[General] -> DropPodTrailer` is [Ares feature](https://ares-"
-"developers.github.io/Ares-docs/new/droppod.html)."
-msgstr ""
-"`[General] -> DropPodTrailer` 是一个 [Ares 功能](https://ares-"
-"developers.github.io/Ares-docs/new/droppod.html)。"
 
 #~ msgid ""
 #~ "Now it is possible to designate "
@@ -8271,4 +8339,70 @@ msgstr ""
 #~ "Allowed Ares' `SW.AuxBuildings` and "
 #~ "`SW.NegBuildings` to count building upgrades."
 #~ msgstr "允许了 Ares 的 `SW.AuxBuildings` 和 `SW.NegBuildings` 计入建筑加载物。"
+
+#~ msgid ""
+#~ "If `[CombatDamage] -> AllowWeaponSelectAgainstWalls`"
+#~ " is set to true, `Secondary` will "
+#~ "now be used against walls if "
+#~ "`Primary` weapon Warhead has `Wall=false`, "
+#~ "`Secondary` has `Wall=true` and the "
+#~ "firer does not have "
+#~ "`NoSecondaryWeaponFallback` set to true."
+#~ msgstr ""
+#~ "现在如果 `[CombatDamage] -> "
+#~ "AllowWeaponSelectAgainstWalls` 设置为 true，假设 `Primary`"
+#~ " 武器的弹头拥有 `Wall=false`，而 `Secondary` 武器拥有 "
+#~ "`Wall=true` 且开火者没有将 `NoSecondaryWeaponFallback` 设为"
+#~ " true 那么 `Secondary` 将在应对墙时被使用。"
+
+#~ msgid ""
+#~ "Setting `[AudioVisual] -> ColorAddUse8BitRGB` "
+#~ "to true makes game treat values "
+#~ "from `[ColorAdd]` as 8-bit RGB (0-255)"
+#~ " instead of RGB565 (0-31 for red "
+#~ "& blue, 0-63 for green). This "
+#~ "works for `LaserTargetColor`, `IronCurtainColor`,"
+#~ " `BerserkColor` and `ForceShieldColor`."
+#~ msgstr ""
+#~ "设置 `[AudioVisual] -> ColorAddUse8BitRGB` 为 "
+#~ "true 时游戏会将 `[ColorAdd]` 中的值视为 8 位 "
+#~ "RGB(0-255)而不是 RGB565（红色和蓝色为 0-31，绿色为 0-63）。这适用于 "
+#~ "`LaserTargetColor`、`IronCurtainColor`、`BerserkColor` 和 "
+#~ "`ForceShieldColor`。（已知 KratosPP v0.1.15会抵消该逻辑）"
+
+#~ msgid ""
+#~ "[SOMETECHNO]        ; TechnoType\n"
+#~ "Image=              ; name of the file"
+#~ " that will be used as image, "
+#~ "without extension\n"
+#~ msgstr ""
+#~ "[SOMETECHNO]        ; TechnoType\n"
+#~ "Image=              ; name of the file"
+#~ " that will be used as image, "
+#~ "without extension\n"
+
+#~ msgid ""
+#~ "Vanilla game applies some weird "
+#~ "unnecessary math which resulted in the"
+#~ " voxel light source being \"nudged\" "
+#~ "up by a bit and light being "
+#~ "applied incorrectly on tilted voxels. It"
+#~ " is now possible to fix that."
+#~ msgstr ""
+#~ "原本的游戏中使用了一些奇怪且不必要的数学计算导致 Voxel 的光源被 “微调” "
+#~ "向上了一些并在倾斜的 Voxel 上光照效果不正确。现在可以修复这个问题。"
+
+#~ msgid ""
+#~ "Please note that enabling this will "
+#~ "remove the vertical offset vanilla "
+#~ "engine applies to the light source "
+#~ "position. Assuming vanilla lighting this "
+#~ "will make the light shine even "
+#~ "more from below the ground than it"
+#~ " was before, so it is recommended "
+#~ "to turn the Z value up in "
+#~ "value of `VoxelLightSource`."
+#~ msgstr ""
+#~ "请注意启用此功能将移除原版引擎对光源位置应用的垂直偏移。假设使用原版光照这将会使光线从地下照射来更多，因此建议将 "
+#~ "`VoxelLightSource` 的 Z 值调高。"
 

--- a/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/New-or-Enhanced-Logics.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Phobos \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-06 19:57+0800\n"
+"POT-Creation-Date: 2025-12-06 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -687,44 +687,44 @@ msgstr "`AttachEffect.CheckOnFirer` 可设为 true 以将必须存在／禁止�
 #: ../../New-or-Enhanced-Logics.md:1227 ../../New-or-Enhanced-Logics.md:1247
 #: ../../New-or-Enhanced-Logics.md:1264 ../../New-or-Enhanced-Logics.md:1283
 #: ../../New-or-Enhanced-Logics.md:1306 ../../New-or-Enhanced-Logics.md:1319
-#: ../../New-or-Enhanced-Logics.md:1340 ../../New-or-Enhanced-Logics.md:1375
-#: ../../New-or-Enhanced-Logics.md:1403 ../../New-or-Enhanced-Logics.md:1414
-#: ../../New-or-Enhanced-Logics.md:1436 ../../New-or-Enhanced-Logics.md:1454
-#: ../../New-or-Enhanced-Logics.md:1468 ../../New-or-Enhanced-Logics.md:1499
-#: ../../New-or-Enhanced-Logics.md:1515 ../../New-or-Enhanced-Logics.md:1538
-#: ../../New-or-Enhanced-Logics.md:1551 ../../New-or-Enhanced-Logics.md:1567
-#: ../../New-or-Enhanced-Logics.md:1610 ../../New-or-Enhanced-Logics.md:1643
-#: ../../New-or-Enhanced-Logics.md:1663 ../../New-or-Enhanced-Logics.md:1677
-#: ../../New-or-Enhanced-Logics.md:1707 ../../New-or-Enhanced-Logics.md:1739
-#: ../../New-or-Enhanced-Logics.md:1759 ../../New-or-Enhanced-Logics.md:1773
-#: ../../New-or-Enhanced-Logics.md:1785 ../../New-or-Enhanced-Logics.md:1799
-#: ../../New-or-Enhanced-Logics.md:1818 ../../New-or-Enhanced-Logics.md:1837
-#: ../../New-or-Enhanced-Logics.md:1850 ../../New-or-Enhanced-Logics.md:1880
-#: ../../New-or-Enhanced-Logics.md:1910 ../../New-or-Enhanced-Logics.md:1926
-#: ../../New-or-Enhanced-Logics.md:1942 ../../New-or-Enhanced-Logics.md:1960
-#: ../../New-or-Enhanced-Logics.md:1976 ../../New-or-Enhanced-Logics.md:1989
-#: ../../New-or-Enhanced-Logics.md:2008 ../../New-or-Enhanced-Logics.md:2031
-#: ../../New-or-Enhanced-Logics.md:2048 ../../New-or-Enhanced-Logics.md:2065
-#: ../../New-or-Enhanced-Logics.md:2088 ../../New-or-Enhanced-Logics.md:2101
-#: ../../New-or-Enhanced-Logics.md:2118 ../../New-or-Enhanced-Logics.md:2133
-#: ../../New-or-Enhanced-Logics.md:2156 ../../New-or-Enhanced-Logics.md:2171
-#: ../../New-or-Enhanced-Logics.md:2209 ../../New-or-Enhanced-Logics.md:2232
-#: ../../New-or-Enhanced-Logics.md:2279 ../../New-or-Enhanced-Logics.md:2303
-#: ../../New-or-Enhanced-Logics.md:2314 ../../New-or-Enhanced-Logics.md:2329
-#: ../../New-or-Enhanced-Logics.md:2364 ../../New-or-Enhanced-Logics.md:2382
-#: ../../New-or-Enhanced-Logics.md:2406 ../../New-or-Enhanced-Logics.md:2432
-#: ../../New-or-Enhanced-Logics.md:2447 ../../New-or-Enhanced-Logics.md:2470
-#: ../../New-or-Enhanced-Logics.md:2490 ../../New-or-Enhanced-Logics.md:2500
-#: ../../New-or-Enhanced-Logics.md:2511 ../../New-or-Enhanced-Logics.md:2521
-#: ../../New-or-Enhanced-Logics.md:2538 ../../New-or-Enhanced-Logics.md:2552
-#: ../../New-or-Enhanced-Logics.md:2565 ../../New-or-Enhanced-Logics.md:2576
-#: ../../New-or-Enhanced-Logics.md:2586 ../../New-or-Enhanced-Logics.md:2602
-#: ../../New-or-Enhanced-Logics.md:2623 ../../New-or-Enhanced-Logics.md:2639
-#: ../../New-or-Enhanced-Logics.md:2650 ../../New-or-Enhanced-Logics.md:2673
-#: ../../New-or-Enhanced-Logics.md:2701 ../../New-or-Enhanced-Logics.md:2718
-#: ../../New-or-Enhanced-Logics.md:2736 ../../New-or-Enhanced-Logics.md:2750
-#: ../../New-or-Enhanced-Logics.md:2774 ../../New-or-Enhanced-Logics.md:2789
-#: ../../New-or-Enhanced-Logics.md:2811
+#: ../../New-or-Enhanced-Logics.md:1340 ../../New-or-Enhanced-Logics.md:1366
+#: ../../New-or-Enhanced-Logics.md:1399 ../../New-or-Enhanced-Logics.md:1427
+#: ../../New-or-Enhanced-Logics.md:1438 ../../New-or-Enhanced-Logics.md:1460
+#: ../../New-or-Enhanced-Logics.md:1478 ../../New-or-Enhanced-Logics.md:1492
+#: ../../New-or-Enhanced-Logics.md:1523 ../../New-or-Enhanced-Logics.md:1541
+#: ../../New-or-Enhanced-Logics.md:1556 ../../New-or-Enhanced-Logics.md:1580
+#: ../../New-or-Enhanced-Logics.md:1596 ../../New-or-Enhanced-Logics.md:1612
+#: ../../New-or-Enhanced-Logics.md:1655 ../../New-or-Enhanced-Logics.md:1688
+#: ../../New-or-Enhanced-Logics.md:1708 ../../New-or-Enhanced-Logics.md:1722
+#: ../../New-or-Enhanced-Logics.md:1752 ../../New-or-Enhanced-Logics.md:1784
+#: ../../New-or-Enhanced-Logics.md:1804 ../../New-or-Enhanced-Logics.md:1818
+#: ../../New-or-Enhanced-Logics.md:1830 ../../New-or-Enhanced-Logics.md:1844
+#: ../../New-or-Enhanced-Logics.md:1863 ../../New-or-Enhanced-Logics.md:1882
+#: ../../New-or-Enhanced-Logics.md:1895 ../../New-or-Enhanced-Logics.md:1925
+#: ../../New-or-Enhanced-Logics.md:1955 ../../New-or-Enhanced-Logics.md:1971
+#: ../../New-or-Enhanced-Logics.md:1987 ../../New-or-Enhanced-Logics.md:2005
+#: ../../New-or-Enhanced-Logics.md:2021 ../../New-or-Enhanced-Logics.md:2034
+#: ../../New-or-Enhanced-Logics.md:2053 ../../New-or-Enhanced-Logics.md:2076
+#: ../../New-or-Enhanced-Logics.md:2092 ../../New-or-Enhanced-Logics.md:2105
+#: ../../New-or-Enhanced-Logics.md:2122 ../../New-or-Enhanced-Logics.md:2137
+#: ../../New-or-Enhanced-Logics.md:2160 ../../New-or-Enhanced-Logics.md:2175
+#: ../../New-or-Enhanced-Logics.md:2213 ../../New-or-Enhanced-Logics.md:2236
+#: ../../New-or-Enhanced-Logics.md:2283 ../../New-or-Enhanced-Logics.md:2307
+#: ../../New-or-Enhanced-Logics.md:2318 ../../New-or-Enhanced-Logics.md:2333
+#: ../../New-or-Enhanced-Logics.md:2368 ../../New-or-Enhanced-Logics.md:2386
+#: ../../New-or-Enhanced-Logics.md:2410 ../../New-or-Enhanced-Logics.md:2436
+#: ../../New-or-Enhanced-Logics.md:2451 ../../New-or-Enhanced-Logics.md:2474
+#: ../../New-or-Enhanced-Logics.md:2494 ../../New-or-Enhanced-Logics.md:2504
+#: ../../New-or-Enhanced-Logics.md:2515 ../../New-or-Enhanced-Logics.md:2525
+#: ../../New-or-Enhanced-Logics.md:2542 ../../New-or-Enhanced-Logics.md:2556
+#: ../../New-or-Enhanced-Logics.md:2569 ../../New-or-Enhanced-Logics.md:2580
+#: ../../New-or-Enhanced-Logics.md:2590 ../../New-or-Enhanced-Logics.md:2606
+#: ../../New-or-Enhanced-Logics.md:2627 ../../New-or-Enhanced-Logics.md:2643
+#: ../../New-or-Enhanced-Logics.md:2654 ../../New-or-Enhanced-Logics.md:2677
+#: ../../New-or-Enhanced-Logics.md:2705 ../../New-or-Enhanced-Logics.md:2722
+#: ../../New-or-Enhanced-Logics.md:2740 ../../New-or-Enhanced-Logics.md:2754
+#: ../../New-or-Enhanced-Logics.md:2778 ../../New-or-Enhanced-Logics.md:2793
+#: ../../New-or-Enhanced-Logics.md:2815
 msgid "In `rulesmd.ini`:"
 msgstr "在 `rulesmd.ini`："
 
@@ -1059,14 +1059,14 @@ msgstr "![image](_static/images/radtype-01.png) *混合起来的多种辐射类�
 #: ../../New-or-Enhanced-Logics.md:192 ../../New-or-Enhanced-Logics.md:300
 #: ../../New-or-Enhanced-Logics.md:512 ../../New-or-Enhanced-Logics.md:637
 #: ../../New-or-Enhanced-Logics.md:791 ../../New-or-Enhanced-Logics.md:1216
-#: ../../New-or-Enhanced-Logics.md:1327 ../../New-or-Enhanced-Logics.md:1589
-#: ../../New-or-Enhanced-Logics.md:1592 ../../New-or-Enhanced-Logics.md:1671
-#: ../../New-or-Enhanced-Logics.md:1730 ../../New-or-Enhanced-Logics.md:1749
-#: ../../New-or-Enhanced-Logics.md:1832 ../../New-or-Enhanced-Logics.md:2148
-#: ../../New-or-Enhanced-Logics.md:2179 ../../New-or-Enhanced-Logics.md:2204
-#: ../../New-or-Enhanced-Logics.md:2262 ../../New-or-Enhanced-Logics.md:2311
-#: ../../New-or-Enhanced-Logics.md:2423 ../../New-or-Enhanced-Logics.md:2712
-#: ../../New-or-Enhanced-Logics.md:2762 ../../New-or-Enhanced-Logics.md:2805
+#: ../../New-or-Enhanced-Logics.md:1327 ../../New-or-Enhanced-Logics.md:1634
+#: ../../New-or-Enhanced-Logics.md:1637 ../../New-or-Enhanced-Logics.md:1716
+#: ../../New-or-Enhanced-Logics.md:1775 ../../New-or-Enhanced-Logics.md:1794
+#: ../../New-or-Enhanced-Logics.md:1877 ../../New-or-Enhanced-Logics.md:2152
+#: ../../New-or-Enhanced-Logics.md:2183 ../../New-or-Enhanced-Logics.md:2208
+#: ../../New-or-Enhanced-Logics.md:2266 ../../New-or-Enhanced-Logics.md:2315
+#: ../../New-or-Enhanced-Logics.md:2427 ../../New-or-Enhanced-Logics.md:2716
+#: ../../New-or-Enhanced-Logics.md:2766 ../../New-or-Enhanced-Logics.md:2809
 msgid "image"
 msgstr "图像"
 
@@ -1249,8 +1249,8 @@ msgstr "激光尾焰现在同样可以使用 EBolt 或 辐射波 特效。"
 #: ../../New-or-Enhanced-Logics.md:246 ../../New-or-Enhanced-Logics.md:528
 #: ../../New-or-Enhanced-Logics.md:557 ../../New-or-Enhanced-Logics.md:571
 #: ../../New-or-Enhanced-Logics.md:584 ../../New-or-Enhanced-Logics.md:688
-#: ../../New-or-Enhanced-Logics.md:748 ../../New-or-Enhanced-Logics.md:1581
-#: ../../New-or-Enhanced-Logics.md:2185
+#: ../../New-or-Enhanced-Logics.md:748 ../../New-or-Enhanced-Logics.md:1626
+#: ../../New-or-Enhanced-Logics.md:2189
 msgid "In `artmd.ini`:"
 msgstr "在 `artmd.ini`："
 
@@ -1987,13 +1987,13 @@ msgstr ""
 "通过设置 `Tint.Color` 和 `Tint Intensity` 可以为拥有护盾的科技类型使用类似于铁幕／力场护盾或 "
 "`Psychedelic=true` 弹头的染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:456 ../../New-or-Enhanced-Logics.md:1464
+#: ../../New-or-Enhanced-Logics.md:456 ../../New-or-Enhanced-Logics.md:1488
 msgid ""
 "`Tint.Intensity` is additive lighting increase/decrease - 1.0 is the "
 "default object lighting."
 msgstr "`Tint.Intensity` 是增加／减少的光照，1.0 是默认的对象光照。"
 
-#: ../../New-or-Enhanced-Logics.md:457 ../../New-or-Enhanced-Logics.md:1465
+#: ../../New-or-Enhanced-Logics.md:457 ../../New-or-Enhanced-Logics.md:1489
 msgid ""
 "`Tint.VisibleToHouses` can be used to customize which houses can see the "
 "tint effect."
@@ -4478,14 +4478,14 @@ msgstr ""
 msgid "Convert TechnoType"
 msgstr "单位转换超武"
 
-#: ../../New-or-Enhanced-Logics.md:1079 ../../New-or-Enhanced-Logics.md:2265
+#: ../../New-or-Enhanced-Logics.md:1079 ../../New-or-Enhanced-Logics.md:2269
 msgid ""
 "Warheads can now change TechnoTypes of affected units to other Types in "
 "the same category (infantry to infantry, vehicles to vehicles, aircraft "
 "to aircraft)."
 msgstr "现在弹头可以将受影响单位的科技类型更改为同大类的其他科技类型（步兵到步兵，车辆到车辆，战机到战机）。"
 
-#: ../../New-or-Enhanced-Logics.md:1080 ../../New-or-Enhanced-Logics.md:2266
+#: ../../New-or-Enhanced-Logics.md:1080 ../../New-or-Enhanced-Logics.md:2270
 msgid ""
 "`ConvertN.From` (where N is 0, 1, 2...) specifies which TechnoTypes are "
 "valid for conversion. This entry can have many types listed, meanging "
@@ -4495,15 +4495,15 @@ msgstr ""
 "`ConvertN.From`（此处 N 为 0, 1, "
 "2...）指定哪些科技类型可用于转换。此条目可以列出许多类型以一次全部转换。当没有包含任何类型时将影响所有有效目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1081 ../../New-or-Enhanced-Logics.md:2267
+#: ../../New-or-Enhanced-Logics.md:1081 ../../New-or-Enhanced-Logics.md:2271
 msgid "`ConvertN.To` specifies the TechnoType which is the result of conversion."
 msgstr "`ConvertN.To` 指定转换后的科技类型。"
 
-#: ../../New-or-Enhanced-Logics.md:1082 ../../New-or-Enhanced-Logics.md:2268
+#: ../../New-or-Enhanced-Logics.md:1082 ../../New-or-Enhanced-Logics.md:2272
 msgid "`ConvertN.AffectedHouses` specifies whose units can be converted."
 msgstr "`ConvertN.AffectedHouses` 指定哪些所属方的单位可以被转换。"
 
-#: ../../New-or-Enhanced-Logics.md:1083 ../../New-or-Enhanced-Logics.md:2269
+#: ../../New-or-Enhanced-Logics.md:1083 ../../New-or-Enhanced-Logics.md:2273
 msgid ""
 "`Convert.From`, `Convert.To` and `Convert.AffectedHouses` (without "
 "numbers) are a valid alternative to `Convert0.From`, `Convert0.To` and "
@@ -4565,8 +4565,8 @@ msgstr ""
 "Convert.AffectedHouses=owner    ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1108 ../../New-or-Enhanced-Logics.md:2074
-#: ../../New-or-Enhanced-Logics.md:2293
+#: ../../New-or-Enhanced-Logics.md:1108 ../../New-or-Enhanced-Logics.md:1375
+#: ../../New-or-Enhanced-Logics.md:2297
 msgid ""
 "This feature has the same limitations as [Ares' Type Conversion](https"
 "://ares-developers.github.io/Ares-docs/new/typeconversion.html). This "
@@ -4575,8 +4575,8 @@ msgstr ""
 "此功能与 [Ares 的单位转换](https://ares-developers.github.io/Ares-"
 "docs/new/typeconversion.html) 存在同样的限制。此功能不支持建筑类型。"
 
-#: ../../New-or-Enhanced-Logics.md:1112 ../../New-or-Enhanced-Logics.md:2078
-#: ../../New-or-Enhanced-Logics.md:2297
+#: ../../New-or-Enhanced-Logics.md:1112 ../../New-or-Enhanced-Logics.md:1379
+#: ../../New-or-Enhanced-Logics.md:2301
 msgid ""
 "This feature requires Ares 3.0 or higher to function! When Ares 3.0+ is "
 "not detected, not all properties of a unit may be updated."
@@ -5366,28 +5366,73 @@ msgid ""
 msgstr "如果你设置了回收的 FLH，那么最好一并设置一个至少为 `0.5` 格的回收范围。否则子机发射器可能无法正确回收子机。"
 
 #: ../../New-or-Enhanced-Logics.md:1358
+msgid "Automatic conversion based on ammo"
+msgstr "基于弹药量的自动变形"
+
+#: ../../New-or-Enhanced-Logics.md:1360
+msgid "Units can now be converted into another unit by ammo count."
+msgstr "单位现在可以根据弹药量转换成另一种单位"
+
+#: ../../New-or-Enhanced-Logics.md:1361
+msgid ""
+"`Ammo.AutoConvertMinimumAmount` determines the minimal number of ammo at "
+"which a unit converts automatically after the ammo update."
+msgstr "`Ammo.AutoConvertMinimumAmount` 决定触发自动变形的最小弹药量。"
+
+#: ../../New-or-Enhanced-Logics.md:1362
+msgid ""
+"`Ammo.AutoConvertMaximumAmount` determines the maximum number of ammo at "
+"which a unit converts automatically after the ammo update."
+msgstr "`Ammo.AutoConvertMaximumAmount` 决定触发自动变形的最大弹药量。"
+
+#: ../../New-or-Enhanced-Logics.md:1363
+msgid ""
+"`Ammo.AutoConvertType` specify the new techno after the conversion. This "
+"unit must be of the same type of the original (infantry -> infantry, "
+"vehicle -> vehicle or aircraft -> aircraft)."
+msgstr "`Ammo.AutoConvertType` 指定变形成哪个新单位。该单位必须与原单位同属一类（载具变载具，步兵变步兵，战机变战机）。"
+
+#: ../../New-or-Enhanced-Logics.md:1364
+msgid ""
+"Setting a negative number will disable the ammo count check, and when "
+"both checks are disabled, conversion will not occur."
+msgstr "设为负数将会禁用弹药数量检查，当两个检查都被禁用时将不会触发变形。"
+
+#: ../../New-or-Enhanced-Logics.md:1367
+msgid ""
+"[SOMETECHNO]                      ; TechnoType, before conversion\n"
+"Ammo.AutoConvertMinimumAmount=-1  ; integer\n"
+"Ammo.AutoConvertMaximumAmount=-1  ; integer\n"
+"Ammo.AutoConvertType=             ; TechnoType, after conversion\n"
+msgstr ""
+"[SOMETECHNO]                      ; TechnoType, before conversion\n"
+"Ammo.AutoConvertMinimumAmount=-1  ; integer\n"
+"Ammo.AutoConvertMaximumAmount=-1  ; integer\n"
+"Ammo.AutoConvertType=             ; TechnoType, after conversion\n"
+
+#: ../../New-or-Enhanced-Logics.md:1382
 msgid "Automatic passenger deletion"
 msgstr "自动删除乘客"
 
-#: ../../New-or-Enhanced-Logics.md:1360
+#: ../../New-or-Enhanced-Logics.md:1384
 msgid ""
 "Transports can erase passengers over time. Passengers are deleted in "
 "order of entering the transport, from first to last."
 msgstr "运输工具可以随时间删除乘客。乘客将按照进入运输工具顺序的先后被删除。"
 
-#: ../../New-or-Enhanced-Logics.md:1361
+#: ../../New-or-Enhanced-Logics.md:1385
 msgid ""
 "`PassengerDeletion.Rate` determines the interval in game frames that it "
 "takes to erase a single passenger."
 msgstr "`PassengerDeletion.Rate` 决定删除单个乘客所需的游戏帧数。"
 
-#: ../../New-or-Enhanced-Logics.md:1362
+#: ../../New-or-Enhanced-Logics.md:1386
 msgid ""
 "If `PassengerDeletion.Rate.SizeMultiply` is set to true, this time "
 "interval is multiplied by the passenger's `Size`."
 msgstr "如果 `PassengerDeletion.Rate.SizeMultiply` 设为 true 则此时间间隔将乘算乘客的 `Size`。"
 
-#: ../../New-or-Enhanced-Logics.md:1363
+#: ../../New-or-Enhanced-Logics.md:1387
 msgid ""
 "`PassengerDeletion.UseCostAsRate`, if set to true, changes the time "
 "interval for erasing a passenger to be based on the passenger's `Cost`. "
@@ -5396,25 +5441,25 @@ msgstr ""
 "如果 `PassengerDeletion.UseCostAsRate` 设为 true 则删除乘客的间隔将基于乘客的 `Cost` "
 "计算。这不考虑 `FactoryPlant` 等修正。"
 
-#: ../../New-or-Enhanced-Logics.md:1364
+#: ../../New-or-Enhanced-Logics.md:1388
 msgid ""
 "`PassengerDeletion.CostMultiplier` can be used to modify the cost-based "
 "time interval."
 msgstr "`PassengerDeletion.CostMultiplier` 可用于设置基于成本的时间间隔倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:1365
+#: ../../New-or-Enhanced-Logics.md:1389
 msgid ""
 "`PassengerDeletion.CostRateCap` can be used to set a cap to the cost-"
 "based time interval."
 msgstr "`PassengerDeletion.CostRateCap` 可用于设置基于成本计算的时间间隔上限。"
 
-#: ../../New-or-Enhanced-Logics.md:1366
+#: ../../New-or-Enhanced-Logics.md:1390
 msgid ""
 "`PassengerDeletion.AllowedHouses` determines which houses passengers can "
 "belong to be eligible for deletion."
 msgstr "`PassengerDeletion.AllowedHouses` 决定了哪些所属方的乘客会被删除。"
 
-#: ../../New-or-Enhanced-Logics.md:1367
+#: ../../New-or-Enhanced-Logics.md:1391
 msgid ""
 "`PassengerDeletion.DontScore`, if set to true, makes it so that the "
 "deleted passengers are not counted as having been killed by the transport"
@@ -5423,7 +5468,7 @@ msgstr ""
 "如果 `PassengerDeletion.DontScore` 设为 true "
 "则删除的乘客不会被视为被运输工具击杀（没有经验，不会计入所属方击杀数等）。"
 
-#: ../../New-or-Enhanced-Logics.md:1368
+#: ../../New-or-Enhanced-Logics.md:1392
 msgid ""
 "If `PassengerDeletion.Soylent` is set to true, an amount of credits is "
 "refunded to the owner of the transport. The exact amount refunded is "
@@ -5433,19 +5478,19 @@ msgstr ""
 "如果 `PassengerDeletion.Soylent` 设为 true 则会向运输工具的所有者返还一定数量的资金。具体金额由乘客的 "
 "`Soylent` 决定，若为设置则由 `Cost` 决定（这里可受到 `FactoryPlant` 等修正的影响）。"
 
-#: ../../New-or-Enhanced-Logics.md:1369
+#: ../../New-or-Enhanced-Logics.md:1393
 msgid ""
 "`PassengerDeletion.SoylentMultiplier` is a direct multiplier applied to "
 "the refunded amount of credits."
 msgstr "`PassengerDeletion.SoylentMultiplier` 是直接应用于返还资金的倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:1370
+#: ../../New-or-Enhanced-Logics.md:1394
 msgid ""
 "`PassengerDeletion.SoylentAllowedHouses` determines which houses "
 "passengers can belong to be eligible for refunding."
 msgstr "`PassengerDeletion.SoylentAllowedHouses` 决定了哪些所属方的乘客会造成资金返还。"
 
-#: ../../New-or-Enhanced-Logics.md:1371
+#: ../../New-or-Enhanced-Logics.md:1395
 msgid ""
 "`PassengerDeletion.DisplaySoylent` can be set to true to display the "
 "amount of credits refunded on the transport. "
@@ -5457,7 +5502,7 @@ msgstr ""
 "以在运输工具上显示返还的资金金额。`PassengerDeletion.DisplaySoylentToHouses` "
 "决定了哪些所属方可以看到此消息，`PassengerDeletion.DisplaySoylentOffset` 可用于调整显示坐标偏移。"
 
-#: ../../New-or-Enhanced-Logics.md:1372
+#: ../../New-or-Enhanced-Logics.md:1396
 msgid ""
 "`PassengerDeletion.ReportSound` and `PassengerDeletion.Anim` can be used "
 "to specify a sound and animation to play when a passenger is erased, "
@@ -5467,13 +5512,13 @@ msgstr ""
 "`PassengerDeletion.ReportSound` 和 `PassengerDeletion.Anim` "
 "可用于分别指定在删除乘客时播放的声音和动画。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:1373
+#: ../../New-or-Enhanced-Logics.md:1397
 msgid ""
 "If `PassengerDeletion.UnderEMP` is set to true, the deletion will be "
 "processed when the transport is under EMP or deactivated."
 msgstr "如果 `PassengerDeletion.UnderEMP` 设为 true 则在运输工具受 EMP 影响或瘫痪时继续执行删除操作。"
 
-#: ../../New-or-Enhanced-Logics.md:1376
+#: ../../New-or-Enhanced-Logics.md:1400
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "PassengerDeletion.Rate=0                        ; integer, game frames\n"
@@ -5523,11 +5568,11 @@ msgstr ""
 "PassengerDeletion.Anim=                         ; List of AnimationTypes\n"
 "PassengerDeletion.UnderEMP=false                ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1396
+#: ../../New-or-Enhanced-Logics.md:1420
 msgid "Automatic passenger owner change to match transport owner"
 msgstr "自动同步载员所属方"
 
-#: ../../New-or-Enhanced-Logics.md:1398
+#: ../../New-or-Enhanced-Logics.md:1422
 msgid ""
 "Transports with `Passengers.SyncOwner` set to true will have the owner of"
 " their passengers changed to match the transport if transport's owner "
@@ -5536,14 +5581,14 @@ msgstr ""
 "如果运输工具的 `Passengers.SyncOwner` 设为 true "
 "则当运输工具的所有者发生改变那么其载员的所有者也将会更改以与运输工具同步。"
 
-#: ../../New-or-Enhanced-Logics.md:1399
+#: ../../New-or-Enhanced-Logics.md:1423
 msgid ""
 "On `OpenTopped=true` transports this will also disable checks that "
 "prevent target acquisition by passengers when the transport is "
 "temporarily mind controlled."
 msgstr "对于 `OpenTopped=true` 的运输工具这还将禁用在运输工具暂时被心灵控制时阻止载员对目标进行攻击的检查。"
 
-#: ../../New-or-Enhanced-Logics.md:1400
+#: ../../New-or-Enhanced-Logics.md:1424
 msgid ""
 "`Passengers.SyncOwner.RevertOnExit`, if set to true (which is the "
 "default), changes the passengers' owner back to whatever it was "
@@ -5552,13 +5597,13 @@ msgstr ""
 "如果 `Passengers.SyncOwner.RevertOnExit` 设为 "
 "true（默认行为），当载员被弹出时，其所属方将恢复为载员进入时所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:1401
+#: ../../New-or-Enhanced-Logics.md:1425
 msgid ""
 "Does not work on passengers acquired through use of `Abductor=true` "
 "weapon *(Ares feature)*."
 msgstr "不适用于通过 `Abductor=true` 武器（*Ares 功能*）获取的载员。"
 
-#: ../../New-or-Enhanced-Logics.md:1404
+#: ../../New-or-Enhanced-Logics.md:1428
 msgid ""
 "[SOMETECHNO]                            ; TechnoType\n"
 "Passengers.SyncOwner=false              ; boolean\n"
@@ -5568,11 +5613,11 @@ msgstr ""
 "Passengers.SyncOwner=false              ; boolean\n"
 "Passengers.SyncOwner.RevertOnExit=true  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1410
+#: ../../New-or-Enhanced-Logics.md:1434
 msgid "Automatically firing weapons"
 msgstr "自动发射武器"
 
-#: ../../New-or-Enhanced-Logics.md:1412
+#: ../../New-or-Enhanced-Logics.md:1436
 msgid ""
 "You can now make TechnoType automatically fire its weapon(s) without "
 "having to scan for suitable targets by setting `AutoFire`, on either its "
@@ -5584,7 +5629,7 @@ msgstr ""
 "现在你可以设置 `AutoFire` 使科技类型根据 `AutoFire.TargetSelf` "
 "选择当前单元格或开火者自身自动发射其武器而无需检索一个合适的目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1415
+#: ../../New-or-Enhanced-Logics.md:1439
 msgid ""
 "[SOMETECHNO]               ; TechnoType\n"
 "AutoFire=false             ; boolean\n"
@@ -5594,15 +5639,15 @@ msgstr ""
 "AutoFire=false             ; boolean\n"
 "AutoFire.TargetSelf=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1421
+#: ../../New-or-Enhanced-Logics.md:1445
 msgid "Build limit group"
 msgstr "建造限制组"
 
-#: ../../New-or-Enhanced-Logics.md:1423
+#: ../../New-or-Enhanced-Logics.md:1447
 msgid "You can now make different technos share build limit in a group."
 msgstr "现在你可以使不同的科技类型在一个组内共享建造限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1424
+#: ../../New-or-Enhanced-Logics.md:1448
 msgid ""
 "`BuildLimitGroup.Types` determines the technos that'll be used for build "
 "limit conditions of the selected techno. Note that the limit won't be "
@@ -5612,7 +5657,7 @@ msgstr ""
 "`BuildLimitGroup.Types` "
 "决定了将用于所选科技类型建造条件的其他科技类型。注意该语句并不提供任何限制效果。要实现这点你需要手动位每个科技类型设置建造限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1425
+#: ../../New-or-Enhanced-Logics.md:1449
 msgid ""
 "`BuildLimitGroup.Nums` determines the amount of technos that would reach "
 "the build limit. If using a single integer, it'll use the sum of all "
@@ -5625,7 +5670,7 @@ msgstr ""
 " `BuildLimitGroup.Types` 数量相同的整数列表，则会为每个科技类型计算建造限制，其值的位置与 "
 "`BuildLimitGroup.Types` 中的位置对应。"
 
-#: ../../New-or-Enhanced-Logics.md:1426
+#: ../../New-or-Enhanced-Logics.md:1450
 msgid ""
 "`BuildLimitGroup.Factor` determines each of this techno instance will "
 "count as what value when calculating build limit."
@@ -5633,13 +5678,13 @@ msgstr ""
 "`BuildLimitGroup.Factor` 决定了每个此类科技类型在计算建造限制时将被视为多少来进行计算（类似一个用于 "
 "`BuildLimit` 的 `Size`）。"
 
-#: ../../New-or-Enhanced-Logics.md:1427
+#: ../../New-or-Enhanced-Logics.md:1451
 msgid ""
 "This is only used by BuildLimitGroup. No other place will use it when "
 "counting owned objects, including `BuildLimitGroup.ExtraLimit`."
 msgstr "这仅由 BuildLimitGroup 使用。其他地方不会使用它来计算，包括 `BuildLimitGroup.ExtraLimit`。"
 
-#: ../../New-or-Enhanced-Logics.md:1428
+#: ../../New-or-Enhanced-Logics.md:1452
 msgid ""
 "`BuildLimitGroup.ContentIfAnyMatch` determines the rule of calculating "
 "build limit per techno. If set to true, build limit will be content if "
@@ -5651,7 +5696,7 @@ msgstr ""
 "true，则当组内任意科技类型的数量达到其 `BuildLimitGroup.Nums` 值时视为全组达到建造限制。如果设置为 "
 "false，则只有当组内所有科技类型的数量达到时建造限制才有效。"
 
-#: ../../New-or-Enhanced-Logics.md:1429
+#: ../../New-or-Enhanced-Logics.md:1453
 msgid ""
 "`BuildLimitGroup.NotBuildableIfQueueMatch` determines the moment to stop "
 "the techno's production. If set to true, its production will be stopped "
@@ -5662,19 +5707,19 @@ msgstr ""
 "`BuildLimitGroup.NotBuildableIfQueueMatch` 决定了禁用科技类型生产的时刻，如果设为 true "
 "则已存在的科技类型与处于生产序列中的科技类型只和满足条件就会停止生产。如果设为 false 则只有地图上实际存在的科技类型满足条件才会停止生产。"
 
-#: ../../New-or-Enhanced-Logics.md:1430
+#: ../../New-or-Enhanced-Logics.md:1454
 msgid ""
 "You can also add an extra value into `BuildLimitGroup.Nums`, determined "
 "by the amount of specific technos owned by its house."
 msgstr "你还可以根据其所属方拥有的特定科技类型数量向 `BuildLimitGroup.Nums` 添加一个额外调整值。"
 
-#: ../../New-or-Enhanced-Logics.md:1431
+#: ../../New-or-Enhanced-Logics.md:1455
 msgid ""
 "`BuildLimitGroup.ExtraLimit.Types` determines the technos that'll be used"
 " for extra value calculation."
 msgstr "`BuildLimitGroup.ExtraLimit.Types` 决定了将用于额外值计算的科技类型。"
 
-#: ../../New-or-Enhanced-Logics.md:1432
+#: ../../New-or-Enhanced-Logics.md:1456
 msgid ""
 "`BuildLimitGroup.ExtraLimit.Nums` determines the actual value of "
 "increment. Value matching the position in "
@@ -5686,7 +5731,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.Types` "
 "中对应位置的科技类型一一对应。每个列表中的科技类型会使建造限制增加其场上存在的数量 * 该列表中对应值。"
 
-#: ../../New-or-Enhanced-Logics.md:1433
+#: ../../New-or-Enhanced-Logics.md:1457
 msgid ""
 "`BuildLimitGroup.ExtraLimit.MaxCount` determines the maximum amount of "
 "technos being counted into the extra value calculation. Value matching "
@@ -5698,7 +5743,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.Types` 中对应位置的科技类型一一对应。如果未设置或设为小于 1 "
 "的值，则视为无最大数量限制。"
 
-#: ../../New-or-Enhanced-Logics.md:1434
+#: ../../New-or-Enhanced-Logics.md:1458
 msgid ""
 "`BuildLimitGroup.ExtraLimit.MaxNum` determines the maximum of values in "
 "`BuildLimitGroup.Nums` after extra limit calculation. If not set or set "
@@ -5707,7 +5752,7 @@ msgstr ""
 "`BuildLimitGroup.ExtraLimit.MaxNum` 决定了在计算额外值后 `BuildLimitGroup.Nums` "
 "的最大值。如果未设置或设为小于 1 的值，则视为无最大值。"
 
-#: ../../New-or-Enhanced-Logics.md:1437
+#: ../../New-or-Enhanced-Logics.md:1461
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "BuildLimitGroup.Types=                          ; List of TechnoTypes\n"
@@ -5733,17 +5778,17 @@ msgstr ""
 "BuildLimitGroup.ExtraLimit.MaxCount=            ; List of integers\n"
 "BuildLimitGroup.ExtraLimit.MaxNum=0             ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1450
+#: ../../New-or-Enhanced-Logics.md:1474
 msgid "Convert TechnoType on owner house change"
 msgstr "根据操作者变形"
 
-#: ../../New-or-Enhanced-Logics.md:1452
+#: ../../New-or-Enhanced-Logics.md:1476
 msgid ""
 "You can now change a unit's type when changing ownership from human to "
 "computer or from computer to human."
 msgstr "现在你可以在操作者从人类改为 AI 玩家或从 AI 玩家改为人类玩家时执行单位转换。"
 
-#: ../../New-or-Enhanced-Logics.md:1455
+#: ../../New-or-Enhanced-Logics.md:1479
 msgid ""
 "[SOMETECHNO]                ; TechnoType\n"
 "Convert.HumanToComputer=    ; TechnoType\n"
@@ -5753,11 +5798,11 @@ msgstr ""
 "Convert.HumanToComputer=    ; TechnoType\n"
 "Convert.ComputerToHuman=    ; TechnoType\n"
 
-#: ../../New-or-Enhanced-Logics.md:1461
+#: ../../New-or-Enhanced-Logics.md:1485
 msgid "Custom tint on TechnoTypes"
 msgstr "染色"
 
-#: ../../New-or-Enhanced-Logics.md:1463
+#: ../../New-or-Enhanced-Logics.md:1487
 msgid ""
 "A tint effect similar to that used by Iron Curtain / Force Shield or "
 "`Psychedelic=true` Warheads can be applied to TechnoTypes naturally by "
@@ -5766,13 +5811,13 @@ msgstr ""
 "通过设置 `Tint.Color` 和 `Tint Intensity` 可以为拥有护盾的科技类型使用类似于铁幕／力场护盾或 "
 "`Psychedelic=true` 弹头的染色效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1466
+#: ../../New-or-Enhanced-Logics.md:1490
 msgid ""
 "Tint effects can also be applied by [attached effects](#attached-effects)"
 " and on [shields](#shields)."
 msgstr "染色效果也可以通过 [Attach Effect](#attached-effects) 和 [护盾](#shields) 应用。"
 
-#: ../../New-or-Enhanced-Logics.md:1469
+#: ../../New-or-Enhanced-Logics.md:1493
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "Tint.Color=               ; integer - R,G,B\n"
@@ -5786,17 +5831,17 @@ msgstr ""
 "Tint.VisibleToHouses=all  ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1476
+#: ../../New-or-Enhanced-Logics.md:1500
 msgid "Customizable OpenTopped properties"
 msgstr "自定义 `OpenTopped` 属性"
 
-#: ../../New-or-Enhanced-Logics.md:1478
+#: ../../New-or-Enhanced-Logics.md:1502
 msgid ""
 "You can now override global `OpenTopped` transport properties per "
 "TechnoType."
 msgstr "现在你可以为每个科技类型微观设定全局 `OpenTopped` 运输工具的属性。"
 
-#: ../../New-or-Enhanced-Logics.md:1479
+#: ../../New-or-Enhanced-Logics.md:1503
 msgid ""
 "`OpenTopped.IgnoreRangefinding` can be used to disable `OpenTopped` "
 "transport rangefinding behaviour where smallest weapon range between "
@@ -5806,7 +5851,7 @@ msgstr ""
 "`OpenTopped.IgnoreRangefinding` 可用于禁用 `OpenTopped` "
 "运输工具在接近超出射程的目标和扫描潜在目标时使用运输工具与所有载员之间的 `Range` 最小武器的射程这一测距行为。"
 
-#: ../../New-or-Enhanced-Logics.md:1480
+#: ../../New-or-Enhanced-Logics.md:1504
 msgid ""
 "`OpenTopped.AllowFiringIfDeactivated` can be used to customize whether or"
 " not passengers can fire out when the transport is deactivated (EMP, "
@@ -5815,13 +5860,13 @@ msgstr ""
 "`OpenTopped.AllowFiringIfDeactivated` 可用于自定义当运输工具被瘫痪（EMP、`PoweredUnit` "
 "等）时载员是否可以开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1481
+#: ../../New-or-Enhanced-Logics.md:1505
 msgid ""
 "`OpenTopped.ShareTransportTarget` controls whether or not the current "
 "target of the transport itself is passed to the passengers as well."
 msgstr "`OpenTopped.ShareTransportTarget` 控制运输工具的当前目标是否传递给乘客。"
 
-#: ../../New-or-Enhanced-Logics.md:1483
+#: ../../New-or-Enhanced-Logics.md:1507
 msgid ""
 "[SOMETECHNO]                              ; TechnoType\n"
 "OpenTopped.RangeBonus=                    ; integer, override of the "
@@ -5845,30 +5890,30 @@ msgstr ""
 "OpenTopped.AllowFiringIfDeactivated=true  ; boolean\n"
 "OpenTopped.ShareTransportTarget=true      ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1493
+#: ../../New-or-Enhanced-Logics.md:1517
 msgid "Customizable spawns queue"
 msgstr "自定义子机序列"
 
-#: ../../New-or-Enhanced-Logics.md:1494
+#: ../../New-or-Enhanced-Logics.md:1518
 msgid ""
 "It is now possible to spawn multiple types of spawnees from a spawner "
 "with `Spawns.Queue`. The order of spawnees in this queue is the order of "
 "their respawn."
 msgstr "现在可以通过 `Spawns.Queue` 从子机发射器生成多种子机。该序列中的子机顺序即为其重新生成顺序。"
 
-#: ../../New-or-Enhanced-Logics.md:1495
+#: ../../New-or-Enhanced-Logics.md:1519
 msgid ""
 "`Spawns` still needs to be set to enable the spawner logic and act as a "
 "default spawnee."
 msgstr "仍需设置 `Spawns` 以启用子机逻辑并作为默认子机。"
 
-#: ../../New-or-Enhanced-Logics.md:1496
+#: ../../New-or-Enhanced-Logics.md:1520
 msgid ""
 "`SpawnsNumber` still needs to be set to determine the amount of spawnee "
 "slots."
 msgstr "仍需设置 `SpawnsNumber` 以决定子机数量。"
 
-#: ../../New-or-Enhanced-Logics.md:1497
+#: ../../New-or-Enhanced-Logics.md:1521
 msgid ""
 "If the length of the queue is longer than the spawner's `SpawnsNumber`, "
 "spawnee after this length will be omitted. If the length is shorter "
@@ -5878,7 +5923,7 @@ msgstr ""
 "如果队列长度超过子机发射器的 `SpawnsNumber`，超出部分的子机将被忽略。如果队列长度过短则剩余部分由 `Spawns` "
 "定义的子机填补。因此建议将它们设为等长。"
 
-#: ../../New-or-Enhanced-Logics.md:1500
+#: ../../New-or-Enhanced-Logics.md:1524
 msgid ""
 "[SOMETECHNO]        ; TechnoType\n"
 "Spawns.Queue=       ; List of AircraftTypes, in order\n"
@@ -5886,32 +5931,82 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "Spawns.Queue=       ; List of AircraftTypes, in order\n"
 
-#: ../../New-or-Enhanced-Logics.md:1506
+#: ../../New-or-Enhanced-Logics.md:1530
 msgid ""
 "Note that all spawnees in a queue should have `MissileSpawn` set to the "
 "same value (all to true or false). Mixing them will make missile spawnees"
 " can't hit their targets."
 msgstr "注意队列中的所有子机应当拥有相同的 `MissileSpawn` 值（均为 true 或均为 false）。混合使用会导致导弹类子机无法命中目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1509
+#: ../../New-or-Enhanced-Logics.md:1533
+msgid "Customize Ares's radar jam logic"
+msgstr "自定义 Ares 的雷达干扰逻辑"
+
+#: ../../New-or-Enhanced-Logics.md:1535
+msgid "It is now possible to customize some properties of Ares's radar jam logic."
+msgstr "现在可以自定义 Ares 雷达干扰逻辑的部分属性。"
+
+#: ../../New-or-Enhanced-Logics.md:1536
+msgid "`RadarJamHouses` determines which houses will be affected by the jam."
+msgstr "`RadarJamHouses` 决定哪些所属方会受到雷达干扰效果影响。"
+
+#: ../../New-or-Enhanced-Logics.md:1537
+msgid ""
+"`RadarJamDelay` determines the interval of the jam, default to 30 frames "
+"like Ares did. Shorter interval means the jam will be applied more "
+"timely, but worse for performance."
+msgstr "`RadarJamDelay` 决定干扰间隔，默认同 Ares 为 30。较短的间隔会使干扰生效更及时但会降低性能。"
+
+#: ../../New-or-Enhanced-Logics.md:1538
+msgid ""
+"`RadarJamAffect` determines a list of buildings with `Radar=yes` or "
+"`SpySat=yes` that could be affected by the jam. If it's empty, all radar "
+"buildings will be affected."
+msgstr ""
+"`RadarJamAffect` 决定哪些拥有 `Radar=yes` 或 `SpySat=yes` "
+"的建筑会受到干扰。如果为空则所有雷达建筑都会受到干扰。"
+
+#: ../../New-or-Enhanced-Logics.md:1539
+msgid ""
+"`RadarJamIgnore` determines a list of buildings with `Radar=yes` or "
+"`SpySat=yes` that couldn't be affected by the jam."
+msgstr "`RadarJamIgnore` 决定哪些拥有 `Radar=yes` 或 `SpySat=yes` 的建筑不受到干扰。"
+
+#: ../../New-or-Enhanced-Logics.md:1542
+msgid ""
+"[SOMETECHNO]                      ; TechnoType, with RadarJamRadius=\n"
+"RadarJamHouses=enemies            ; List of Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"RadarJamDelay=30                  ; integer\n"
+"RadarJamAffect=                   ; List of BuildingTypes\n"
+"RadarJamIgnore=                   ; List of BuildingTypes\n"
+msgstr ""
+"[SOMETECHNO]                      ; TechnoType, with RadarJamRadius=\n"
+"RadarJamHouses=enemies            ; List of Affected House Enumeration "
+"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
+"RadarJamDelay=30                  ; integer\n"
+"RadarJamAffect=                   ; List of BuildingTypes\n"
+"RadarJamIgnore=                   ; List of BuildingTypes\n"
+
+#: ../../New-or-Enhanced-Logics.md:1550
 msgid "Customize EVA voice and `SellSound` when selling units"
 msgstr "单位出售音效"
 
-#: ../../New-or-Enhanced-Logics.md:1511
+#: ../../New-or-Enhanced-Logics.md:1552
 msgid ""
 "When a building or a unit is sold, a sell sound as well as an EVA is "
 "played to the owner. These configurations have been deglobalized."
 msgstr "当建筑或单位被出售时将向所有者播放出售音效和 EVA 语音。这些设置以允许微观定义。"
 
-#: ../../New-or-Enhanced-Logics.md:1512
+#: ../../New-or-Enhanced-Logics.md:1553
 msgid "`EVA.Sold` is used to customize the EVA voice when selling."
 msgstr "`EVA.Sold` 用于自定义出售时的 EVA 语音。"
 
-#: ../../New-or-Enhanced-Logics.md:1513
+#: ../../New-or-Enhanced-Logics.md:1554
 msgid "`SellSound` is used to customize the report sound when selling."
 msgstr "`SellSound` 用于自定义出售时的音效。"
 
-#: ../../New-or-Enhanced-Logics.md:1516
+#: ../../New-or-Enhanced-Logics.md:1557
 msgid ""
 "[SOMETECHNO]    ; BuildingType or VehicleType\n"
 "EVA.Sold=       ; EVA entry, default to EVA_StructureSold for buildings "
@@ -5923,17 +6018,17 @@ msgstr ""
 "and EVA_UnitSold for vehicles\n"
 "SellSound=      ; Sound entry, default to [AudioVisual] -> SellSound\n"
 
-#: ../../New-or-Enhanced-Logics.md:1523
+#: ../../New-or-Enhanced-Logics.md:1564
 msgid ""
 "Vanilla game played vehicles' `SellSound` globally. This has been changed"
 " in consistency with buildings' `SellSound`."
 msgstr "原版游戏中出售载具的 `SellSound` 是全局的。这已改为与建筑出售的 `SellSound` 保持一致。"
 
-#: ../../New-or-Enhanced-Logics.md:1526
+#: ../../New-or-Enhanced-Logics.md:1567
 msgid "Disabling fallback to (Elite)Secondary weapon"
 msgstr "禁用副武器自动推算"
 
-#: ../../New-or-Enhanced-Logics.md:1528
+#: ../../New-or-Enhanced-Logics.md:1569
 msgid ""
 "It is now possible to disable the fallback to `(Elite)Secondary` weapon "
 "from `(Elite)Primary` weapon if it cannot fire at the chosen target by "
@@ -5949,35 +6044,35 @@ msgstr ""
 "武器。`NoSecondaryWeaponFallback.AllowAA` 控制对抛射体拥有 `AA` 且应对空中目标的情况。这不适用于总是选择"
 " `(Elite)Secondary` 武器的特殊情况，包括但不限于以下几种："
 
-#: ../../New-or-Enhanced-Logics.md:1529
+#: ../../New-or-Enhanced-Logics.md:1570
 msgid ""
 "`OpenTransportWeapon=1` on an unit firing from inside `OpenTopped=true` "
 "transport."
 msgstr "`OpenTransportWeapon=1` 的单位在一个 `OpenTopped=true` 的运输工具内开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1530
+#: ../../New-or-Enhanced-Logics.md:1571
 msgid ""
 "`NoAmmoWeapon=1` on an unit with `Ammo` value higher than 0 and current "
 "ammo count lower or  equal to `NoAmmoAmount`."
 msgstr "`NoAmmoWeapon=1` 的单位在 `Ammo` 大于 0 且当前弹药数量小于等于 `NoAmmoAmount`。"
 
-#: ../../New-or-Enhanced-Logics.md:1531
+#: ../../New-or-Enhanced-Logics.md:1572
 msgid ""
 "Deployed `IsSimpleDeployer=true` units with `DeployFireWeapon=1` set or "
 "omitted."
 msgstr "拥有 `DeployFireWeapon=1` 的 `IsSimpleDeployer=true` 单位处于部署状态。"
 
-#: ../../New-or-Enhanced-Logics.md:1532
+#: ../../New-or-Enhanced-Logics.md:1573
 msgid "`DrainWeapon=true` weapons against enemy `Drainable=yes` buildings."
 msgstr "`DrainWeapon=true` 的武器应对敌方 `Drainable=yes` 的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1533
+#: ../../New-or-Enhanced-Logics.md:1574
 msgid ""
 "Units with `IsLocomotor=true` set on `Warhead` of `(Elite)Primary` weapon"
 " against buildings."
 msgstr "单位使用一个 `Warhead` 拥有 `IsLocomotor=true` 设置的 `(Elite)Primary` 应对建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1534
+#: ../../New-or-Enhanced-Logics.md:1575
 msgid ""
 "Weapons with `ElectricAssault=true` set on `Warhead` against "
 "`Overpowerable=true` buildings belonging to owner or allies."
@@ -5985,33 +6080,50 @@ msgstr ""
 "对所有者或盟友的 `Overpowerable=true` 建筑使用 `Warhead` 拥有 `ElectricAssault=true` "
 "设置的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1535
+#: ../../New-or-Enhanced-Logics.md:1576
 msgid "`Overpowerable=true` buildings that are currently overpowered."
 msgstr "`Overpowerable=true` 的建筑当前处于过载状态。"
 
-#: ../../New-or-Enhanced-Logics.md:1536
+#: ../../New-or-Enhanced-Logics.md:1577
 msgid ""
 "Any system using `(Elite)WeaponX`, f.ex `Gunner=true` or "
 "`IsGattling=true` is also wholly exempt."
 msgstr "任何使用 `(Elite)WeaponX` 的系统也完全不受影响，例如 `Gunner=true` 或 `IsGattling=true`。"
 
-#: ../../New-or-Enhanced-Logics.md:1539
+#: ../../New-or-Enhanced-Logics.md:1578
 msgid ""
+"If `[CombatDamage] -> AllowWeaponSelectAgainstWalls` is set to true, "
+"`Secondary` will now be used against walls if `Primary` weapon Warhead "
+"has `Wall=false`, `Secondary` has `Wall=true` and the firer does not have"
+" `NoSecondaryWeaponFallback` set to true."
+msgstr ""
+"现在如果 `[CombatDamage] -> AllowWeaponSelectAgainstWalls` 设置为 true，假设 "
+"`Primary` 武器的弹头拥有 `Wall=false`，而 `Secondary` 武器拥有 `Wall=true` 且开火者没有将 "
+"`NoSecondaryWeaponFallback` 设为 true 那么 `Secondary` 将在应对墙时被使用。"
+
+#: ../../New-or-Enhanced-Logics.md:1581
+msgid ""
+"[CombatDamage]\n"
+"AllowWeaponSelectAgainstWalls=false      ; boolean\n"
+"\n"
 "[SOMETECHNO]                             ; TechnoType\n"
 "NoSecondaryWeaponFallback=false          ; boolean\n"
 "NoSecondaryWeaponFallback.AllowAA=false  ; boolean\n"
 msgstr ""
+"[CombatDamage]\n"
+"AllowWeaponSelectAgainstWalls=false      ; boolean\n"
+"\n"
 "[SOMETECHNO]                             ; TechnoType\n"
 "NoSecondaryWeaponFallback=false          ; boolean\n"
 "NoSecondaryWeaponFallback.AllowAA=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1545
+#: ../../New-or-Enhanced-Logics.md:1590
 msgid ""
 "Disguise logic additions (disguise-based movement speed, disguise "
 "blinking visibility)"
 msgstr "伪装逻辑增强"
 
-#: ../../New-or-Enhanced-Logics.md:1547
+#: ../../New-or-Enhanced-Logics.md:1592
 msgid ""
 "`DisguiseBlinkingVisibility` can be used to customize which players can "
 "see disguises blinking on units. This does not affect targeting but does "
@@ -6021,7 +6133,7 @@ msgstr ""
 "`DisguiseBlinkingVisibility` "
 "可用于自定义哪些玩家可以看到单位的伪装闪烁。这不影响目标选择，但会影响军衔的可见性——闪烁的伪装意味着始终可见原单位的军衔而不是伪装单位的。"
 
-#: ../../New-or-Enhanced-Logics.md:1548
+#: ../../New-or-Enhanced-Logics.md:1593
 msgid ""
 "Another thing to note is that in singleplayer missions, for purposes of "
 "the disguise blinking, disguised objects owned by any player-controlled "
@@ -6033,7 +6145,7 @@ msgstr ""
 "另一个需要注意的是在单人任务中，就伪装闪烁而言，任何玩家所控制的所属方所拥有的伪装单位即使与玩家所属方不是盟友视为当前玩家所有，这意味着玩家始终可以看到它们的伪装闪烁，除非"
 " `DisguiseBlinkingVisibility` 设置为 `none` 或 `enemies`。"
 
-#: ../../New-or-Enhanced-Logics.md:1549
+#: ../../New-or-Enhanced-Logics.md:1594
 msgid ""
 "`UseDisguiseMovementSpeed`, if set, makes disguised unit adjust its "
 "movement speed to match that of the disguise, if applicable. Note that "
@@ -6043,7 +6155,7 @@ msgstr ""
 "`UseDisguiseMovementSpeed` "
 "如果设置则在可行的情况下伪装单位将调整其移动速度以匹配伪装目标的速度。注意即使伪装被识破只要未被解除此设置就依旧生效。"
 
-#: ../../New-or-Enhanced-Logics.md:1552
+#: ../../New-or-Enhanced-Logics.md:1597
 msgid ""
 "[General]\n"
 "DisguiseBlinkingVisibility=owner  ; List of Affected House Enumeration "
@@ -6059,27 +6171,27 @@ msgstr ""
 "[SOMETECHNO]                      ; TechnoType\n"
 "UseDisguiseMovementSpeed=false    ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1560
+#: ../../New-or-Enhanced-Logics.md:1605
 msgid "Extended gattling rate down logic"
 msgstr "拓展的盖特掉档逻辑"
 
-#: ../../New-or-Enhanced-Logics.md:1562
+#: ../../New-or-Enhanced-Logics.md:1607
 msgid "Now you can customize some effects of `RateDown`."
 msgstr "现在你可以自定义 `RateDown` 的一些效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1563
+#: ../../New-or-Enhanced-Logics.md:1608
 msgid ""
 "`RateDown.Delay` controls the delay before using `RateDown` to reduce the"
 " gattling value."
 msgstr "`RateDown.Delay` 控制停火多少帧后才开始使用 `RateDown` 减少盖特计时器。"
 
-#: ../../New-or-Enhanced-Logics.md:1564
+#: ../../New-or-Enhanced-Logics.md:1609
 msgid ""
 "`RateDown.Reset` controls whether to reset the gattling value directly "
 "when the techno has no target or changes targets."
 msgstr "`RateDown.Reset` 控制当科技类型失去目标或更换目标时是否立即清空盖特计时器。"
 
-#: ../../New-or-Enhanced-Logics.md:1565
+#: ../../New-or-Enhanced-Logics.md:1610
 msgid ""
 "`RateDown.Cover.Value` replaces the original `RateDown` when techno's "
 "ammo is lower than `RateDown.Cover.AmmoBelow`."
@@ -6087,7 +6199,7 @@ msgstr ""
 "`RateDown.Cover.Value` 用于在科技类型的弹药低于 `RateDown.Cover.AmmoBelow` 时替代 "
 "`RateDown` 使用。"
 
-#: ../../New-or-Enhanced-Logics.md:1568
+#: ../../New-or-Enhanced-Logics.md:1613
 msgid ""
 "[SOMETECHNO]                  ; TechnoType, with IsGattling=yes\n"
 "RateDown.Delay=0              ; integer, game frames\n"
@@ -6101,11 +6213,11 @@ msgstr ""
 "RateDown.Cover.Value=0        ; integer\n"
 "RateDown.Cover.AmmoBelow=-2   ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1576
+#: ../../New-or-Enhanced-Logics.md:1621
 msgid "Firing offsets for specific Burst shots"
 msgstr "Burst 开火坐标"
 
-#: ../../New-or-Enhanced-Logics.md:1578
+#: ../../New-or-Enhanced-Logics.md:1623
 msgid ""
 "You can now specify separate firing offsets for each of the shots fired "
 "by weapon with `Burst` via using "
@@ -6123,14 +6235,14 @@ msgstr ""
 "开始的连发索引，这些值将按顺序解析，直到没有常规或精英武器的值为止，如果精英武器缺少值则默认使用常规武器的 "
 "FLH。如果特定连发索引缺少值，则使用基础标签（例如 `PrimaryFireFLH`）的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1579
+#: ../../New-or-Enhanced-Logics.md:1624
 msgid ""
 "Burst-index specific firing offsets are absolute firing offsets and the "
 "lateral shifting based on burst index that occurs with the base firing "
 "offsets is not applied."
 msgstr "特定连发索引使用的是不会根据连发索引而将 L 值镜像的绝对坐标。"
 
-#: ../../New-or-Enhanced-Logics.md:1582
+#: ../../New-or-Enhanced-Logics.md:1627
 msgid ""
 "[SOMETECHNO]    ; TechnoType Image\n"
 "FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to "
@@ -6140,11 +6252,11 @@ msgstr ""
 "FLHKEY.BurstN=  ; integer - Forward,Lateral,Height. FLHKey refers to "
 "weapon-specific FLH key name and N is zero-based burst shot index.\n"
 
-#: ../../New-or-Enhanced-Logics.md:1587
+#: ../../New-or-Enhanced-Logics.md:1632
 msgid "Forcing specific weapon against certain targets"
 msgstr "对特定目标使用特定武器"
 
-#: ../../New-or-Enhanced-Logics.md:1589
+#: ../../New-or-Enhanced-Logics.md:1634
 msgid ""
 "![image](_static/images/underwater-new-attack-tag.gif) *Naval underwater "
 "target behavior with `ForceWeapon.Naval.Decloaked` in [C&C: "
@@ -6154,7 +6266,7 @@ msgstr ""
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中使用 "
 "`ForceWeapon.Naval.Decloaked` 的海军对水下目标行为*"
 
-#: ../../New-or-Enhanced-Logics.md:1592
+#: ../../New-or-Enhanced-Logics.md:1637
 msgid ""
 "![image](_static/images/forceweapon_emp.gif) *Enemy behavior against EMP "
 "targets with `ForceWeapon.UnderEMP` in [C&C: "
@@ -6164,7 +6276,7 @@ msgstr ""
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中敌人使用 "
 "`ForceWeapon.UnderEMP` 攻击 EMP 状态目标的行为*"
 
-#: ../../New-or-Enhanced-Logics.md:1595
+#: ../../New-or-Enhanced-Logics.md:1640
 msgid ""
 "Can be used to override normal weapon selection logic to force specific "
 "weapons to use against certain targets. If multiple are set and target "
@@ -6172,7 +6284,7 @@ msgid ""
 "effect."
 msgstr "可用于覆盖正常的武器选择逻辑，以强制对特定目标使用特定武器。目标满足条件则按所列出规则的顺序使用第一个满足条件的规则。"
 
-#: ../../New-or-Enhanced-Logics.md:1596
+#: ../../New-or-Enhanced-Logics.md:1641
 msgid ""
 "`ForceWeapon.Naval.Decloaked` forces specified weapon to be used against "
 "uncloaked `Naval=yes` targets. Useful if your naval unit has one weapon "
@@ -6181,25 +6293,25 @@ msgstr ""
 "`ForceWeapon.Naval.Decloaked` 强制指定对未隐形（下潜）状态 `Naval=yes` "
 "的目标使用的武器。如果你的海军单位有一个武器仅用于水下目标另一个武器用于水面目标那么这个规则会很有用。"
 
-#: ../../New-or-Enhanced-Logics.md:1597
+#: ../../New-or-Enhanced-Logics.md:1642
 msgid ""
 "`ForceWeapon.Cloaked` forces specified weapon to be used against any "
 "cloaked targets."
 msgstr "`ForceWeapon.Cloaked` 强制指定对隐形（下潜）状态目标使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1598
+#: ../../New-or-Enhanced-Logics.md:1643
 msgid ""
 "`ForceWeapon.Disguised` forces specified weapon to be used against any "
 "disguised targets."
 msgstr "`ForceWeapon.Disguised` 强制指定针对伪装目标所使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1599
+#: ../../New-or-Enhanced-Logics.md:1644
 msgid ""
 "`ForceWeapon.UnderEMP` forces specified weapon to be used if the target "
 "is under EMP effect."
 msgstr "`ForceWeapon.UnderEMP` 强制指定对与被 EMP 瘫痪了的目标所使用的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1600
+#: ../../New-or-Enhanced-Logics.md:1645
 msgid ""
 "`ForceWeapon.InRange` forces specified a list of weapons to be used once "
 "the target is within their `Range`. If `ForceWeapon.InRange.TechnoOnly` "
@@ -6214,7 +6326,7 @@ msgstr ""
 "则仅在目标为单位时才能像其他强制武器效果那样生效，否则在攻击空地时也会生效。该单位会按列表顺序选取首个符合条件的武器。在未设置 "
 "`ForceAAWeapon.InRange` 的情况下这同时用于地面和空中目标。"
 
-#: ../../New-or-Enhanced-Logics.md:1601
+#: ../../New-or-Enhanced-Logics.md:1646
 msgid ""
 "`ForceAAWeapon.InRange` does the same thing but only for air target. "
 "Taking priority to `ForceWeapon.InRange`, which means that it can only be"
@@ -6223,7 +6335,7 @@ msgstr ""
 "`ForceAAWeapon.InRange` 是 `ForceWeapon.InRange` 的对空版本。当两个参数同时存在时 "
 "`ForceWeapon.InRange` 仅用于对地。"
 
-#: ../../New-or-Enhanced-Logics.md:1602
+#: ../../New-or-Enhanced-Logics.md:1647
 msgid ""
 "`Force(AA)Weapon.InRange.Overrides` overrides the range when decides "
 "which weapon to use. Value from position matching the position from "
@@ -6234,7 +6346,7 @@ msgstr ""
 "`Force(AA)Weapon.InRange` 中的武器序号一一对应，如果一个武器的对应的值小于 0 或不存在那么使用武器自身的 "
 "`Range`。"
 
-#: ../../New-or-Enhanced-Logics.md:1603
+#: ../../New-or-Enhanced-Logics.md:1648
 msgid ""
 "If `Force(AA)Weapon.InRange.ApplyRangeModifiers` is set to true, any "
 "applicable weapon range modifiers from the firer are applied to the "
@@ -6243,11 +6355,11 @@ msgstr ""
 "如果 `Force(AA)Weapon.InRange.ApplyRangeModifiers` 设为 true "
 "则任何来自开火者的武器射程加成也将参与射程判定。"
 
-#: ../../New-or-Enhanced-Logics.md:1604
+#: ../../New-or-Enhanced-Logics.md:1649
 msgid "A series of tags can force specified weapons based on the target's type."
 msgstr "一系列根据目标类型强制使用特定武器的标签："
 
-#: ../../New-or-Enhanced-Logics.md:1605
+#: ../../New-or-Enhanced-Logics.md:1650
 msgid ""
 "`ForceWeapon.Naval.Units` forces specified weapon to be used against "
 "`Naval=yes` units. Taking priority to `ForceWeapon.Units`."
@@ -6255,7 +6367,7 @@ msgstr ""
 "`ForceWeapon.Naval.Units` 强制指定对 `Naval=yes` 的单位所使用的武器。优先级高于 "
 "`ForceWeapon.Units`。"
 
-#: ../../New-or-Enhanced-Logics.md:1606
+#: ../../New-or-Enhanced-Logics.md:1651
 msgid ""
 "If `ForceWeapon.Defenses` is enabled, it'll be used if the target is a "
 "building with `BuildCat=Combat`. Otherwise it'll follow "
@@ -6264,7 +6376,7 @@ msgstr ""
 "`ForceWeapon.Defenses` 是 `ForceWeapon.Buildings` 针对 `BuildCat=Combat` "
 "类建筑目标的分离设置，不启用即沿用后者。"
 
-#: ../../New-or-Enhanced-Logics.md:1607
+#: ../../New-or-Enhanced-Logics.md:1652
 msgid ""
 "`ForceWeapon.Infantry/Units/Aircraft` can be applied to both ground and "
 "air target if `ForceAAWeapon.Infantry/Units/Aircraft` is not set."
@@ -6272,7 +6384,7 @@ msgstr ""
 "`ForceWeapon.Infantry/Units/Aircraft` 在未设置 "
 "`ForceAAWeapon.Infantry/Units/Aircraft` 时同时控制对空对地。"
 
-#: ../../New-or-Enhanced-Logics.md:1608
+#: ../../New-or-Enhanced-Logics.md:1653
 msgid ""
 "`ForceAAWeapon.Infantry/Units/Aircraft` do the same things but only for "
 "air target. Taking priority to "
@@ -6282,7 +6394,7 @@ msgstr ""
 "`ForceAAWeapon.Infantry/Units/Aircraft` 是 "
 "`ForceWeapon.Infantry/Units/Aircraft` 的对空版本。当两个参数同时存在时后者仅用于对地。"
 
-#: ../../New-or-Enhanced-Logics.md:1611
+#: ../../New-or-Enhanced-Logics.md:1656
 msgid ""
 "[SOMETECHNO]                                    ; TechnoType\n"
 "ForceWeapon.Naval.Decloaked=-1                  ; integer, -1 to disable\n"
@@ -6332,7 +6444,7 @@ msgstr ""
 "ForceAAWeapon.Units=-1                          ; integer, -1 to disable\n"
 "ForceAAWeapon.Aircraft=-1                       ; integer, -1 to disable\n"
 
-#: ../../New-or-Enhanced-Logics.md:1636
+#: ../../New-or-Enhanced-Logics.md:1681
 msgid ""
 "Specifically, if a position has `Force(AA)Weapon.InRange` set to -1 and "
 "`Force(AA)Weapon.InRange.Overrides` set to a positive value, it'll use "
@@ -6341,17 +6453,17 @@ msgstr ""
 "特别说明，如果某个位置的 `Force(AA)Weapon.InRange` 设为 -1 而 "
 "`Force(AA)Weapon.InRange.Overrides` 为正值，那么在满足条件时使用默认的武器选取规则。"
 
-#: ../../New-or-Enhanced-Logics.md:1639
+#: ../../New-or-Enhanced-Logics.md:1684
 msgid "Fast access vehicle/structure"
 msgstr "快速进入载具／建筑"
 
-#: ../../New-or-Enhanced-Logics.md:1641
+#: ../../New-or-Enhanced-Logics.md:1686
 msgid ""
 "Now you can let infantry or vehicle passengers quickly enter or leave the"
 " transport vehicles/structures without queuing."
 msgstr "现在你可以让步兵或载具类载员无需排队地快速进入或离开运输载具／建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1644
+#: ../../New-or-Enhanced-Logics.md:1689
 msgid ""
 "[General]\n"
 "NoQueueUpToEnter=false          ; boolean\n"
@@ -6377,7 +6489,7 @@ msgstr ""
 "NoQueueUpToUnload=              ; boolean, default to [General] -> "
 "NoQueueUpToUnload(.Buildings)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1657
+#: ../../New-or-Enhanced-Logics.md:1702
 msgid ""
 "Note that this logic is used for "
 "[Passenger](https://modenc.renegadeprojects.com/Passengers) logic, which "
@@ -6387,18 +6499,18 @@ msgstr ""
 "注意该逻辑用于 [乘客](https://modenc.renegadeprojects.com/Passengers) 逻辑，这与 "
 "[驻军](https://modenc.renegadeprojects.com/Occupier) 是两个不同的东西。"
 
-#: ../../New-or-Enhanced-Logics.md:1660
+#: ../../New-or-Enhanced-Logics.md:1705
 msgid "Initial spawns number"
 msgstr "初始子机数量"
 
-#: ../../New-or-Enhanced-Logics.md:1661
+#: ../../New-or-Enhanced-Logics.md:1706
 msgid ""
 "It is now possible to set the initial amount of spawnees for a spawner, "
 "instead of always being filled. Won't work if it's larger than "
 "`SpawnsNumber`."
 msgstr "现在可以设置子机发射器的初始子机数量，而不再总是初始满载。如果初始数量大于 `SpawnsNumber` 则无效。"
 
-#: ../../New-or-Enhanced-Logics.md:1664
+#: ../../New-or-Enhanced-Logics.md:1709
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialSpawnsNumber=      ; integer\n"
@@ -6406,11 +6518,11 @@ msgstr ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialSpawnsNumber=      ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1669
+#: ../../New-or-Enhanced-Logics.md:1714
 msgid "Initial strength for TechnoTypes and cloned infantry"
 msgstr "科技类型与克隆步兵的初始血量"
 
-#: ../../New-or-Enhanced-Logics.md:1671
+#: ../../New-or-Enhanced-Logics.md:1716
 msgid ""
 "![image](_static/images/initialstrength.cloning-01.png) *Initial strength"
 " for cloned infantry example in [C&C: "
@@ -6419,13 +6531,13 @@ msgstr ""
 "![image](_static/images/initialstrength.cloning-01.png) *[C&C: "
 "Reloaded](https://www.moddb.com/mods/cncreloaded) 中克隆步兵的初始血量示例*"
 
-#: ../../New-or-Enhanced-Logics.md:1674
+#: ../../New-or-Enhanced-Logics.md:1719
 msgid ""
 "`InitialStrength` can be used to set how many hitpoints a TechnoType "
 "starts with."
 msgstr "`InitialStrength` 可用于设置科技类型的初始血量。"
 
-#: ../../New-or-Enhanced-Logics.md:1675
+#: ../../New-or-Enhanced-Logics.md:1720
 msgid ""
 "`InitialStrength.Cloning` can be used to specify a percentage of "
 "hitpoints (single value or a range from which a random value is picked) "
@@ -6434,7 +6546,7 @@ msgstr ""
 "`InitialStrength.Cloning` 可以用于指定克隆步兵由 `Cloning=true` "
 "建筑创建时的初始血量百分比（单个值或从其中随机选取的一对值）。"
 
-#: ../../New-or-Enhanced-Logics.md:1678
+#: ../../New-or-Enhanced-Logics.md:1723
 msgid ""
 "[SOMETECHNO]              ; TechnoType\n"
 "InitialStrength=          ; integer\n"
@@ -6450,7 +6562,7 @@ msgstr ""
 "InitialStrength.Cloning=  ; floating point value - single or comma-sep. "
 "range (percentages)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1687
+#: ../../New-or-Enhanced-Logics.md:1732
 msgid ""
 "Both `InitialStrength` and `InitialStrength.Cloning` never surpass the "
 "type's `Strength`, even if your values are bigger than it."
@@ -6458,67 +6570,67 @@ msgstr ""
 "`InitialStrength` 和 `InitialStrength.Cloning` 都不会超过单位的 "
 "`Strength`，即使你设置了一个比它更大的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1690
+#: ../../New-or-Enhanced-Logics.md:1735
 msgid "Kill Object Automatically"
 msgstr "自毁"
 
-#: ../../New-or-Enhanced-Logics.md:1692
+#: ../../New-or-Enhanced-Logics.md:1737
 msgid ""
 "Objects can be destroyed automatically if *any* of these conditions is "
 "met:"
 msgstr "如果满足以下 **任何** 条件对象将会自毁："
 
-#: ../../New-or-Enhanced-Logics.md:1693
+#: ../../New-or-Enhanced-Logics.md:1738
 msgid "`OnAmmoDepletion`: The object will die if the remaining ammo reaches 0."
 msgstr "`OnAmmoDepletion`：如果剩余弹药达到 0 则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1694
+#: ../../New-or-Enhanced-Logics.md:1739
 msgid "`AfterDelay`: The object will die if the countdown (in frames) reaches 0."
 msgstr "`AfterDelay`：如果倒计时（以帧为单位）达到 0 则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1695
+#: ../../New-or-Enhanced-Logics.md:1740
 msgid ""
 "`TechnosExist` / `TechnosDontExist`: The object will die if TechnoTypes "
 "exist or do not exist, respectively."
 msgstr "`TechnosExist`／`TechnosDontExist`：如果科技类型分别存在或不存在则对象死亡。"
 
-#: ../../New-or-Enhanced-Logics.md:1696
+#: ../../New-or-Enhanced-Logics.md:1741
 msgid ""
 "`Technos(Dont)Exist.Any` controls whether or not a single listed "
 "TechnoType is enough to satisfy the requirement or if all are required."
 msgstr "`Technos(Dont)Exist.Any` 控制需要列出的单个科技类型还是所有科技类型来满足条件。"
 
-#: ../../New-or-Enhanced-Logics.md:1697
+#: ../../New-or-Enhanced-Logics.md:1742
 msgid ""
 "`Technos(Dont)Exist.AllowLimboed` controls whether or not limboed "
 "TechnoTypes (f.ex those in transports) are counted."
 msgstr "`Technos(Dont)Exist.AllowLimboed` 控制是否计入虚拟的科技类型（例如在运输工具中的那些）。"
 
-#: ../../New-or-Enhanced-Logics.md:1698
+#: ../../New-or-Enhanced-Logics.md:1743
 msgid "`Technos(Dont)Exist.Houses` controls which houses are checked."
 msgstr "`Technos(Dont)Exist.Houses` 控制检查哪些所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:1700
+#: ../../New-or-Enhanced-Logics.md:1745
 msgid "The auto-death behavior can be chosen from the following:"
 msgstr "自毁行为有以下选择："
 
-#: ../../New-or-Enhanced-Logics.md:1701
+#: ../../New-or-Enhanced-Logics.md:1746
 msgid "`kill`: The object will be destroyed normally."
 msgstr "`kill`：对象将正常摧毁。"
 
-#: ../../New-or-Enhanced-Logics.md:1702
+#: ../../New-or-Enhanced-Logics.md:1747
 msgid ""
 "`vanish`: The object will be directly removed from the game peacefully "
 "instead of actually getting killed."
 msgstr "`vanish`：对象将被直接从游戏中静默移除而不是真正击杀。"
 
-#: ../../New-or-Enhanced-Logics.md:1703
+#: ../../New-or-Enhanced-Logics.md:1748
 msgid ""
 "`sell`: If the object is a **building** with buildup, it will be sold "
 "instead of destroyed."
 msgstr "`sell`：如果对象是拥有建造动画的 **建筑**，它将被出售而不是被摧毁。"
 
-#: ../../New-or-Enhanced-Logics.md:1704
+#: ../../New-or-Enhanced-Logics.md:1749
 msgid ""
 "If this option is not set, the self-destruction logic will not be "
 "enabled. `AutoDeath.VanishAnimation` can be set to animation to play at "
@@ -6528,7 +6640,7 @@ msgstr ""
 "如果未设置此项那么自毁逻辑将不会启用。如果选择 `vanish` 行为，那么可以使用 `AutoDeath.VanishAnimation` "
 "设置自毁时播放的动画。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:1705
+#: ../../New-or-Enhanced-Logics.md:1750
 msgid ""
 "This logic also supports buildings delivered by "
 "[LimboDelivery](#limbodelivery). However in this case, all "
@@ -6538,7 +6650,7 @@ msgstr ""
 "此逻辑还支持通过 [虚拟投放](#limbodelivery) 提供的建筑。不过这种情况下所有 `AutoDeath.Behavior` "
 "值都将只是使建筑简单地移除。"
 
-#: ../../New-or-Enhanced-Logics.md:1708
+#: ../../New-or-Enhanced-Logics.md:1753
 msgid ""
 "[SOMETECHNO]                                   ; TechnoType\n"
 "AutoDeath.Behavior=                            ; enumeration (kill | "
@@ -6574,18 +6686,18 @@ msgstr ""
 "AutoDeath.TechnosExist.Houses=owner            ; Affected House "
 "Enumeration (none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1725
+#: ../../New-or-Enhanced-Logics.md:1770
 msgid ""
 "Please notice that if the object is a unit which carries passengers, they"
 " will not be released even with the `kill` option **if you are not using "
 "Ares 3.0+**."
 msgstr "请注意 **如果你没有使用 Ares 3.0+** 那么对于携带载员的单位即使使用 `kill` 行为载员也不会被释放。"
 
-#: ../../New-or-Enhanced-Logics.md:1728
+#: ../../New-or-Enhanced-Logics.md:1773
 msgid "Mind Control enhancement"
 msgstr "心灵控制增强"
 
-#: ../../New-or-Enhanced-Logics.md:1730
+#: ../../New-or-Enhanced-Logics.md:1775
 msgid ""
 "![image](_static/images/mindcontrol-max-range-01.gif) *Mind Control Range"
 " Limit used in [Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-"
@@ -6598,26 +6710,26 @@ msgstr ""
 "![image](_static/images/mindcontrol-multiple-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的多重心控单位自动释放第一个受害者*"
 
-#: ../../New-or-Enhanced-Logics.md:1735
+#: ../../New-or-Enhanced-Logics.md:1780
 msgid ""
 "Mind controllers now can have the upper limit of the control distance. "
 "Tag values greater than 0 will activate this feature."
 msgstr "心灵控制者现在可以设置控制距离的上限。标签值大于 0 将激活此功能。"
 
-#: ../../New-or-Enhanced-Logics.md:1736
+#: ../../New-or-Enhanced-Logics.md:1781
 msgid ""
 "Mind controllers now can decide which house can see the link drawn "
 "between itself and the controlled units."
 msgstr "心灵控制者现在可以设置哪些所属方可以看到它与被心灵控制单位之间的连线。"
 
-#: ../../New-or-Enhanced-Logics.md:1737
+#: ../../New-or-Enhanced-Logics.md:1782
 msgid ""
 "Mind controllers with multiple controlling slots can now release the "
 "first controlled unit when they have reached the control limit and are "
 "ordered to control a new target."
 msgstr "多重心控单位现在可以达到控制上限而又要控制一个新目标时释放第一个被控制的单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1740
+#: ../../New-or-Enhanced-Logics.md:1785
 msgid ""
 "[SOMETECHNO]                          ; TechnoType\n"
 "MindControlRangeLimit=-1.0            ; floating point value\n"
@@ -6631,11 +6743,11 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "MultiMindControl.ReleaseVictim=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1747
+#: ../../New-or-Enhanced-Logics.md:1792
 msgid "Multi Weapon"
 msgstr "多武器"
 
-#: ../../New-or-Enhanced-Logics.md:1749
+#: ../../New-or-Enhanced-Logics.md:1794
 msgid ""
 "![image](_static/images/multiweapons.gif) *Multi Weapon used to release "
 "different weapons against different targets in **Zero Boundary** by "
@@ -6645,7 +6757,7 @@ msgstr ""
 "*@[暴风硫](https://space.bilibili.com/11638715/lists/5358986) 在 **零点界限** "
 "中使用多武器逻辑来实现对不同目标使用不同武器*"
 
-#: ../../New-or-Enhanced-Logics.md:1752
+#: ../../New-or-Enhanced-Logics.md:1797
 msgid ""
 "You can now use `WeaponX` to enable more than 2 weapons for a TechnoType "
 "without hardcoded `Gunner=yes`, `IsGattling=yes` or `IsChargeTurret=yes` "
@@ -6654,13 +6766,13 @@ msgstr ""
 "现在你可以使用 `WeaponX` 来为一个单位启用 2 种以上的武器而无需原先硬编码的 "
 "`Gunner=yes`、`IsGattling=yes` 或 `IsChargeTurret=yes` 这些启用语句。"
 
-#: ../../New-or-Enhanced-Logics.md:1753
+#: ../../New-or-Enhanced-Logics.md:1798
 msgid ""
 "Set `MultiWeapon=yes` to enable this feature, be careful not to forget "
 "`WeaponCount`."
 msgstr "设置 `MultiWeapon=yes` 来启用此功能，注意别忘了设置 `WeaponCount`。"
 
-#: ../../New-or-Enhanced-Logics.md:1754
+#: ../../New-or-Enhanced-Logics.md:1799
 msgid ""
 "`MultiWeapon.IsSecondary` specifies which weapons will be considered as "
 "`Secondary` when selecting weapons or triggering infantry's "
@@ -6670,20 +6782,20 @@ msgstr ""
 "`MultiWeapon.IsSecondary` 指定在选择武器或触发步兵 `SecondaryFire` 时哪些武器被视为 "
 "`Secondary`，若不设置则使用 `Weapon1`。"
 
-#: ../../New-or-Enhanced-Logics.md:1755
+#: ../../New-or-Enhanced-Logics.md:1800
 msgid ""
 "`MultiWeapon.SelectCount` determines the number of weapons that can be "
 "selected by default weapon selection logic. Notice that higher number is "
 "bad for performance."
 msgstr "`MultiWeapon.SelectCount` 决定默认武器选用逻辑下可以被考虑使用的武器数量。设置过高会导致性能问题。"
 
-#: ../../New-or-Enhanced-Logics.md:1756
+#: ../../New-or-Enhanced-Logics.md:1801
 msgid ""
 "If the number is smaller than the total amount of weapons, the ones with "
 "smaller indices will be picked."
 msgstr "如果该值小于武器数量那么将会优先选择索引序号更小的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1757
+#: ../../New-or-Enhanced-Logics.md:1802
 msgid ""
 "Other weapons can still be used for logic that specify a weapon index, "
 "such as [ForceWeapon](#forcing-specific-weapon-against-certain-targets)."
@@ -6691,7 +6803,7 @@ msgstr ""
 "其他武器仍可通过 [对特定目标使用特定武器](#forcing-specific-weapon-against-certain-targets) "
 "等指定武器索引序号的逻辑来使用。"
 
-#: ../../New-or-Enhanced-Logics.md:1760
+#: ../../New-or-Enhanced-Logics.md:1805
 msgid ""
 "[SOMETECHNO]                    ; TechnoType\n"
 "MultiWeapon=false               ; boolean\n"
@@ -6703,21 +6815,21 @@ msgstr ""
 "MultiWeapon.IsSecondary=        ; List of integers\n"
 "MultiWeapon.SelectCount=2       ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1767
+#: ../../New-or-Enhanced-Logics.md:1812
 msgid "Multi VoiceAttack"
 msgstr "多武器的攻击指令音效"
 
-#: ../../New-or-Enhanced-Logics.md:1769
+#: ../../New-or-Enhanced-Logics.md:1814
 msgid "Units can customize the attack voice that plays when using more weapons."
 msgstr "单位可以在使用更多武器时自定义各武器下达攻击指令时的音效。"
 
-#: ../../New-or-Enhanced-Logics.md:1770
+#: ../../New-or-Enhanced-Logics.md:1815
 msgid ""
 "If you need to assign an attack-voice to `Weapon1`, simply set "
 "`VoiceWeapon1Attack`. The same applies to other weapons."
 msgstr "如果你需要为 `Weapon1` 分配攻击音效那么直接设置 `VoiceWeapon1Attack` 即可。其他武器同理。"
 
-#: ../../New-or-Enhanced-Logics.md:1771
+#: ../../New-or-Enhanced-Logics.md:1816
 msgid ""
 "`VoiceEliteWeaponNAttack` can also be used to specify attack voices for "
 "`EliteWeaponN`. The default is `VoiceWeaponNAttack`."
@@ -6725,7 +6837,7 @@ msgstr ""
 "也可使用 `VoiceEliteWeaponNAttack` 指定用于 `EliteWeaponN` 的音效。默认使用 "
 "`VoiceWeaponNAttack`。"
 
-#: ../../New-or-Enhanced-Logics.md:1774
+#: ../../New-or-Enhanced-Logics.md:1819
 msgid ""
 "[SOMETECHNO]                ; TechnoType\n"
 "VoiceWeaponNAttack=         ; Sound entry\n"
@@ -6735,23 +6847,23 @@ msgstr ""
 "VoiceWeaponNAttack=         ; Sound entry\n"
 "VoiceEliteWeaponNAttack=    ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1780
+#: ../../New-or-Enhanced-Logics.md:1825
 msgid "No Manual Move"
 msgstr "禁止手动移动"
 
-#: ../../New-or-Enhanced-Logics.md:1782
+#: ../../New-or-Enhanced-Logics.md:1827
 msgid ""
 "You can now specify whether a TechnoType is unable to receive move "
 "command."
 msgstr "现在你可以指定一个科技类型是否无法接收移动指令。"
 
-#: ../../New-or-Enhanced-Logics.md:1783
+#: ../../New-or-Enhanced-Logics.md:1828
 msgid ""
 "Set this to `true` on a building with `UndeploysInto` set could prevent "
 "it from undeploying when setting the rally point."
 msgstr "在一个拥有 `UndeploysInto` 的建筑上将此设为 true 可以阻止其在设置集结点时反部署。"
 
-#: ../../New-or-Enhanced-Logics.md:1786
+#: ../../New-or-Enhanced-Logics.md:1831
 msgid ""
 "[SOMETECHNO]        ; TechnoType\n"
 "NoManualMove=false  ; boolean\n"
@@ -6759,18 +6871,18 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "NoManualMove=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1792
+#: ../../New-or-Enhanced-Logics.md:1837
 msgid ""
 "Note that you can still undeploy the building by using a "
 "`BuildingUndeploy=true` warhead or by setting a rally point and selling "
 "it."
 msgstr "注意你仍可使用一个 `BuildingUndeploy=true` 的弹头或设置集结点后出售建筑来解除部署。"
 
-#: ../../New-or-Enhanced-Logics.md:1795
+#: ../../New-or-Enhanced-Logics.md:1840
 msgid "No rearm and reload in EMP or temporal"
 msgstr "EMP 或超时空停止 CD"
 
-#: ../../New-or-Enhanced-Logics.md:1797
+#: ../../New-or-Enhanced-Logics.md:1842
 msgid ""
 "Now you can make technos unable to rearm and reload when they are in EMP "
 "or locked by a temporal weapon. Defaults to values in `[General]`. This "
@@ -6779,7 +6891,7 @@ msgstr ""
 "现在你可以让科技类型在 EMP 或被超时空武器冻结时武器 ROF 与弹药 Reload 也同步停止。默认值取自 "
 "`[General]`。这对机场战机的重新装填无效。"
 
-#: ../../New-or-Enhanced-Logics.md:1800
+#: ../../New-or-Enhanced-Logics.md:1845
 msgid ""
 "[General]\n"
 "NoRearm.UnderEMP=false   ; boolean\n"
@@ -6805,17 +6917,17 @@ msgstr ""
 "NoReload.UnderEMP=       ; boolean\n"
 "NoReload.Temporal=       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1814
+#: ../../New-or-Enhanced-Logics.md:1859
 msgid "Overload characteristic dehardcoded"
 msgstr "自定义脑车过载"
 
-#: ../../New-or-Enhanced-Logics.md:1816
+#: ../../New-or-Enhanced-Logics.md:1861
 msgid ""
 "It is now possible to customize `Overload` behaviors for a TechnoType "
 "with `InfiniteMindControl=yes` weapon."
 msgstr "现在可以为一个使用 `InfiniteMindControl=yes` 武器的单位自定义其过载相关特性。"
 
-#: ../../New-or-Enhanced-Logics.md:1819
+#: ../../New-or-Enhanced-Logics.md:1864
 msgid ""
 "\n"
 "[SOMETECHNO]                  ; TechnoType\n"
@@ -6845,11 +6957,11 @@ msgstr ""
 "[CombatDamage] -> DefaultSparkSystem\n"
 "Overload.ParticleSysCount=5   ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1830
+#: ../../New-or-Enhanced-Logics.md:1875
 msgid "Promoted Spawns"
 msgstr "子机升级"
 
-#: ../../New-or-Enhanced-Logics.md:1832
+#: ../../New-or-Enhanced-Logics.md:1877
 msgid ""
 "![image](_static/images/promotedspawns-01.gif) *Promoted Spawns in "
 "[Fantasy ADVENTURE](https://www.moddb.com/mods/fantasy-adventure)*"
@@ -6857,11 +6969,11 @@ msgstr ""
 "![image](_static/images/promotedspawns-01.gif) "
 "*[幻想奇遇](https://www.moddb.com/mods/fantasy-adventure) 中的子机同步升级*"
 
-#: ../../New-or-Enhanced-Logics.md:1835
+#: ../../New-or-Enhanced-Logics.md:1880
 msgid "The spawned units will promote as their owner's veterancy."
 msgstr "生成的单位可以根据其所有者的等级进行同步升级。"
 
-#: ../../New-or-Enhanced-Logics.md:1838
+#: ../../New-or-Enhanced-Logics.md:1883
 msgid ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "Promote.IncludeSpawns=false  ; boolean\n"
@@ -6869,15 +6981,15 @@ msgstr ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "Promote.IncludeSpawns=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1843
+#: ../../New-or-Enhanced-Logics.md:1888
 msgid "Promotion animation"
 msgstr "升级动画"
 
-#: ../../New-or-Enhanced-Logics.md:1845
+#: ../../New-or-Enhanced-Logics.md:1890
 msgid "You can now specify an animation on the unit or structure promotion."
 msgstr "现在你可以在单位或建筑升级时播放指定动画。"
 
-#: ../../New-or-Enhanced-Logics.md:1846
+#: ../../New-or-Enhanced-Logics.md:1891
 msgid ""
 "`Promote.VeteranAnimation` is used when unit or structure is promoted to "
 "veteran. If this is set for a TechnoType, it'll override the global "
@@ -6887,7 +6999,7 @@ msgstr ""
 "`Promote.VeteranAnimation` 用于单位或建筑升级为老兵时。若为单位设置本句则覆盖全局 `[AudioVisual]` "
 "中的设置。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:1847
+#: ../../New-or-Enhanced-Logics.md:1892
 msgid ""
 "`Promote.EliteAnimation` is used when unit or structure is promoted to "
 "elite. If this is set for a TechnoType, it'll override the global setting"
@@ -6897,13 +7009,13 @@ msgstr ""
 "`Promote.EliteAnimation` 用于单位或建筑升级为精英时。若为单位设置本句则覆盖全局 `[AudioVisual]` "
 "中的设置。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:1848
+#: ../../New-or-Enhanced-Logics.md:1893
 msgid ""
 "If `Promote.EliteAnimation` is not defined, `Promote.VeteranAnimation` "
 "will play instead when unit or structure is promoted to elite."
 msgstr "如果未定义 `Promote.EliteAnimation` 则使用 `Promote.VeteranAnimation`。"
 
-#: ../../New-or-Enhanced-Logics.md:1851
+#: ../../New-or-Enhanced-Logics.md:1896
 msgid ""
 "[AudioVisual]\n"
 "Promote.VeteranAnimation=         ; List of AnimationTypes\n"
@@ -6925,11 +7037,11 @@ msgstr ""
 "Promote.EliteAnimation=           ; List of AnimationTypes, default to "
 "Promote.EliteAnimation in [AudioVisual]\n"
 
-#: ../../New-or-Enhanced-Logics.md:1861
+#: ../../New-or-Enhanced-Logics.md:1906
 msgid "Raise alert when technos are taking damage"
 msgstr "单位受伤警报"
 
-#: ../../New-or-Enhanced-Logics.md:1863
+#: ../../New-or-Enhanced-Logics.md:1908
 msgid ""
 "In Vanilla, non-building technos will not generate radar events or EVAs "
 "when attacked, so players can hardly notice them until they are "
@@ -6940,17 +7052,17 @@ msgstr ""
 "在原版，非建筑科技类型在收到攻击时不会生成雷达事件或 EVA "
 "播报，因此它们很难在被摧毁前被玩家注意到。现在当你的单位受到攻击时可以收到雷达事件（以及可选的声音效果），以便及时应战。"
 
-#: ../../New-or-Enhanced-Logics.md:1864
+#: ../../New-or-Enhanced-Logics.md:1909
 msgid ""
 "`[AudioVisual] -> CombatAlert` is a global switch, set it to `true` to "
 "enable the entire logic."
 msgstr "`[AudioVisual] -> CombatAlert` 是一个全局开关，将其设置为 `true` 以启用整个逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1865
+#: ../../New-or-Enhanced-Logics.md:1910
 msgid "These flags controlls when to trigger a combat alert."
 msgstr "这些标签控制什么时候触发战斗警报。"
 
-#: ../../New-or-Enhanced-Logics.md:1866
+#: ../../New-or-Enhanced-Logics.md:1911
 msgid ""
 "You can disable this logic on specific techno by setting `[TechnoType] ->"
 " CombatAlert` to `false`, which default to `[AudioVisual] -> "
@@ -6961,7 +7073,7 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.Default`。如果 `CombatAlert.Default` 也为空，则默认为对"
 " `Insignificant=yes` 或 `Spawned=yes` 的科技类型禁用。"
 
-#: ../../New-or-Enhanced-Logics.md:1867
+#: ../../New-or-Enhanced-Logics.md:1912
 msgid ""
 "`[AudioVisual] -> CombatAlert.IgnoreBuilding` will turn the logic off on "
 "buildings. You can override it for specific building by setting "
@@ -6972,13 +7084,13 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.NotBuilding` 为 `true` "
 "来为特定建筑覆盖设置。你可能希望将其用于载具性质的建筑。"
 
-#: ../../New-or-Enhanced-Logics.md:1868
+#: ../../New-or-Enhanced-Logics.md:1913
 msgid ""
 "`[AudioVisual] -> CombatAlert.SuppressIfInScreen` decides whether to "
 "disable the logic for the units in the current screen."
 msgstr "`[AudioVisual] -> CombatAlert.SuppressIfInScreen` 决定是否为当前屏幕中的单位禁用此逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1869
+#: ../../New-or-Enhanced-Logics.md:1914
 msgid ""
 "`[AudioVisual] -> CombatAlert.Interval` decides the time interval (in "
 "frames) between alerts, to prevent the alert from being anonying. It is "
@@ -6987,13 +7099,13 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.Interval` 决定警报之间的间隔（以帧为单位），以防止警报过于频繁。默认为 "
 "150 帧。"
 
-#: ../../New-or-Enhanced-Logics.md:1870
+#: ../../New-or-Enhanced-Logics.md:1915
 msgid ""
 "`[AudioVisual] -> CombatAlert.SuppressIfAllyDamage` decides whether to "
 "disable the logic for the damage from allys."
 msgstr "`[AudioVisual] -> CombatAlert.SuppressIfAllyDamage` 决定是否为盟友造成的伤害禁用此逻辑。"
 
-#: ../../New-or-Enhanced-Logics.md:1871
+#: ../../New-or-Enhanced-Logics.md:1916
 msgid ""
 "Technos hitted by a warhead with `[WarheadType] -> CombatAlert.Suppress` "
 "setted to `true` will not raise a radar event or EVA. This flag is "
@@ -7004,11 +7116,11 @@ msgstr ""
 "的弹头击中将不会触发雷达事件或 EVA。此标签默认为 Ares 标签 `[WarheadType] -> Malicious` 的相反值和 "
 "`[WarheadType] -> Nonprovocative` 的值。"
 
-#: ../../New-or-Enhanced-Logics.md:1872
+#: ../../New-or-Enhanced-Logics.md:1917
 msgid "And the following flags controlls the effect of a combat alert."
 msgstr "以下标签控制战斗警报的效果。"
 
-#: ../../New-or-Enhanced-Logics.md:1873
+#: ../../New-or-Enhanced-Logics.md:1918
 msgid ""
 "`[AudioVisual] -> CombatAlert.MakeAVoice` decides whether to play some "
 "sound effect with the combat alert. Set it to `true` will enable the "
@@ -7017,7 +7129,7 @@ msgstr ""
 "`[AudioVisual] -> CombatAlert.MakeAVoice` 决定是否与战斗警报一起播放一些音效。将其设为 true "
 "以启用以下标签，否则它们将被忽略。"
 
-#: ../../New-or-Enhanced-Logics.md:1874
+#: ../../New-or-Enhanced-Logics.md:1919
 msgid ""
 "`[TechnoType] -> CombatAlert.UseFeedbackVoice` decides whether to use the"
 " sound defined by `VoiceFeedback`. Default to `[AudioVisual] -> "
@@ -7026,7 +7138,7 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.UseFeedbackVoice` 决定是否使用 `VoiceFeedback` "
 "定义的声音。默认为 `[AudioVisual] -> CombatAlert.UseFeedbackVoice`。"
 
-#: ../../New-or-Enhanced-Logics.md:1875
+#: ../../New-or-Enhanced-Logics.md:1920
 msgid ""
 "`[TechnoType] -> CombatAlert.UseAttackVoice` decides whether to use the "
 "sound defined by `VoiceAttack`. Default to `[AudioVisual] -> "
@@ -7035,7 +7147,7 @@ msgstr ""
 "`[TechnoType] -> CombatAlert.UseAttackVoice` 决定是否使用 `VoiceAttack` "
 "定义的声音。默认为 `[AudioVisual] -> CombatAlert.UseAttackVoice`。"
 
-#: ../../New-or-Enhanced-Logics.md:1876
+#: ../../New-or-Enhanced-Logics.md:1921
 msgid ""
 "`[TechnoType] -> CombatAlert.UseEVA` decides whether to play an EVA. "
 "Default to `[AudioVisual] -> CombatAlert.UseEVA`. The EVA to play is "
@@ -7046,7 +7158,7 @@ msgstr ""
 "CombatAlert.UseEVA`。所用的 EVA 默认为 `EVA_UnitsInCombat`，可以通过 `[TechnoType] ->"
 " CombatAlert.EVA` 指定。"
 
-#: ../../New-or-Enhanced-Logics.md:1877
+#: ../../New-or-Enhanced-Logics.md:1922
 msgid ""
 "The sound effect is taken **at order**, feedback first, attack then, eva "
 "finally. The flags in `[AudioVisual]` controlls whether to check it "
@@ -7055,7 +7167,7 @@ msgstr ""
 "声音效果 **依次** 被使用，首先是反馈，然后是攻击，最后是 EVA。在 `[AudioVisual]` "
 "中的标签控制是否全局检查，可以为每个科技类型单独指定。"
 
-#: ../../New-or-Enhanced-Logics.md:1878
+#: ../../New-or-Enhanced-Logics.md:1923
 msgid ""
 "An example: You set `CombatAlert.UseFeedbackVoice` and "
 "`CombatAlert.UseEVA` to `true` and `CombatAlert.UseAttackVoice` to "
@@ -7068,7 +7180,7 @@ msgstr ""
 "`VoiceFeedback`、`VoiceAttack` 和 `CombatAlert.EVA` 的单位将播放 "
 "`VoiceFeedback`。拥有 `VoiceAttack` 的单位将播放 `EVA_UnitsInCombat`。"
 
-#: ../../New-or-Enhanced-Logics.md:1881
+#: ../../New-or-Enhanced-Logics.md:1926
 msgid ""
 "[AudioVisual]\n"
 "CombatAlert=false                      ; boolean\n"
@@ -7116,11 +7228,11 @@ msgstr ""
 "[SOMEWARHEAD]                          ; WarheadType\n"
 "CombatAlert.Suppress=                  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1906
+#: ../../New-or-Enhanced-Logics.md:1951
 msgid "Recount burst index"
 msgstr "重置连发索引"
 
-#: ../../New-or-Enhanced-Logics.md:1908
+#: ../../New-or-Enhanced-Logics.md:1953
 msgid ""
 "You can now make technos recount their current burst index when they have"
 " changed the firing weapon or have maintained for a period of time "
@@ -7128,7 +7240,7 @@ msgid ""
 "and 30 frames)."
 msgstr "现在你可以让单位在更换了开火武器或一段时间（取上一次发射武器的 `ROF` 与 30 帧之间的较大值）内没有目标的情况下重置当前的连发索引。"
 
-#: ../../New-or-Enhanced-Logics.md:1911
+#: ../../New-or-Enhanced-Logics.md:1956
 msgid ""
 "[General]\n"
 "RecountBurst=false  ; boolean\n"
@@ -7142,15 +7254,15 @@ msgstr ""
 "[SOMETECHNO]        ; TechnoType\n"
 "RecountBurst=       ; boolean, default to [General] -> RecountBurst\n"
 
-#: ../../New-or-Enhanced-Logics.md:1919
+#: ../../New-or-Enhanced-Logics.md:1964
 msgid "Reset MindControl after transformation"
 msgstr "变形后重置心控效果"
 
-#: ../../New-or-Enhanced-Logics.md:1921
+#: ../../New-or-Enhanced-Logics.md:1966
 msgid "After the unit conversion is completed, its mind control can be reset."
 msgstr "单位变形完毕后其心控效果可被重置。"
 
-#: ../../New-or-Enhanced-Logics.md:1922
+#: ../../New-or-Enhanced-Logics.md:1967
 msgid ""
 "If all warheads don't have `MindControl=yes`, then "
 "`Convert.ResetMindControl=yes` will release all controlled units."
@@ -7158,7 +7270,7 @@ msgstr ""
 "如果变形后的单位所有弹头都没有 `MindControl=yes`，那么 `Convert.ResetMindControl=yes` "
 "将释放所有被心控的单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1923
+#: ../../New-or-Enhanced-Logics.md:1968
 msgid ""
 "If any warhead has `MindControl=yes`, then `Convert.ResetMindControl=yes`"
 " resets its maximum number of controls."
@@ -7166,7 +7278,7 @@ msgstr ""
 "如果变形后的单位任意弹头拥有 `MindControl=yes`，那么 `Convert.ResetMindControl=yes` "
 "将重置最大控制数量上限。"
 
-#: ../../New-or-Enhanced-Logics.md:1924
+#: ../../New-or-Enhanced-Logics.md:1969
 msgid ""
 "If all weapons don't have `InfiniteMindControl=yes`, then "
 "`Convert.ResetMindControl=yes` release controlled units that exceed the "
@@ -7175,7 +7287,7 @@ msgstr ""
 "如果变形后的单位所有武器都没有 `InfiniteMindControl=yes`，那么 "
 "`Convert.ResetMindControl=yes` 将释放超出上限的被心控单位。"
 
-#: ../../New-or-Enhanced-Logics.md:1927
+#: ../../New-or-Enhanced-Logics.md:1972
 msgid ""
 "[SOMETECHNO]                            ; TechnoType, before conversion\n"
 "Convert.ResetMindControl=false          ; boolean\n"
@@ -7183,11 +7295,11 @@ msgstr ""
 "[SOMETECHNO]                            ; TechnoType, before conversion\n"
 "Convert.ResetMindControl=false          ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:1932
+#: ../../New-or-Enhanced-Logics.md:1977
 msgid "Revenge weapon"
 msgstr "复仇武器"
 
-#: ../../New-or-Enhanced-Logics.md:1934
+#: ../../New-or-Enhanced-Logics.md:1979
 msgid ""
 "![Revenge Weapon](_static/images/revengeweapon.gif) *Revenge Weapon usage"
 " in [RA2: Reboot](https://www.moddb.com/mods/reboot)*"
@@ -7195,11 +7307,11 @@ msgstr ""
 "![image](_static/images/revengeweapon.gif) *[RA2: "
 "Reboot](https://www.moddb.com/mods/reboot) 中的复仇武器*"
 
-#: ../../New-or-Enhanced-Logics.md:1934
+#: ../../New-or-Enhanced-Logics.md:1979
 msgid "Revenge Weapon"
 msgstr "复仇武器"
 
-#: ../../New-or-Enhanced-Logics.md:1937
+#: ../../New-or-Enhanced-Logics.md:1982
 msgid ""
 "Similar to `DeathWeapon` in that it is fired after a TechnoType is "
 "killed, but with the difference that it will be fired on whoever dealt "
@@ -7211,20 +7323,20 @@ msgstr ""
 "`DeathWeapon`，它在科技类型被击杀后发射，但不同的是它将发射给造成伤害并杀死科技类型的人。如果科技类型不是由于其他科技类型造成的直接伤害而死亡，那么"
 " `RevengeWeapon` 将不会被发射。"
 
-#: ../../New-or-Enhanced-Logics.md:1938
+#: ../../New-or-Enhanced-Logics.md:1983
 msgid ""
 "`RevengeWeapon.AffectsHouses` can be used to filter which houses the "
 "damage that killed the TechnoType is allowed to come from to fire the "
 "weapon."
 msgstr "`RevengeWeapon.AffectsHouses` 可用于筛选可以对哪些所属方的击杀者发射武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1939
+#: ../../New-or-Enhanced-Logics.md:1984
 msgid ""
 "It is possible to grant revenge weapons through [attached effects"
 "](#attached-effects) as well."
 msgstr "也可以通过 [Attach Effect](#attached-effects) 来授予复仇武器。"
 
-#: ../../New-or-Enhanced-Logics.md:1940
+#: ../../New-or-Enhanced-Logics.md:1985
 msgid ""
 "If a Warhead has `SuppressRevengeWeapons` set to true, it will not "
 "trigger revenge weapons. `SuppressRevengeWeapons.Types` can be used to "
@@ -7235,7 +7347,7 @@ msgstr ""
 "则不会触发复仇武器。`SuppressRevengeWeapons.Types` "
 "可用于列出受影响的武器类型，如果没有列出，则所有武器类型都受影响。"
 
-#: ../../New-or-Enhanced-Logics.md:1943
+#: ../../New-or-Enhanced-Logics.md:1988
 msgid ""
 "[SOMETECHNO]                    ; TechnoType\n"
 "RevengeWeapon=                  ; WeaponType\n"
@@ -7255,11 +7367,11 @@ msgstr ""
 "SuppressRevengeWeapons=false    ; boolean\n"
 "SuppressRevengeWeapons.Types=   ; List of WeaponTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:1953
+#: ../../New-or-Enhanced-Logics.md:1998
 msgid "Shared Ammo"
 msgstr "共享弹药"
 
-#: ../../New-or-Enhanced-Logics.md:1955
+#: ../../New-or-Enhanced-Logics.md:2000
 msgid ""
 "Transports with `OpenTopped=yes` and `Ammo.Shared=yes` will transfer ammo"
 " to passengers that have `Ammo.Shared=yes`. In addition, a transport can "
@@ -7271,17 +7383,17 @@ msgstr ""
 "的载员共享弹药。此外如果载员拥有与运输工具相同的 `Ammo.Shared.Group=<integer>` "
 "值则运输工具可以筛选谁将接收弹药而忽略不拥有同组值的其他载员。"
 
-#: ../../New-or-Enhanced-Logics.md:1957
+#: ../../New-or-Enhanced-Logics.md:2002
 msgid ""
 "Transports with `Ammo.Shared.Group=-1` will transfer ammo to any "
 "passenger with `Ammo.Shared=yes` ignoring the group."
 msgstr "拥有 `Ammo.Shared.Group=-1` 的运输工具将像任何拥有 `Ammo.Shared=yes` 的载员共享弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:1958
+#: ../../New-or-Enhanced-Logics.md:2003
 msgid "Transports must have ammo and should be able to reload ammo."
 msgstr "运输工具必须拥有弹药并应当能够自行重装弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:1961
+#: ../../New-or-Enhanced-Logics.md:2006
 msgid ""
 "[SOMETECHNO1]         ; TechnoType, transport with OpenTopped=yes\n"
 "Ammo.Shared=no        ; boolean\n"
@@ -7299,17 +7411,17 @@ msgstr ""
 "Ammo.Shared=no        ; boolean\n"
 "Ammo.Shared.Group=-1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:1971
+#: ../../New-or-Enhanced-Logics.md:2016
 msgid "Sound entry on unit's creation"
 msgstr "单位创建时音效"
 
-#: ../../New-or-Enhanced-Logics.md:1973
+#: ../../New-or-Enhanced-Logics.md:2018
 msgid ""
 "When a unit is created, sound specified in `VoiceCreated` will be played "
 "for the unit owner."
 msgstr "当一个单位被创建时将为单位所有者播放 `VoiceCreated` 指定的音效。"
 
-#: ../../New-or-Enhanced-Logics.md:1974
+#: ../../New-or-Enhanced-Logics.md:2019
 msgid ""
 "If `IsVoiceCreatedGlobal` is set to true, `VoiceCreated` will be played "
 "globally instead of `EVA_UnitReady`."
@@ -7317,7 +7429,7 @@ msgstr ""
 "如果 `IsVoiceCreatedGlobal` 设为 true 则将全局播放 `VoiceCreated` 而不是 "
 "`EVA_UnitReady`。"
 
-#: ../../New-or-Enhanced-Logics.md:1977
+#: ../../New-or-Enhanced-Logics.md:2022
 msgid ""
 "[AudioVisual]\n"
 "IsVoiceCreatedGlobal=false   ; boolean\n"
@@ -7331,15 +7443,15 @@ msgstr ""
 "[SOMETECHNO]                 ; TechnoType\n"
 "VoiceCreated=                ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:1985
+#: ../../New-or-Enhanced-Logics.md:2030
 msgid "Targeting limitation for berzerk technos"
 msgstr "狂暴单位索敌限制"
 
-#: ../../New-or-Enhanced-Logics.md:1987
+#: ../../New-or-Enhanced-Logics.md:2032
 msgid "Now you can specify which houses berzerk's technos can target and fire."
 msgstr "现在你可以设定狂暴单位可以对哪些所属方的目标索敌和开火。"
 
-#: ../../New-or-Enhanced-Logics.md:1990
+#: ../../New-or-Enhanced-Logics.md:2035
 msgid ""
 "[General]\n"
 "BerzerkTargeting=all  ; Affected House Enumeration "
@@ -7349,24 +7461,24 @@ msgstr ""
 "BerzerkTargeting=all  ; Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:1995
+#: ../../New-or-Enhanced-Logics.md:2040
 msgid "Tiberium eater"
 msgstr "马夫逻辑"
 
-#: ../../New-or-Enhanced-Logics.md:1997
+#: ../../New-or-Enhanced-Logics.md:2042
 msgid ""
 "TechnoTypes can convert the ores underneath them into credits in real "
 "time, like GDI's MARV in Command & Conquer 3 Kane's Wrath."
 msgstr "可以让单位实时将自身脚下的矿石直接转化为资金，就像《凯恩之怒》中 GDI 的 MARV 那样。"
 
-#: ../../New-or-Enhanced-Logics.md:1998
+#: ../../New-or-Enhanced-Logics.md:2043
 msgid ""
 "`TiberiumEater.TransDelay` specifies the interval frames between two "
 "eating processes, 0 means eat in every frame. When it's below 0, the "
 "logic will be turned off for this TechnoType."
 msgstr "`TiberiumEater.TransDelay` 指定了两次吃矿之间间隔的帧数，0 代表逐帧。负值禁用。"
 
-#: ../../New-or-Enhanced-Logics.md:1999
+#: ../../New-or-Enhanced-Logics.md:2044
 msgid ""
 "`TiberiumEater.CellN` set a list of cells that'll process tiberium "
 "eating, where `N` is 0-based and the values are offset related to the "
@@ -7376,31 +7488,31 @@ msgstr ""
 "`TiberiumEater.CellN` 用于设定吃矿位置以单元格为单位的偏移列表，`N` 为 0 "
 "始序号，数值表示相对于单位所在单元格的偏移坐标。如果不设置则只吃脚下的。"
 
-#: ../../New-or-Enhanced-Logics.md:2000
+#: ../../New-or-Enhanced-Logics.md:2045
 msgid ""
 "`TiberiumEater.AmountPerCell` controls the amount of ores that can be "
 "eaten at each cell at once. No limit when it's below 0."
 msgstr "`TiberiumEater.AmountPerCell` 控制单次吃矿对与每个单元格而言可吃进去的矿石量上限。负值喂不饱。"
 
-#: ../../New-or-Enhanced-Logics.md:2001
+#: ../../New-or-Enhanced-Logics.md:2046
 msgid ""
 "By default, ores mined in this way worth the same as regular harvesting. "
 "This can be adjusted by `TiberiumEater.CashMultiplier`."
 msgstr "默认通过此方式采集的矿石价值与常规采矿相同。这可以通过 `TiberiumEater.CashMultiplier` 加以调整。"
 
-#: ../../New-or-Enhanced-Logics.md:2002
+#: ../../New-or-Enhanced-Logics.md:2047
 msgid ""
 "`TiberiumEater.Display`, if set to true, will create a flying text to "
 "display the total credits received in each eating process."
 msgstr "若 `TiberiumEater.Display` 设为 true 则每次吃矿时都会飘起一个代表所得总资金量的数字。"
 
-#: ../../New-or-Enhanced-Logics.md:2003
+#: ../../New-or-Enhanced-Logics.md:2048
 msgid ""
 "`TiberiumEater.Display.Houses` determines which houses can see the "
 "credits display."
 msgstr "`TiberiumEater.Display.Houses` 决定了哪些所属方能看见。"
 
-#: ../../New-or-Enhanced-Logics.md:2004
+#: ../../New-or-Enhanced-Logics.md:2049
 msgid ""
 "An animation will be played at each mined cell in an eating process. If "
 "`TiberiumEater.Anims` contains 8 entries, entry from position matching "
@@ -7408,7 +7520,7 @@ msgid ""
 "be chosen randomly."
 msgstr "每次吃矿时都会在被吃的单元格播放动画。若 `TiberiumEater.Anims` 包含 8 个条目则根据单位当前朝向选择动画，否则随机选取。"
 
-#: ../../New-or-Enhanced-Logics.md:2005
+#: ../../New-or-Enhanced-Logics.md:2050
 msgid ""
 "`TiberiumEater.Anims.TiberiumN`, if set, will override "
 "`TiberiumEater.Anims` when eating corresponding tiberium type."
@@ -7416,13 +7528,13 @@ msgstr ""
 "若设置了 `TiberiumEater.Anims.TiberiumN` 则在吃进去对应类型（`N` = `[0,3]`）的矿石时使用对应序列的 "
 "`TiberiumEater.Anims`。"
 
-#: ../../New-or-Enhanced-Logics.md:2006
+#: ../../New-or-Enhanced-Logics.md:2051
 msgid ""
 "If `TiberiumEater.AnimMove` set to true, the animations will move with "
 "the TechnoType."
 msgstr "若 `TiberiumEater.AnimMove` 设为 true 则动画会跟随单位移动。"
 
-#: ../../New-or-Enhanced-Logics.md:2009
+#: ../../New-or-Enhanced-Logics.md:2054
 msgid ""
 "[SOMETECHNO]                      ; InfantryType, VehicleType or "
 "AircraftType\n"
@@ -7456,18 +7568,18 @@ msgstr ""
 "TiberiumEater.Anims.Tiberium3=    ; List of AnimationTypes\n"
 "TiberiumEater.AnimMove=true       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2025
+#: ../../New-or-Enhanced-Logics.md:2070
 msgid "Weapons fired on warping in / out"
 msgstr "武器在传送时开火"
 
-#: ../../New-or-Enhanced-Logics.md:2027
+#: ../../New-or-Enhanced-Logics.md:2072
 msgid ""
 "It is now possible to add weapons that are fired on a teleporting "
 "TechnoType when it warps in or out. They are at the same time as the "
 "appropriate animations (`WarpIn` / `WarpOut`) are displayed."
 msgstr "现在可以在科技类型传送来/去时发射武器。它们会与相应的 (`WarpIn`／`WarpOut`) 动画一起显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2028
+#: ../../New-or-Enhanced-Logics.md:2073
 msgid ""
 "`WarpInMinRangeWeapon` is used instead of `WarpInWeapon` if the distance "
 "traveled (in leptons) was less than `ChronoRangeMinimum`. This works "
@@ -7478,7 +7590,7 @@ msgstr ""
 "时使用，无论是否设置了 `ChronoTrigger`。如果未设置 `WarpInMinRangeWeapon`，则默认为 "
 "`WarpInWeapon`。"
 
-#: ../../New-or-Enhanced-Logics.md:2029
+#: ../../New-or-Enhanced-Logics.md:2074
 msgid ""
 "If `WarpInWeapon.UseDistanceAsDamage` is set, `Damage` of "
 "`WarpIn(MinRange)Weapon` is overriden by the number of whole cells "
@@ -7487,7 +7599,7 @@ msgstr ""
 "如果设置了 `WarpInWeapon.UseDistanceAsDamage` 则 `WarpIn(MinRange)Weapon` 的 "
 "`Damage` 将被覆盖为传送所跨越的完整单元格数。"
 
-#: ../../New-or-Enhanced-Logics.md:2032
+#: ../../New-or-Enhanced-Logics.md:2077
 msgid ""
 "[SOMETECHNO]                            ; TechnoType\n"
 "WarpInWeapon=                           ; WeaponType\n"
@@ -7501,126 +7613,27 @@ msgstr ""
 "WarpInWeapon.UseDistanceAsDamage=false  ; boolean\n"
 "WarpOutWeapon=                          ; WeaponType\n"
 
-#: ../../New-or-Enhanced-Logics.md:2040
-msgid "Customize Ares's radar jam logic"
-msgstr "自定义 Ares 的雷达干扰逻辑"
-
-#: ../../New-or-Enhanced-Logics.md:2042
-msgid "It is now possible to customize some properties of Ares's radar jam logic."
-msgstr "现在可以自定义 Ares 雷达干扰逻辑的部分属性。"
-
-#: ../../New-or-Enhanced-Logics.md:2043
-msgid "`RadarJamHouses` determines which houses will be affected by the jam."
-msgstr "`RadarJamHouses` 决定哪些所属方会受到雷达干扰效果影响。"
-
-#: ../../New-or-Enhanced-Logics.md:2044
-msgid ""
-"`RadarJamDelay` determines the interval of the jam, default to 30 frames "
-"like Ares did. Shorter interval means the jam will be applied more "
-"timely, but worse for performance."
-msgstr "`RadarJamDelay` 决定干扰间隔，默认同 Ares 为 30。较短的间隔会使干扰生效更及时但会降低性能。"
-
-#: ../../New-or-Enhanced-Logics.md:2045
-msgid ""
-"`RadarJamAffect` determines a list of buildings with `Radar=yes` or "
-"`SpySat=yes` that could be affected by the jam. If it's empty, all radar "
-"buildings will be affected."
-msgstr ""
-"`RadarJamAffect` 决定哪些拥有 `Radar=yes` 或 `SpySat=yes` "
-"的建筑会受到干扰。如果为空则所有雷达建筑都会受到干扰。"
-
-#: ../../New-or-Enhanced-Logics.md:2046
-msgid ""
-"`RadarJamIgnore` determines a list of buildings with `Radar=yes` or "
-"`SpySat=yes` that couldn't be affected by the jam."
-msgstr "`RadarJamIgnore` 决定哪些拥有 `Radar=yes` 或 `SpySat=yes` 的建筑不受到干扰。"
-
-#: ../../New-or-Enhanced-Logics.md:2049
-msgid ""
-"[SOMETECHNO]                      ; TechnoType, with RadarJamRadius=\n"
-"RadarJamHouses=enemies            ; List of Affected House Enumeration "
-"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
-"RadarJamDelay=30                  ; integer\n"
-"RadarJamAffect=                   ; List of BuildingTypes\n"
-"RadarJamIgnore=                   ; List of BuildingTypes\n"
-msgstr ""
-"[SOMETECHNO]                      ; TechnoType, with RadarJamRadius=\n"
-"RadarJamHouses=enemies            ; List of Affected House Enumeration "
-"(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
-"RadarJamDelay=30                  ; integer\n"
-"RadarJamAffect=                   ; List of BuildingTypes\n"
-"RadarJamIgnore=                   ; List of BuildingTypes\n"
-
-#: ../../New-or-Enhanced-Logics.md:2057
-msgid "Automatic conversion based on ammo"
-msgstr "基于弹药量的自动变形"
-
-#: ../../New-or-Enhanced-Logics.md:2059
-msgid "Units can now be converted into another unit by ammo count."
-msgstr "单位现在可以根据弹药量转换成另一种单位"
-
-#: ../../New-or-Enhanced-Logics.md:2060
-msgid ""
-"`Ammo.AutoConvertMinimumAmount` determines the minimal number of ammo at "
-"which a unit converts automatically after the ammo update."
-msgstr ""
-"`Ammo.AutoConvertMinimumAmount` 决定触发自动变形的最小弹药量。"
-
-#: ../../New-or-Enhanced-Logics.md:2061
-msgid ""
-"`Ammo.AutoConvertMaximumAmount` determines the maximum number of ammo at "
-"which a unit converts automatically after the ammo update."
-msgstr ""
-"`Ammo.AutoConvertMaximumAmount` 决定触发自动变形的最大弹药量。"
-
-#: ../../New-or-Enhanced-Logics.md:2062
-msgid ""
-"`Ammo.AutoConvertType` specify the new techno after the conversion. This "
-"unit must be of the same type of the original (infantry -> infantry, "
-"vehicle -> vehicle or aircraft -> aircraft)."
-msgstr ""
-"`Ammo.AutoConvertType` 指定变形成哪个新单位。该单位必须与原单位同属一类（载具变载具，步兵变步兵，战机变战机）。"
-
-#: ../../New-or-Enhanced-Logics.md:2063
-msgid ""
-"Setting a negative number will disable the ammo count check, and when "
-"both checks are disabled, conversion will not occur."
-msgstr ""
-"设为负数将会禁用弹药数量检查，当两个检查都被禁用时将不会触发变形。"
-
-#: ../../New-or-Enhanced-Logics.md:2066
-msgid ""
-"[SOMETECHNO]                      ; TechnoType, before conversion\n"
-"Ammo.AutoConvertMinimumAmount=-1  ; integer\n"
-"Ammo.AutoConvertMaximumAmount=-1  ; integer\n"
-"Ammo.AutoConvertType=             ; TechnoType, after conversion\n"
-msgstr ""
-"[SOMETECHNO]                      ; TechnoType, before conversion\n"
-"Ammo.AutoConvertMinimumAmount=-1  ; integer\n"
-"Ammo.AutoConvertMaximumAmount=-1  ; integer\n"
-"Ammo.AutoConvertType=             ; TechnoType, after conversion\n"
-
-#: ../../New-or-Enhanced-Logics.md:2081
+#: ../../New-or-Enhanced-Logics.md:2085
 msgid "Terrain"
 msgstr "地形对象"
 
-#: ../../New-or-Enhanced-Logics.md:2083
+#: ../../New-or-Enhanced-Logics.md:2087
 msgid "Destroy animation & sound"
 msgstr "摧毁动画与音效"
 
-#: ../../New-or-Enhanced-Logics.md:2085
+#: ../../New-or-Enhanced-Logics.md:2089
 msgid ""
 "You can now specify a destroy animation and sound for a TerrainType that "
 "are played when it is destroyed."
 msgstr "现在你可以指定当地形对象被摧毁时播放播放的摧毁动画与音效。如果列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:2086
+#: ../../New-or-Enhanced-Logics.md:2090
 msgid ""
 "If more than one animation is listed in `DestroyAnim`, a random one is "
 "selected."
 msgstr "如果 `DestroyAnim` 中列出了多个动画，则将随机选择一个。"
 
-#: ../../New-or-Enhanced-Logics.md:2089
+#: ../../New-or-Enhanced-Logics.md:2093
 msgid ""
 "[SOMETERRAINTYPE]  ; TerrainType\n"
 "DestroyAnim=       ; List of AnimationTypes\n"
@@ -7630,21 +7643,21 @@ msgstr ""
 "DestroyAnim=       ; List of AnimationTypes\n"
 "DestroySound=      ; Sound entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:2095
+#: ../../New-or-Enhanced-Logics.md:2099
 msgid "Vehicles"
 msgstr "载具类型"
 
-#: ../../New-or-Enhanced-Logics.md:2097
+#: ../../New-or-Enhanced-Logics.md:2101
 msgid "Amphibious access vehicle"
 msgstr "两栖载具装载拓展"
 
-#: ../../New-or-Enhanced-Logics.md:2099
+#: ../../New-or-Enhanced-Logics.md:2103
 msgid ""
 "Now you can let amphibious infantry or vehicle passengers enter or leave "
 "amphibious transport vehicles on water surface."
 msgstr "现在两栖步兵或载具可以在水中进入或离开两栖运输工具。"
 
-#: ../../New-or-Enhanced-Logics.md:2102
+#: ../../New-or-Enhanced-Logics.md:2106
 msgid ""
 "[General]\n"
 "AmphibiousEnter=false    ; boolean\n"
@@ -7666,11 +7679,11 @@ msgstr ""
 "AmphibiousUnload=        ; boolean, default to [General] -> "
 "AmphibiousUnload\n"
 
-#: ../../New-or-Enhanced-Logics.md:2112
+#: ../../New-or-Enhanced-Logics.md:2116
 msgid "Automatic deploy and blocking deploying based on ammo"
 msgstr "基于弹药量的自动部署与禁用部署"
 
-#: ../../New-or-Enhanced-Logics.md:2114
+#: ../../New-or-Enhanced-Logics.md:2118
 msgid ""
 "It is now possible for deployable vehicles (`DeploysInto`, `DeployFire`, "
 "`IsSimpleDeployer` and those that have passengers) to automatically "
@@ -7679,7 +7692,7 @@ msgstr ""
 "现可为可部署（`DeploysInto`、`DeployFire`、`IsSimpleDeployer` "
 "以及那些有乘客的）载具设定根据当前弹药量自动部署或禁用部署"
 
-#: ../../New-or-Enhanced-Logics.md:2115
+#: ../../New-or-Enhanced-Logics.md:2119
 msgid ""
 "`Ammo.AutoDeployMinimumAmount` & `Ammo.AutoDeployMaximumAmount` determine"
 " minimum and maximum ammo the vehicle should have for it to automatically"
@@ -7688,7 +7701,7 @@ msgstr ""
 "`Ammo.AutoDeployMinimumAmount` & `Ammo.AutoDeployMaximumAmount` "
 "分别设定载具自动部署所需的最低与最高弹药量阈值，负值表示禁用检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2116
+#: ../../New-or-Enhanced-Logics.md:2120
 msgid ""
 "`Ammo.DeployUnlockMinimumAmount` & `Ammo.DeployUnlockMaximumAmount` "
 "determine minimum and maximum ammo the vehicle should have for deploying "
@@ -7697,7 +7710,7 @@ msgstr ""
 "`Ammo.DeployUnlockMinimumAmount` & `Ammo.DeployUnlockMaximumAmount` "
 "分别设定载具启用部署功能所需的最低与最高弹药量阈值，负值表示禁用检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2119
+#: ../../New-or-Enhanced-Logics.md:2123
 msgid ""
 "[SOMEVEHICLE]                      ; VehicleType\n"
 "Ammo.AutoDeployMinimumAmount=-1    ; integer\n"
@@ -7711,11 +7724,11 @@ msgstr ""
 "Ammo.DeployUnlockMinimumAmount=-1  ; integer\n"
 "Ammo.DeployUnlockMaximumAmount=-1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:2127
+#: ../../New-or-Enhanced-Logics.md:2131
 msgid "Damaged unit image changes"
 msgstr "载具伤残更换图像"
 
-#: ../../New-or-Enhanced-Logics.md:2129
+#: ../../New-or-Enhanced-Logics.md:2133
 msgid ""
 "When a unit is damaged (health points percentage is lower than "
 "`[AudioVisual] -> ConditionYellow` percentage), it now may use different "
@@ -7724,7 +7737,7 @@ msgstr ""
 "现在当载具伤残（生命值低于 `[AudioVisual] -> ConditionYellow` 的百分比）时可以通过 "
 "`Image.ConditionYellow` 为载具设置不同的图像。"
 
-#: ../../New-or-Enhanced-Logics.md:2130
+#: ../../New-or-Enhanced-Logics.md:2134
 msgid ""
 "Similar, `Image.ConditionRed` is used as image if unit health points "
 "percentage is lower than `[AudioVisual] -> ConditionRed` percentage."
@@ -7732,7 +7745,7 @@ msgstr ""
 "同样的如果载具生命值低于 `[AudioVisual] -> ConditionRed` 的百分比那么将会使用 "
 "`Image.ConditionRed` 作为图像。"
 
-#: ../../New-or-Enhanced-Logics.md:2131
+#: ../../New-or-Enhanced-Logics.md:2135
 msgid ""
 "It is also works on water by setting `WaterImage.ConditionYellow` and "
 "`WaterImage.ConditionRed` VehicleType, similar to Ares' `WaterImage`."
@@ -7740,7 +7753,7 @@ msgstr ""
 "类似于 Ares 的 `WaterImage`，可以通过设置 `WaterImage.ConditionYellow` 和 "
 "`WaterImage.ConditionRed` 的载具类型来在水上应用这一效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2134
+#: ../../New-or-Enhanced-Logics.md:2138
 msgid ""
 "[SOMEVEHICLE]                         ; VehicleType\n"
 "Image.ConditionYellow=                ; VehicleType entry\n"
@@ -7754,17 +7767,17 @@ msgstr ""
 "WaterImage.ConditionYellow=           ; VehicleType entry\n"
 "WaterImage.ConditionRed=              ; VehicleType entry\n"
 
-#: ../../New-or-Enhanced-Logics.md:2143
+#: ../../New-or-Enhanced-Logics.md:2147
 msgid ""
 "Note that the VehicleTypes had to be defined under [VehicleTypes] and use"
 " same image type (SHP/VXL) for vanilla/damaged states."
 msgstr "注意这些被使用的载具必须在 `[VehicleTypes]` 下注册并且在常规／伤残状态下使用相同的图像类型（Shape／Voxel）。"
 
-#: ../../New-or-Enhanced-Logics.md:2146
+#: ../../New-or-Enhanced-Logics.md:2150
 msgid "Jumpjet Tilts While Moving"
 msgstr "Jumpjet 在移动时倾斜"
 
-#: ../../New-or-Enhanced-Logics.md:2148
+#: ../../New-or-Enhanced-Logics.md:2152
 msgid ""
 "![image](_static/images/jumpjet-tilt.gif) *Jumpjet Tilts in [Project Rush"
 " - Conquer](https://www.moddb.com/mods/project-rush-conquer)*"
@@ -7773,31 +7786,31 @@ msgstr ""
 "*[冲击计划：征服](https://www.moddb.com/mods/project-rush-conquer) 中的 Jumpjet "
 "前倾*"
 
-#: ../../New-or-Enhanced-Logics.md:2151
+#: ../../New-or-Enhanced-Logics.md:2155
 msgid ""
 "Now you can make jumpjets tilt forward when moving forward and sideways "
 "when turning by setting `JumpjetTilt` to true."
 msgstr "现在你可以通过将 `JumpjetTilt` 设为 true 来使 Jumpjet 单位在向前移动时前倾以及在转向时侧倾。"
 
-#: ../../New-or-Enhanced-Logics.md:2152
+#: ../../New-or-Enhanced-Logics.md:2156
 msgid "The maximum tilt angle will not exceed 90 degrees."
 msgstr "最大倾斜角度不会超过 90 度。"
 
-#: ../../New-or-Enhanced-Logics.md:2153
+#: ../../New-or-Enhanced-Logics.md:2157
 msgid ""
 "The magnitude of the forward tilt is related to the current speed and "
 "acceleration. They are additive and have two coefficients that can be "
 "adjusted for details."
 msgstr "向前倾斜的幅度与当前速度和加速度相关。它们会相加，这里给出两个用于细节调整的系数。"
 
-#: ../../New-or-Enhanced-Logics.md:2154
+#: ../../New-or-Enhanced-Logics.md:2158
 msgid ""
 "The magnitude of the sideways tilt is related to the current speed and "
 "rotation angle. They are multiplied and also have two coefficients that "
 "can be adjusted for details."
 msgstr "侧向倾斜的幅度与当前速度和旋转角度相关。它们会相乘，同样给出两个用于细节调整的系数。"
 
-#: ../../New-or-Enhanced-Logics.md:2157
+#: ../../New-or-Enhanced-Logics.md:2161
 msgid ""
 "[SOMEVEHICLE]                           ; VehicleType, with "
 "Locomotor=Jumpjet\n"
@@ -7815,24 +7828,24 @@ msgstr ""
 "JumpjetTilt.SidewaysRotationFactor=1.0  ; floating point value\n"
 "JumpjetTilt.SidewaysSpeedFactor=1.0     ; floating point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:2166
+#: ../../New-or-Enhanced-Logics.md:2170
 msgid "Turret Response"
 msgstr "炮塔响应"
 
-#: ../../New-or-Enhanced-Logics.md:2168
+#: ../../New-or-Enhanced-Logics.md:2172
 msgid ""
 "When the vehicle loses its target, you can customize whether to align the"
 " turret direction with the vehicle body."
 msgstr "你可以自定义当载具丢失目标时炮塔方向是否回正（与车身对齐）"
 
-#: ../../New-or-Enhanced-Logics.md:2169
+#: ../../New-or-Enhanced-Logics.md:2173
 msgid ""
 "When `Speed=0` or TechnoTypes cells cannot move due to "
 "`MovementRestrictedTo`, the default value is no; in other cases, it is "
 "yes."
 msgstr "若 `Speed=0` 或单位由于 `MovementRestrictedTo` 导致无法移动，则默认 no；否则默认 yes。"
 
-#: ../../New-or-Enhanced-Logics.md:2172
+#: ../../New-or-Enhanced-Logics.md:2176
 msgid ""
 "[SOMEVEHICLE]       ; VehicleType\n"
 "TurretResponse=     ; boolean\n"
@@ -7840,11 +7853,11 @@ msgstr ""
 "[SOMEVEHICLE]       ; VehicleType\n"
 "TurretResponse=     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2177
+#: ../../New-or-Enhanced-Logics.md:2181
 msgid "Turretless Shape Vehicle FireUp"
 msgstr "无炮塔 Shape 载具开火前摇"
 
-#: ../../New-or-Enhanced-Logics.md:2179
+#: ../../New-or-Enhanced-Logics.md:2183
 msgid ""
 "![image](_static/images/vehiclefireup.gif) *Use the pre-firing animation "
 "effect for Shape vehicle-type mecha units in **Zero Boundary** by "
@@ -7854,18 +7867,18 @@ msgstr ""
 "*@[暴风硫](https://space.bilibili.com/11638715/lists/5358986) 在 **零点界限** 中为 "
 "Shape 载具类型的机甲单位使用开火前摇效果*"
 
-#: ../../New-or-Enhanced-Logics.md:2182
+#: ../../New-or-Enhanced-Logics.md:2186
 msgid "`Voxel=no` turretless vehicles now support the use of `FireUp`."
 msgstr "现在 `Voxel=no` 的无炮塔载具已经支持 `FireUp`。"
 
-#: ../../New-or-Enhanced-Logics.md:2183
+#: ../../New-or-Enhanced-Logics.md:2187
 msgid ""
 "`FireUp.ResetInRetarget` determines whether a vehicle's FireUp count is "
 "reset when its target changes. Forced to be `yes` when there is no "
 "target."
 msgstr "`FireUp.ResetInRetarget` 决定当前载具目标改变时其前摇是否重置。失去目标强制重置。"
 
-#: ../../New-or-Enhanced-Logics.md:2186
+#: ../../New-or-Enhanced-Logics.md:2190
 msgid ""
 "[SOMEVEHICLE]                   ; VehicleType\n"
 "FireUp=                         ; integer\n"
@@ -7875,41 +7888,41 @@ msgstr ""
 "FireUp=                         ; integer\n"
 "FireUp.ResetInRetarget=true     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2192
+#: ../../New-or-Enhanced-Logics.md:2196
 msgid "Warheads"
 msgstr "弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2195
+#: ../../New-or-Enhanced-Logics.md:2199
 msgid "All new Warhead effects"
 msgstr "所有新增的弹头效果"
 
-#: ../../New-or-Enhanced-Logics.md:2196
+#: ../../New-or-Enhanced-Logics.md:2200
 msgid ""
 "Can be used with `CellSpread` and Ares' GenericWarhead superweapon where "
 "applicable."
 msgstr "可在适用的情况下与 `CellSpread` 和 Ares 的通用弹头超级武器一起使用。"
 
-#: ../../New-or-Enhanced-Logics.md:2197
+#: ../../New-or-Enhanced-Logics.md:2201
 msgid "Cannot be used with `MindControl.Permanent=yes` of Ares."
 msgstr "不能与 Ares 的 `MindControl.Permanent=yes` 共同使用。"
 
-#: ../../New-or-Enhanced-Logics.md:2198
+#: ../../New-or-Enhanced-Logics.md:2202
 msgid ""
 "Respect `Verses` where applicable unless `EffectsRequireVerses` is set to"
 " `false`."
 msgstr "在适用的情况下除非 `EffectsRequireVerses` 设为 `false` 否则尊重 `Verses`。"
 
-#: ../../New-or-Enhanced-Logics.md:2199
+#: ../../New-or-Enhanced-Logics.md:2203
 msgid ""
 "If target has an active [shield](#shields), its armor type is used "
 "instead unless warhead can penetrate the shield."
 msgstr "如果目标拥有一个激活的 [护盾](#shields)，那么它的护甲类型将被使用，除非弹头可以穿透护盾。"
 
-#: ../../New-or-Enhanced-Logics.md:2202
+#: ../../New-or-Enhanced-Logics.md:2206
 msgid "Break Mind Control on impact"
 msgstr "解除心控"
 
-#: ../../New-or-Enhanced-Logics.md:2204
+#: ../../New-or-Enhanced-Logics.md:2208
 msgid ""
 "![image](_static/images/remove-mc.gif) *Mind control break warhead being "
 "utilized in [RA2: Reboot](https://www.moddb.com/mods/reboot)*"
@@ -7917,13 +7930,13 @@ msgstr ""
 "![image](_static/images/remove-mc.gif) *[RA2: "
 "Reboot](https://www.moddb.com/mods/reboot) 中的心控解除弹头*"
 
-#: ../../New-or-Enhanced-Logics.md:2207
+#: ../../New-or-Enhanced-Logics.md:2211
 msgid ""
 "Warheads can now break mind control (doesn't apply to perma-MC-ed "
 "objects)."
 msgstr "弹头现在可以解除心灵控制（不适用于永久心控的对象）。"
 
-#: ../../New-or-Enhanced-Logics.md:2210
+#: ../../New-or-Enhanced-Logics.md:2214
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "RemoveMindControl=false  ; boolean\n"
@@ -7931,11 +7944,11 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "RemoveMindControl=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2215
+#: ../../New-or-Enhanced-Logics.md:2219
 msgid "Chance-based extra damage or Warhead detonation / 'critical hits'"
 msgstr "暴击"
 
-#: ../../New-or-Enhanced-Logics.md:2217
+#: ../../New-or-Enhanced-Logics.md:2221
 msgid ""
 "Warheads can now apply additional chance-based damage or Warhead "
 "detonation ('critical hits') with the ability to customize chance, "
@@ -7943,7 +7956,7 @@ msgid ""
 "critical hit."
 msgstr "现在弹头可以基于概率额外造成暴击伤害或弹头爆炸，可以自定义暴击的概率、伤害、影响目标、受影响目标生命值阈值和暴击动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2218
+#: ../../New-or-Enhanced-Logics.md:2222
 msgid ""
 "`Crit.Chance` determines chance for a critical hit to occur. By default "
 "this is checked once when the Warhead is detonated and every target that "
@@ -7954,7 +7967,7 @@ msgstr ""
 "`Crit.Chance` 决定暴击发生的概率。默认情况下这在弹头爆炸时检查一次，每个受影响的目标都可能受到暴击。如果设置了 "
 "`Crit.ApplyChancePerTarget`，那么每个目标是否成功进行暴击的概率将单独计算。"
 
-#: ../../New-or-Enhanced-Logics.md:2219
+#: ../../New-or-Enhanced-Logics.md:2223
 msgid ""
 "`Crit.ExtraDamage` determines the damage dealt by the critical hit. If "
 "`Crit.Warhead` is set, the damage is used to detonate the specified "
@@ -7964,20 +7977,20 @@ msgstr ""
 "`Crit.ExtraDamage` 决定暴击造成的额外伤害，如果设置了 "
 "`Crit.Warhead`，那么伤害将用于在每个受影响的目标上引爆指定的弹头，否则伤害将基于当前弹头的 `Verses` 设置直接造成伤害。"
 
-#: ../../New-or-Enhanced-Logics.md:2220
+#: ../../New-or-Enhanced-Logics.md:2224
 msgid ""
 "`Crit.ExtraDamage.ApplyFirepowerMult` determines whether or not the "
 "critical hit damage should multiply the TechnoType's firepower "
 "multipliers."
 msgstr "`Crit.ExtraDamage.ApplyFirepowerMult` 决定暴击造成的额外伤害是否受益于科技类型所拥有的火力加成。"
 
-#: ../../New-or-Enhanced-Logics.md:2221
+#: ../../New-or-Enhanced-Logics.md:2225
 msgid ""
 "`Crit.Warhead` can be used to set a Warhead to detonate instead of using "
 "current Warhead."
 msgstr "`Crit.Warhead` 可用于设置一个替代当前弹头引爆的弹头。"
 
-#: ../../New-or-Enhanced-Logics.md:2222
+#: ../../New-or-Enhanced-Logics.md:2226
 msgid ""
 "`Crit.Warhead.FullDetonation` controls whether or not the Warhead is "
 "detonated fully on the targets (as part of a dummy weapon) or simply "
@@ -7986,20 +7999,20 @@ msgstr ""
 "`Crit.Warhead.FullDetonation` 控制弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 "
 "Phobos 的弹头效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2223
+#: ../../New-or-Enhanced-Logics.md:2227
 msgid ""
 "`Crit.Affects` can be used to customize types of targets that this "
 "Warhead can deal critical hits against. Critical hits cannot affect empty"
 " cells or cells containing only TerrainTypes, overlays etc."
 msgstr "`Crit.Affects` 可用于自定义此弹头可暴击的目标类型。暴击不能影响空置单元格或仅包含地形对象和覆盖物等的单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2224
+#: ../../New-or-Enhanced-Logics.md:2228
 msgid ""
 "`Crit.AffectsHouses` can be used to customize houses that this Warhead "
 "can deal critical hits against."
 msgstr "`Crit.AffectsHouses` 可用于自定义此弹头可暴击的目标所属。"
 
-#: ../../New-or-Enhanced-Logics.md:2225
+#: ../../New-or-Enhanced-Logics.md:2229
 msgid ""
 "`Crit.AffectBelowPercent` and `Crit.AffectAbovePercent` can be used to "
 "set the health percentage that targets must be above and/or below/equal "
@@ -8009,7 +8022,7 @@ msgstr ""
 "`Crit.AffectBelowPercent` 和 `Crit.AffectAbovePercent` "
 "用于设置可被暴击影响的单位其当前血量所占百分比必须高于和／或低于／等于的限制。若目标血量为 0 则跳过该检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2226
+#: ../../New-or-Enhanced-Logics.md:2230
 msgid ""
 "`Crit.AnimList` can be used to set a list of animations used instead of "
 "Warhead's `AnimList` if Warhead deals a critical hit to even one target. "
@@ -8022,7 +8035,7 @@ msgstr ""
 "`Crit.AnimList.PickRandom`（默认为 `AnimList.PickRandom`），则从列表中随机选择一个动画。如果设置了"
 " `Crit.AnimList.CreateAll`（默认为 `AnimList.CreateAll`），则创建列表中的所有动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2227
+#: ../../New-or-Enhanced-Logics.md:2231
 msgid ""
 "`Crit.AnimOnAffectedTargets`, if set, makes the animation(s) from "
 "`Crit.AnimList` play on each affected target *in addition* to animation "
@@ -8037,7 +8050,7 @@ msgstr ""
 "独立所以，`Crit.AnimList.PickRandom` 和 `Crit.AnimList.CreateAll` 将不会默认为 "
 "`AnimList` 对应项的值，需要手动设置。"
 
-#: ../../New-or-Enhanced-Logics.md:2228
+#: ../../New-or-Enhanced-Logics.md:2232
 msgid ""
 "`Crit.ActiveChanceAnims` can be used to set animation to be always "
 "displayed at the Warhead's detonation coordinates if the current Warhead "
@@ -8045,7 +8058,7 @@ msgid ""
 "random one is selected."
 msgstr "`Crit.ActiveChanceAnims` 可用于设置当前弹头有几率造成暴击时始终显示在弹头爆炸坐标处的动画。列出多个动画则随机选择其一。"
 
-#: ../../New-or-Enhanced-Logics.md:2229
+#: ../../New-or-Enhanced-Logics.md:2233
 msgid ""
 "`Crit.SuppressWhenIntercepted`, if set, prevents critical hits from "
 "occuring at all if the warhead was detonated from a [projectile that was "
@@ -8054,13 +8067,13 @@ msgstr ""
 "`Crit.SuppressWhenIntercepted` 如果设置则禁用弹头在被[抛射体拦截](#projectile-"
 "interception-logic)而引爆时造成暴击。"
 
-#: ../../New-or-Enhanced-Logics.md:2230
+#: ../../New-or-Enhanced-Logics.md:2234
 msgid ""
 "`ImmuneToCrit` can be set on TechnoTypes and ShieldTypes to make them "
 "immune to critical hits."
 msgstr "`ImmuneToCrit` 可以设置在科技类型和护盾类型上以使它们免疫暴击。"
 
-#: ../../New-or-Enhanced-Logics.md:2233
+#: ../../New-or-Enhanced-Logics.md:2237
 msgid ""
 "[SOMEWARHEAD]                              ; WarheadType\n"
 "Crit.Chance=0.0                            ; floating point value, "
@@ -8114,7 +8127,7 @@ msgstr ""
 "[SOMETECHNO]                               ; TechnoType\n"
 "ImmuneToCrit=false                         ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2257
+#: ../../New-or-Enhanced-Logics.md:2261
 msgid ""
 "If you set `Crit.Warhead` to the same Warhead it is defined on, or create"
 " a chain of Warheads with it that loops back to the first one there is a "
@@ -8122,11 +8135,11 @@ msgid ""
 "afterwards."
 msgstr "如果你将 `Crit.Warhead` 设为定义暴击的弹头或者创建一个最终回到第一个弹头的循环那么游戏可能会陷入循环并随后卡死或崩溃。"
 
-#: ../../New-or-Enhanced-Logics.md:2260
+#: ../../New-or-Enhanced-Logics.md:2264
 msgid "Convert TechnoType on impact"
 msgstr "单位转换弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2262
+#: ../../New-or-Enhanced-Logics.md:2266
 msgid ""
 "![image](_static/images/convertwh.gif) *Vehicle version of Genetic "
 "Converter in "
@@ -8136,13 +8149,13 @@ msgstr ""
 "*[NanodaSupercalifragilisticexpialidocious](https://www.bilibili.com/opus/896077937747427433)"
 " 中的载具版基因突变*"
 
-#: ../../New-or-Enhanced-Logics.md:2271
+#: ../../New-or-Enhanced-Logics.md:2275
 msgid ""
 "In example, this warhead would convert all affected owned and friendly "
 "`SOLDIERA` and `SOLDIERB` to `NEWSOLDIER`:"
 msgstr "例如这个弹头可以将所有被影响的己方和友方 `SOLDIERA` 和 `SOLDIERB` 转换为 `NEWSOLDIER`："
 
-#: ../../New-or-Enhanced-Logics.md:2272
+#: ../../New-or-Enhanced-Logics.md:2276
 msgid ""
 "[ExampleWH]\n"
 "Convert.From=SOLDIERA,SOLDIERB\n"
@@ -8154,7 +8167,7 @@ msgstr ""
 "Convert.To=NEWSOLDIER\n"
 "Convert.AffectedHouses=team\n"
 
-#: ../../New-or-Enhanced-Logics.md:2280
+#: ../../New-or-Enhanced-Logics.md:2284
 msgid ""
 "[SOMEWARHEAD]                   ; WarheadType\n"
 "ConvertN.From=                  ; List of TechnoTypes\n"
@@ -8180,15 +8193,15 @@ msgstr ""
 "Convert.AffectedHouses=all      ; List of Affected House Enumeration "
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2300
+#: ../../New-or-Enhanced-Logics.md:2304
 msgid "Custom Mind Control Animation"
 msgstr "自定义心灵控制动画"
 
-#: ../../New-or-Enhanced-Logics.md:2301
+#: ../../New-or-Enhanced-Logics.md:2305
 msgid "Allows Warheads to play custom `MindControl.Anim`."
 msgstr "允许弹头播放自定义的 `MindControl.Anim`。"
 
-#: ../../New-or-Enhanced-Logics.md:2304
+#: ../../New-or-Enhanced-Logics.md:2308
 msgid ""
 "[SOMEWARHEAD]                         ; WarheadType\n"
 "MindControl.Anim=                     ; Animation, defaults to "
@@ -8198,15 +8211,15 @@ msgstr ""
 "MindControl.Anim=                     ; Animation, defaults to "
 "[CombatDamage] -> ControlledAnimationType\n"
 
-#: ../../New-or-Enhanced-Logics.md:2309
+#: ../../New-or-Enhanced-Logics.md:2313
 msgid "Custom 'SplashList' on Warheads"
 msgstr "自定义弹头水花"
 
-#: ../../New-or-Enhanced-Logics.md:2311
+#: ../../New-or-Enhanced-Logics.md:2315
 msgid "![image](_static/images/splashlist-01.gif)"
 msgstr "![image](_static/images/splashlist-01.gif)"
 
-#: ../../New-or-Enhanced-Logics.md:2312
+#: ../../New-or-Enhanced-Logics.md:2316
 msgid ""
 "Allows Warheads to play custom water splash animations. See vanilla's "
 "[Conventional](https://www.modenc.renegadeprojects.com/Conventional) "
@@ -8217,7 +8230,7 @@ msgstr ""
 "[Conventional](https://www.modenc.renegadeprojects.com/Conventional) "
 "系统。`SplashList.PickRandom` 可设置为 `true` 以从列表中随机选择一个动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2315
+#: ../../New-or-Enhanced-Logics.md:2319
 msgid ""
 "[SOMEWARHEAD]                ; WarheadType\n"
 "SplashList=                  ; List of AnimationTypes, default to "
@@ -8229,17 +8242,17 @@ msgstr ""
 "[CombatDamage] -> SplashList\n"
 "SplashList.PickRandom=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2321
+#: ../../New-or-Enhanced-Logics.md:2325
 msgid "Damage multipliers"
 msgstr "伤害修正比"
 
-#: ../../New-or-Enhanced-Logics.md:2323
+#: ../../New-or-Enhanced-Logics.md:2327
 msgid ""
 "Warheads are now able to define the extra damage multiplier for owner "
 "house, ally houses and enemy houses."
 msgstr "现在弹头可以定义对己方所属、友方所属、敌方所属的额外伤害倍率。"
 
-#: ../../New-or-Enhanced-Logics.md:2324
+#: ../../New-or-Enhanced-Logics.md:2328
 msgid ""
 "`DamageOwnerMultiplier.NotAffectsEnemies` and "
 "`DamageAlliesMultiplier.NotAffectsEnemies` is used as the default value "
@@ -8249,7 +8262,7 @@ msgstr ""
 "`DamageAlliesMultiplier.NotAffectsEnemies` 用于设定弹头 `AffectsEnemies=false` "
 "时的默认值。"
 
-#: ../../New-or-Enhanced-Logics.md:2325
+#: ../../New-or-Enhanced-Logics.md:2329
 msgid ""
 "`DamageOwnerMultiplier.Berzerk` , `DamageAlliesMultiplier.Berzerk` and "
 "`DamageEnemiesMultiplier.Berzerk` is used when the techno is in berzerk."
@@ -8257,7 +8270,7 @@ msgstr ""
 "`DamageOwnerMultiplier.Berzerk`、`DamageAlliesMultiplier.Berzerk` 和 "
 "`DamageEnemiesMultiplier.Berzerk` 在单位处于狂暴状态时被使用。"
 
-#: ../../New-or-Enhanced-Logics.md:2326
+#: ../../New-or-Enhanced-Logics.md:2330
 msgid ""
 "An extra damage multiplier based on the firer or target's health "
 "percentage will be added to the total multiplier. To be elaborate: the "
@@ -8269,13 +8282,13 @@ msgstr ""
 "DamageSourceHealthMultiplier)`，再增加 `(目标剩余血量比 * "
 "DamageTargetHealthMultiplier)`。"
 
-#: ../../New-or-Enhanced-Logics.md:2327
+#: ../../New-or-Enhanced-Logics.md:2331
 msgid ""
 "These multipliers will not affect damage with ignore defenses like "
 "`Suicide`.etc ."
 msgstr "这些修正不会影响无视防御的伤害，例如 `Suicide` 等。"
 
-#: ../../New-or-Enhanced-Logics.md:2330
+#: ../../New-or-Enhanced-Logics.md:2334
 msgid ""
 "[CombatDamage]\n"
 "DamageOwnerMultiplier=1.0                                  ; floating "
@@ -8361,39 +8374,39 @@ msgstr ""
 "DamageTargetHealthMultiplier=0.0                           ; floating "
 "point value\n"
 
-#: ../../New-or-Enhanced-Logics.md:2353
+#: ../../New-or-Enhanced-Logics.md:2357
 msgid ""
 "`DamageAlliesMultiplier` won't affect your own units like `AffectsAllies`"
 " did."
 msgstr "`DamageAlliesMultiplier` 不会像旧有的 `AffectsAllies` 那样作用于友方单位的同时还带上己方单位。"
 
-#: ../../New-or-Enhanced-Logics.md:2356
+#: ../../New-or-Enhanced-Logics.md:2360
 msgid "Damage technos underground"
 msgstr "杀伤地下单位"
 
-#: ../../New-or-Enhanced-Logics.md:2358
+#: ../../New-or-Enhanced-Logics.md:2362
 msgid "Now you can make the warhead damage technos underground!"
 msgstr "现在你可以让弹头对处于地下的单位造成伤害！"
 
-#: ../../New-or-Enhanced-Logics.md:2359
+#: ../../New-or-Enhanced-Logics.md:2363
 msgid ""
 "To allow weapons to target underground technos, you need [AU](#attack-"
 "technos-underground)."
 msgstr "若需允许武器瞄准地下单位，你需要在抛射体上将 [AU](#attack-technos-underground) 设为 `yes`。"
 
-#: ../../New-or-Enhanced-Logics.md:2360
+#: ../../New-or-Enhanced-Logics.md:2364
 msgid ""
 "Notice that if the projectile detonates underground, its animation effect"
 " may look strange."
 msgstr "注意如果弹头在地下引爆其动画效果可能显示异常。"
 
-#: ../../New-or-Enhanced-Logics.md:2361
+#: ../../New-or-Enhanced-Logics.md:2365
 msgid ""
 "You can use `[WarheadType] -> PlayAnimUnderground=false` to prevent the "
 "warhead animation from playing when the projectile detonates underground."
 msgstr "你可以使用 `[WarheadType] -> PlayAnimUnderground=false` 来阻止弹头在地下引爆时播放动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2362
+#: ../../New-or-Enhanced-Logics.md:2366
 msgid ""
 "You can also use `[WarheadType] -> PlayAnimAboveSurface=true` to make the"
 " warhead animation play on the ground directly above when the projectile "
@@ -8402,7 +8415,7 @@ msgstr ""
 "你也可以使用 `[WarheadType] -> PlayAnimAboveSurface=true` "
 "来使弹头在地下引爆时在其正上方地表处播放弹头动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2365
+#: ../../New-or-Enhanced-Logics.md:2369
 msgid ""
 "[SOMEWARHEAD]                         ; WarheadType\n"
 "AffectsUnderground=false              ; boolean\n"
@@ -8414,11 +8427,11 @@ msgstr ""
 "PlayAnimUnderground=true              ; boolean\n"
 "PlayAnimAboveSurface=false            ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2372
+#: ../../New-or-Enhanced-Logics.md:2376
 msgid "Detonate Warhead on all objects on map"
 msgstr "全图弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2374
+#: ../../New-or-Enhanced-Logics.md:2378
 msgid ""
 "Setting `DetonateOnAllMapObjects` to true allows a Warhead that is "
 "detonated by a projectile (for an example, this excludes things like "
@@ -8436,7 +8449,7 @@ msgstr ""
 "`AirburstWeapon/ShrapnelWeapon`，无论其实际目标如何，都可以对当前地图上所有存在且没死的对象进行引爆，并可以对目标进行筛选。注意，这是在弹头引爆之前的瞬间完成的，因此"
 " `PreImpactAnim`（Ares 功能）可以显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2375
+#: ../../New-or-Enhanced-Logics.md:2379
 msgid ""
 "`DetonateOnAllMapObjects.Full` customizes whether or not the Warhead is "
 "detonated fully on the targets (as part of a dummy weapon) or simply "
@@ -8445,7 +8458,7 @@ msgstr ""
 "`DetonateOnAllMapObjects.Full` "
 "自定义弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 Phobos 的弹头效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2376
+#: ../../New-or-Enhanced-Logics.md:2380
 msgid ""
 "`DetonateOnAllMapObjects.AffectTargets` is used to filter which types of "
 "targets (TechnoTypes) are considered valid and must be set to a valid "
@@ -8458,7 +8471,7 @@ msgstr ""
 "时筛选哪些类型的目标（科技类型）可被视为有效。仅 `none`、`all`、`aircraft`、`buildings`、`infantry` 和"
 " `units` 是有效值。默认为 `none`，因为包含所有对象类型可能会影响性能。"
 
-#: ../../New-or-Enhanced-Logics.md:2377
+#: ../../New-or-Enhanced-Logics.md:2381
 msgid ""
 "`DetonateOnAllMapObjects.AffectHouses` is used to filter which houses "
 "targets can belong to be considered valid and must be set to a valid "
@@ -8469,7 +8482,7 @@ msgstr ""
 "`DetonateOnAllMapObjects.AffectHouses` 用于在非 `none` "
 "时筛选哪些所属方的目标可以被视为有效。仅适用于发射弹头的所属方已知的情况。默认为 `none`，因为包含所有所属方可能会影响性能。"
 
-#: ../../New-or-Enhanced-Logics.md:2378
+#: ../../New-or-Enhanced-Logics.md:2382
 msgid ""
 "`DetonateOnAllMapObjects.AffectTypes` can be used to list specific "
 "TechnoTypes to be considered as valid targets. If any valid TechnoTypes "
@@ -8482,13 +8495,13 @@ msgstr ""
 "`DetonateOnAllMapObjects.AffectTargets` 和 "
 "`DetonateOnAllMapObjects.AffectHouses` 的优先级高于此设置。"
 
-#: ../../New-or-Enhanced-Logics.md:2379
+#: ../../New-or-Enhanced-Logics.md:2383
 msgid ""
 "`DetonateOnAllMapObjects.IgnoreTypes` can be used to list specific "
 "TechnoTypes to be never considered as valid targets."
 msgstr "`DetonateOnAllMapObjects.IgnoreTypes` 可用于列出特定的科技类型不得作为目标。"
 
-#: ../../New-or-Enhanced-Logics.md:2380
+#: ../../New-or-Enhanced-Logics.md:2384
 msgid ""
 "`DetonateOnAllMapObjects.RequireVerses`, if set to true, only considers "
 "targets whose armor type the warhead has non-zero `Verses` value against "
@@ -8500,7 +8513,7 @@ msgstr ""
 "`Verses` 值的目标为有效。对于具有激活状态护盾的目标除非弹头拥有 "
 "`Shield.Penetrate=true`，否则使用护盾的护甲类型。在所有上述筛选之后进行检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2383
+#: ../../New-or-Enhanced-Logics.md:2387
 msgid ""
 "[SOMEWARHEAD]                                ; WarheadType\n"
 "DetonateOnAllMapObjects=false                ; boolean\n"
@@ -8524,7 +8537,7 @@ msgstr ""
 "DetonateOnAllMapObjects.IgnoreTypes=         ; List of TechnoTypes\n"
 "DetonateOnAllMapObjects.RequireVerses=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2395
+#: ../../New-or-Enhanced-Logics.md:2399
 msgid ""
 "While this feature can provide better performance than a large "
 "`CellSpread` value, it still has potential to slow down the game, "
@@ -8535,17 +8548,17 @@ msgstr ""
 "虽然此功能比巨大的 `CellSpread` 值性能上好得多但它仍然可能减慢游戏速度。特别是与动画、AlphaImage 等共同使用时。建议 "
 "modder 谨慎使用并通过筛选语句进行限制。"
 
-#: ../../New-or-Enhanced-Logics.md:2398
+#: ../../New-or-Enhanced-Logics.md:2402
 msgid "Fire weapon when Warhead kills something"
 msgstr "击杀武器"
 
-#: ../../New-or-Enhanced-Logics.md:2400
+#: ../../New-or-Enhanced-Logics.md:2404
 msgid ""
 "`KillWeapon` will be fired at the target TechnoType's location once it's "
 "killed by this Warhead."
 msgstr "被此弹头击杀时目标单位会爆出 `KillWeapon` 指定的武器。"
 
-#: ../../New-or-Enhanced-Logics.md:2401
+#: ../../New-or-Enhanced-Logics.md:2405
 msgid ""
 "`KillWeapon.OnFirer` will be fired at the attacker's location once the "
 "target TechnoType is killed by this Warhead. If the source of this "
@@ -8553,7 +8566,7 @@ msgid ""
 "fired."
 msgstr "如果可以追溯到弹头来自哪个单位，那么 `KillWeapon.OnFirer` 可以让武器发射在开火者的位置。如果追溯不到来源那么将不会发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2402
+#: ../../New-or-Enhanced-Logics.md:2406
 msgid ""
 "`KillWeapon.AffectsHouses` / `KillWeapon.OnFirer.AffectsHouses` and "
 "`KillWeapon.Affects` / `KillWeapon.OnFirer.Affects` can be used to filter"
@@ -8564,13 +8577,13 @@ msgstr ""
 "`KillWeapon.OnFirer.AffectsHouses`／`KillWeapon.OnFirer.Affects` "
 "分别用于筛选哪些所属方和哪些类型的目标可以触发 `KillWeapon` 与 `KillWeapon.OnFirer`。"
 
-#: ../../New-or-Enhanced-Logics.md:2403
+#: ../../New-or-Enhanced-Logics.md:2407
 msgid ""
 "If the source of this Warhead is not another TechnoType, `KillWeapon` "
 "will be fired regardless of the target's house or type."
 msgstr "如果这个弹头的来源不是另一个单位，发射 `KillWeapon` 将不受目标所属方或类型的限制。"
 
-#: ../../New-or-Enhanced-Logics.md:2404
+#: ../../New-or-Enhanced-Logics.md:2408
 msgid ""
 "If a TechnoType has `SuppressKillWeapons` set to true, it will not "
 "trigger `KillWeapon` or `KillWeapon.OnFirer` upon being killed. "
@@ -8581,7 +8594,7 @@ msgstr ""
 "`KillWeapon.OnFirer`。`SuppressKillWeapons.Types` "
 "可用于列出受影响的武器类型，如果没有列出，则所有武器类型都受影响。"
 
-#: ../../New-or-Enhanced-Logics.md:2407
+#: ../../New-or-Enhanced-Logics.md:2411
 msgid ""
 "[SOMEWARHEAD]                         ; WarheadType\n"
 "KillWeapon=                           ; WeaponType\n"
@@ -8615,11 +8628,11 @@ msgstr ""
 "SuppressKillWeapons=false             ; boolean\n"
 "SuppressKillWeapons.Types=            ; List of WeaponTypes\n"
 
-#: ../../New-or-Enhanced-Logics.md:2421
+#: ../../New-or-Enhanced-Logics.md:2425
 msgid "Generate credits on impact"
 msgstr "撒币枪（弹）"
 
-#: ../../New-or-Enhanced-Logics.md:2423
+#: ../../New-or-Enhanced-Logics.md:2427
 msgid ""
 "![image](_static/images/hackerfinallyworks-01.gif) *`TransactMoney` used "
 "in [Rise of the East](https://www.moddb.com/mods/riseoftheeast)*"
@@ -8627,18 +8640,18 @@ msgstr ""
 "![image](_static/images/hackerfinallyworks-01.gif) "
 "*[东方崛起](https://www.moddb.com/mods/riseoftheeast) 中的 `TransactMoney` 应用*"
 
-#: ../../New-or-Enhanced-Logics.md:2426
+#: ../../New-or-Enhanced-Logics.md:2430
 msgid "Warheads can now give credits to its owner at impact."
 msgstr "现在弹头可以在爆炸时向其所有者撒币。"
 
-#: ../../New-or-Enhanced-Logics.md:2427
+#: ../../New-or-Enhanced-Logics.md:2431
 msgid ""
 "`TransactMoney.Display` can be set to display the amount of credits given"
 " or deducted. The number is displayed in green if given, red if deducted "
 "and will move upwards after appearing."
 msgstr "`TransactMoney.Display` 可以设置是否显示给予或扣除的资金金额。给予时数字显示为绿色，扣除时显示为红色，并在出现后向上飘起。"
 
-#: ../../New-or-Enhanced-Logics.md:2428
+#: ../../New-or-Enhanced-Logics.md:2432
 msgid ""
 "`TransactMoney.Display.AtFirer` if set, makes the credits display appear "
 "on firer instead of target. If set and firer is not known, it will "
@@ -8647,19 +8660,19 @@ msgstr ""
 "`TransactMoney.Display.AtFirer` "
 "如果设置则使资金出现在开火者处而非目标处。如果设置但开火者未知则无论如何都显示在目标处。"
 
-#: ../../New-or-Enhanced-Logics.md:2429
+#: ../../New-or-Enhanced-Logics.md:2433
 msgid ""
 "`TransactMoney.Display.Houses` determines which houses can see the "
 "credits display."
 msgstr "`TransactMoney.Display.Houses` 决定哪些所属方可以看到资金显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2430
+#: ../../New-or-Enhanced-Logics.md:2434
 msgid ""
 "`TransactMoney.Display.Offset` is additional pixel offset for the center "
 "of the credits display, by default `0,0` at target's/firer's center."
 msgstr "`TransactMoney.Display.Offset` 是资金显示中心的额外像素偏移量，默认为 `0,0` 即目标／开火者的中心。"
 
-#: ../../New-or-Enhanced-Logics.md:2433
+#: ../../New-or-Enhanced-Logics.md:2437
 msgid ""
 "[SOMEWARHEAD]                        ; WarheadType\n"
 "TransactMoney=0                      ; integer - credits added or "
@@ -8679,11 +8692,11 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "TransactMoney.Display.Offset=0,0     ; X,Y, pixels relative to default\n"
 
-#: ../../New-or-Enhanced-Logics.md:2442
+#: ../../New-or-Enhanced-Logics.md:2446
 msgid "Iron Curtain & Force Shield damage penetration"
 msgstr "铁幕与力场护盾的伤害穿透"
 
-#: ../../New-or-Enhanced-Logics.md:2444
+#: ../../New-or-Enhanced-Logics.md:2448
 msgid ""
 "It is now possible to have Warhead be able to deal damage to Iron "
 "Curtained and/or Force Shielded objects. `PenetratesForceShield` defaults"
@@ -8692,7 +8705,7 @@ msgstr ""
 "现在可以让弹头对被铁幕和力场护盾保护的对象造成伤害。`PenetratesForceShield` 默认为 "
 "`PenetratesIronCurtain` 的值。"
 
-#: ../../New-or-Enhanced-Logics.md:2445
+#: ../../New-or-Enhanced-Logics.md:2449
 msgid ""
 "Note that this does not affect any Warhead effects other than those "
 "adjacent to damage (e.g `Psychedelic`) and things like debris generation "
@@ -8702,7 +8715,7 @@ msgstr ""
 "注意这不会影响关联伤害类效果（例如 `Psychedelic`）之外的弹头功能以及类似碎片生成和 `AirburstWeapon` "
 "的引爆这类通常在攻击被抵消时**本就**不发生的效果。"
 
-#: ../../New-or-Enhanced-Logics.md:2448
+#: ../../New-or-Enhanced-Logics.md:2452
 msgid ""
 "[SOMEWARHEAD]                ; WarheadType\n"
 "PenetratesIronCurtain=false  ; boolean\n"
@@ -8712,29 +8725,29 @@ msgstr ""
 "PenetratesIronCurtain=false  ; boolean\n"
 "PenetratesForceShield=       ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2454
+#: ../../New-or-Enhanced-Logics.md:2458
 msgid "Launch superweapons on impact"
 msgstr "发射超武"
 
-#: ../../New-or-Enhanced-Logics.md:2456
+#: ../../New-or-Enhanced-Logics.md:2460
 msgid "Superweapons can now be launched when a warhead is detonated."
 msgstr "现在弹头可以在引爆时发射超级武器"
 
-#: ../../New-or-Enhanced-Logics.md:2457
+#: ../../New-or-Enhanced-Logics.md:2461
 msgid ""
 "`LaunchSW` specifies the superweapons to launch when the warhead is "
 "detonated. If superweapon has negative `Money.Amount`, the firing house "
 "must have enough credits in order for it to be fired."
 msgstr "`LaunchSW` 指定当弹头引爆时要发射的超级武器。如果超级武器的 `Money.Amount` 为负则发射的所属方还需要拥有足够的资金。"
 
-#: ../../New-or-Enhanced-Logics.md:2458
+#: ../../New-or-Enhanced-Logics.md:2462
 msgid ""
 "`LaunchSW.RealLaunch` controls whether the owner who fired the warhead "
 "must own all listed superweapons. Otherwise they will be launched out of "
 "nowhere."
 msgstr "`LaunchSW.RealLaunch` 控制弹头的所有者是否需要拥有所有列出的超级武器。否则它们将无从发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2459
+#: ../../New-or-Enhanced-Logics.md:2463
 msgid ""
 "`LaunchSW.IgnoreInhibitors` ignores `SW.Inhibitors`/`SW.AnyInhibitor` of "
 "each superweapon, otherwise only non-inhibited superweapons are launched."
@@ -8742,7 +8755,7 @@ msgstr ""
 "`LaunchSW.IgnoreInhibitors` 设置是否忽略每个超级武器的 "
 "`SW.Inhibitors`／`SW.AnyInhibitor`，否则只有未被抑制的超级武器会被发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2460
+#: ../../New-or-Enhanced-Logics.md:2464
 msgid ""
 "`LaunchSW.IgnoreDesignators` ignores `SW.Designators` / "
 "`SW.AnyDesignator` respectively."
@@ -8750,7 +8763,7 @@ msgstr ""
 "`LaunchSW.IgnoreDesignators` 设置是否忽略每个超级武器的 "
 "`SW.Designators`／`SW.AnyDesignator`。"
 
-#: ../../New-or-Enhanced-Logics.md:2461
+#: ../../New-or-Enhanced-Logics.md:2465
 msgid ""
 "`LaunchSW.DisplayMoney` can be set to display the amount of credits given"
 " or deducted by the launched superweapon by `Money.Amount`. The number is"
@@ -8760,31 +8773,31 @@ msgstr ""
 "`LaunchSW.DisplayMoney` 可以设置是否显示所发射超武 `Money.Amount` "
 "而给予或扣除的资金金额。给予时数字显示为绿色，扣除时显示为红色，并在出现后向上飘起。"
 
-#: ../../New-or-Enhanced-Logics.md:2462
+#: ../../New-or-Enhanced-Logics.md:2466
 msgid ""
 "`LaunchSW.DisplayMoney.Houses` determines which houses can see the "
 "credits display."
 msgstr "`LaunchSW.DisplayMoney.Houses` 决定哪些所属方可以看到资金显示。"
 
-#: ../../New-or-Enhanced-Logics.md:2463
+#: ../../New-or-Enhanced-Logics.md:2467
 msgid ""
 "`LaunchSW.DisplayMoney.Offset` is additional pixel offset for the center "
 "of the credits display, by default `0,0` at superweapon's target cell."
 msgstr "`LaunchSW.DisplayMoney.Offset` 是资金显示中心的额外像素偏移量，默认为 `0,0` 即超级武器目标单元格处。"
 
-#: ../../New-or-Enhanced-Logics.md:2466
+#: ../../New-or-Enhanced-Logics.md:2470
 msgid ""
 "For animation warheads/weapons to take effect, `Damage.DealtByInvoker` "
 "must be set."
 msgstr "为使动画弹头／武器上的此逻辑生效必须设置 `Damage.DealtByInvoker`。"
 
-#: ../../New-or-Enhanced-Logics.md:2467
+#: ../../New-or-Enhanced-Logics.md:2471
 msgid ""
 "The superweapons are launched on the *cell* where the warhead is "
 "detonated, instead of being click-fired."
 msgstr "超级武器在弹头引爆的 **单元格** 上发射而不是通过点击发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2471
+#: ../../New-or-Enhanced-Logics.md:2475
 msgid ""
 "[SOMEWARHEAD]                     ; WarheadType\n"
 "LaunchSW=                         ; List of SuperWeaponTypes\n"
@@ -8806,17 +8819,17 @@ msgstr ""
 "(none|owner/self|allies/ally|team|enemies/enemy|all)\n"
 "LaunchSW.DisplayMoney.Offset=0,0  ; X,Y, pixels relative to default\n"
 
-#: ../../New-or-Enhanced-Logics.md:2483
+#: ../../New-or-Enhanced-Logics.md:2487
 msgid ""
 "Due to the nature of some superweapon types, not all superweapons are "
 "suitable for launch. **Please use with caution!**"
 msgstr "由于某些超级武器类型的特性并非所有超级武器都适合发射。**请慎用！**"
 
-#: ../../New-or-Enhanced-Logics.md:2486
+#: ../../New-or-Enhanced-Logics.md:2490
 msgid "Parasite removal"
 msgstr "移除寄生"
 
-#: ../../New-or-Enhanced-Logics.md:2488
+#: ../../New-or-Enhanced-Logics.md:2492
 msgid ""
 "By default if unit takes negative damage from a Warhead (before `Verses` "
 "are calculated), any parasites infecting it are removed and deleted. This"
@@ -8826,7 +8839,7 @@ msgstr ""
 "默认情况下如果单位从弹头收到负伤害（在 `Verses` "
 "前计算）任何寄生单位都会被移除和删除。现在可以自定义此行为以禁用负伤害的移除效果或为任意弹头启用它。"
 
-#: ../../New-or-Enhanced-Logics.md:2491
+#: ../../New-or-Enhanced-Logics.md:2495
 msgid ""
 "[SOMEWARHEAD]     ; WarheadType\n"
 "RemoveParasite=   ; boolean\n"
@@ -8834,18 +8847,18 @@ msgstr ""
 "[SOMEWARHEAD]     ; WarheadType\n"
 "RemoveParasite=   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2496
+#: ../../New-or-Enhanced-Logics.md:2500
 msgid "Remove disguise on impact"
 msgstr "移除伪装"
 
-#: ../../New-or-Enhanced-Logics.md:2498
+#: ../../New-or-Enhanced-Logics.md:2502
 msgid ""
 "Warheads can now remove disguise from disguised spies or mirage tanks. "
 "This will work even if the disguised was acquired by default through "
 "`PermaDisguise`."
 msgstr "弹头现在可以移除间谍或幻影坦克的伪装。即使伪装是通过 `PermaDisguise` 默认获得来的。"
 
-#: ../../New-or-Enhanced-Logics.md:2501
+#: ../../New-or-Enhanced-Logics.md:2505
 msgid ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "RemoveDisguise=false  ; boolean\n"
@@ -8853,19 +8866,19 @@ msgstr ""
 "[SOMEWARHEAD]         ; WarheadType\n"
 "RemoveDisguise=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2506
+#: ../../New-or-Enhanced-Logics.md:2510
 msgid "Reveal map for owner on impact"
 msgstr "揭示弹"
 
-#: ../../New-or-Enhanced-Logics.md:2508
+#: ../../New-or-Enhanced-Logics.md:2512
 msgid "Warheads can now reveal an area or the entire map on impact."
 msgstr "现在弹头可以在引爆时揭示部分区域或整个地图的黑幕。"
 
-#: ../../New-or-Enhanced-Logics.md:2509
+#: ../../New-or-Enhanced-Logics.md:2513
 msgid "Reveal only applies to the owner of the warhead."
 msgstr "仅适用于弹头所有者。"
 
-#: ../../New-or-Enhanced-Logics.md:2512
+#: ../../New-or-Enhanced-Logics.md:2516
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "Reveal=0       ; integer - cell radius, negative values mean reveal the "
@@ -8875,17 +8888,17 @@ msgstr ""
 "Reveal=0       ; integer - cell radius, negative values mean reveal the "
 "entire map\n"
 
-#: ../../New-or-Enhanced-Logics.md:2517
+#: ../../New-or-Enhanced-Logics.md:2521
 msgid "Reverse engineer warhead"
 msgstr "逆向工程弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2519
+#: ../../New-or-Enhanced-Logics.md:2523
 msgid ""
 "Warheads can now uses the reverse-engineering logic *(Ares feature)* , "
 "the technology of the victim will be reversed."
 msgstr "现在弹头可以使用逆向工程逻辑（*Ares 功能*），被命中的单位将会被逆向工程。"
 
-#: ../../New-or-Enhanced-Logics.md:2522
+#: ../../New-or-Enhanced-Logics.md:2526
 msgid ""
 "[SOMEWARHEAD]          ; WarheadType\n"
 "ReverseEngineer=false  ; boolean\n"
@@ -8893,33 +8906,33 @@ msgstr ""
 "[SOMEWARHEAD]          ; WarheadType\n"
 "ReverseEngineer=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2528
+#: ../../New-or-Enhanced-Logics.md:2532
 msgid "This feature requires Ares 3.0 or higher to function!"
 msgstr "此功能需要 3.0 及以上版本的 Ares 才能运作！"
 
-#: ../../New-or-Enhanced-Logics.md:2531
+#: ../../New-or-Enhanced-Logics.md:2535
 msgid "Sell or undeploy building on impact"
 msgstr "将建筑出售或反部署"
 
-#: ../../New-or-Enhanced-Logics.md:2533
+#: ../../New-or-Enhanced-Logics.md:2537
 msgid ""
 "Warheads with `BuildingSell` can now sell buildings with build up image. "
 "It has a higher priority than `BuildingUndeploy`."
 msgstr "现在拥有 `BuildingSell` 的弹头可以出售拥有拔起动画的建筑。它的优先级高于 `BuildingUndeploy`。"
 
-#: ../../New-or-Enhanced-Logics.md:2534
+#: ../../New-or-Enhanced-Logics.md:2538
 msgid ""
 "`BuildingSell.IgnoreUnsellable` controls whether to ignore all possible "
 "situations where sales may be disabled except for build up image."
 msgstr "`BuildingSell.IgnoreUnsellable` 控制是否忽略除了缺失拔起动画之外所有可能禁止建筑出售的情况。"
 
-#: ../../New-or-Enhanced-Logics.md:2535
+#: ../../New-or-Enhanced-Logics.md:2539
 msgid ""
 "Warheads with `BuildingUndeploy` can now undeploy buildings with "
 "`UndeploysInto`."
 msgstr "现在拥有 `BuildingUndeploy` 的弹头可以令目标建筑反部署为 `UndeploysInto` 的对象。"
 
-#: ../../New-or-Enhanced-Logics.md:2536
+#: ../../New-or-Enhanced-Logics.md:2540
 msgid ""
 "`BuildingUndeploy.Leave` controls whether need to let them move to low "
 "threat locations nearby. The threat degree here is calculated using the "
@@ -8929,7 +8942,7 @@ msgstr ""
 "`BuildingUndeploy.Leave` "
 "控制是否需要让它们移动到附近较低威胁的位置。这里的威胁程度使用科技类型的价格计算。如果附近的科技类型没有主武器或属于友方所属，那么不被计入。"
 
-#: ../../New-or-Enhanced-Logics.md:2539
+#: ../../New-or-Enhanced-Logics.md:2543
 msgid ""
 "[SOMEWARHEAD]                        ; WarheadType\n"
 "BuildingSell=false                   ; boolean\n"
@@ -8943,19 +8956,19 @@ msgstr ""
 "BuildingUndeploy=false               ; boolean\n"
 "BuildingUndeploy.Leave=false         ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2547
+#: ../../New-or-Enhanced-Logics.md:2551
 msgid "Shroud map for enemies on impact"
 msgstr "黑幕弹"
 
-#: ../../New-or-Enhanced-Logics.md:2549
+#: ../../New-or-Enhanced-Logics.md:2553
 msgid "Warheads can now shroud an area or the entire map on impact."
 msgstr "现在弹头可以在引爆时填充部分区域或整个地图的黑幕"
 
-#: ../../New-or-Enhanced-Logics.md:2550
+#: ../../New-or-Enhanced-Logics.md:2554
 msgid "Shroud only applies to enemies of the warhead owner."
 msgstr "仅适用于敌对所属方。"
 
-#: ../../New-or-Enhanced-Logics.md:2553
+#: ../../New-or-Enhanced-Logics.md:2557
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CreateGap=0    ; integer - cell radius, negative values mean shroud the "
@@ -8965,11 +8978,11 @@ msgstr ""
 "CreateGap=0    ; integer - cell radius, negative values mean shroud the "
 "entire map\n"
 
-#: ../../New-or-Enhanced-Logics.md:2558
+#: ../../New-or-Enhanced-Logics.md:2562
 msgid "Spawn powerup crate"
 msgstr "生成工具箱"
 
-#: ../../New-or-Enhanced-Logics.md:2560
+#: ../../New-or-Enhanced-Logics.md:2564
 msgid ""
 "Warheads can now spawn powerup crates of specified type(s) on their "
 "impact cells (if free, or nearby cells if occupied something other than a"
@@ -8978,13 +8991,13 @@ msgstr ""
 "现在弹头可以在其引爆的单元格上创建指定类型的升级工具箱（如果空置，若被非工具箱的对象占据则生成到附近的单元格）类似于地图触发动作 `108 "
 "创建工具箱...`。"
 
-#: ../../New-or-Enhanced-Logics.md:2561
+#: ../../New-or-Enhanced-Logics.md:2565
 msgid ""
 "`SpawnsCrateN` where N is a number starting from 0, parsed until no key "
 "is found can be used to define the type of crate spawned."
 msgstr "`SpawnsCrateN` 中的 N 是从 0 开始的数字，游戏会解析到最后一个为止。用于定义每个生成的升级工具箱类型。"
 
-#: ../../New-or-Enhanced-Logics.md:2562
+#: ../../New-or-Enhanced-Logics.md:2566
 msgid ""
 "`SpawnsCrateN.Weight` is a number that determines relative weighting of "
 "spawning corresponding crate type vs. other listed ones (0 is no chance, "
@@ -8993,13 +9006,13 @@ msgstr ""
 "`SpawnsCrateN.Weight` 是一个用于确定生成对应升级工具箱类型与其他列出的类型相比的相对权重（0 "
 "表示没门，越高代表概率越高）如果未定义则默认为 1。"
 
-#: ../../New-or-Enhanced-Logics.md:2563
+#: ../../New-or-Enhanced-Logics.md:2567
 msgid ""
 "`SpawnsCrate.Type/Weight` is an alias for `SpawnsCrate0.Type/Weight` if "
 "latter is not set."
 msgstr "如果未设置 `SpawnsCrate0.Type/Weight` 则 `SpawnsCrate.Type/Weight` 是其别名。"
 
-#: ../../New-or-Enhanced-Logics.md:2566
+#: ../../New-or-Enhanced-Logics.md:2570
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "SpawnsCrate(N).Type=     ; Powerup crate type enum "
@@ -9013,18 +9026,18 @@ msgstr ""
 "\n"
 "SpawnsCrate(N).Weight=1  ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:2572
+#: ../../New-or-Enhanced-Logics.md:2576
 msgid "Trigger specific NotHuman infantry Death anim sequence"
 msgstr "指定非人步兵死亡序列"
 
-#: ../../New-or-Enhanced-Logics.md:2574
+#: ../../New-or-Enhanced-Logics.md:2578
 msgid ""
 "Warheads are now able to trigger specific `NotHuman=yes` infantry `Death`"
 " anim sequence using the corresponding tag. It's value represents "
 "sequences from `Die1` to `Die5`."
 msgstr "现在弹头可以使用相应的标签触发特定的 `NotHuman=yes` 步兵 `Death` 动画序列。其值代表从 `Die1` 到 `Die5`。"
 
-#: ../../New-or-Enhanced-Logics.md:2577
+#: ../../New-or-Enhanced-Logics.md:2581
 msgid ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "NotHuman.DeathSequence=  ; integer (1 to 5)\n"
@@ -9032,17 +9045,17 @@ msgstr ""
 "[SOMEWARHEAD]            ; WarheadType\n"
 "NotHuman.DeathSequence=  ; integer (1 to 5)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2582
+#: ../../New-or-Enhanced-Logics.md:2586
 msgid "Warhead that can not kill"
 msgstr "弹头击杀限制"
 
-#: ../../New-or-Enhanced-Logics.md:2584
+#: ../../New-or-Enhanced-Logics.md:2588
 msgid ""
 "Warheads can now damage the enemy without killing them (minimum health "
 "will be 1)."
 msgstr "现在可以让一个弹头可以杀伤敌人但无法击杀它们（至少保留 1 滴血）。"
 
-#: ../../New-or-Enhanced-Logics.md:2587
+#: ../../New-or-Enhanced-Logics.md:2591
 msgid ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CanKill=true   ; boolean\n"
@@ -9050,11 +9063,11 @@ msgstr ""
 "[SOMEWARHEAD]  ; WarheadType\n"
 "CanKill=true   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2592
+#: ../../New-or-Enhanced-Logics.md:2596
 msgid "Unlimbo detonate warhead"
 msgstr "去虚拟化弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2594
+#: ../../New-or-Enhanced-Logics.md:2598
 msgid ""
 "![Unlimbo Detonate](_static/images/unlimbodetonate.gif) *Unlimbo Detonate"
 " used in **The Call of the Panic Spear** by @[Octagonal "
@@ -9063,36 +9076,36 @@ msgstr ""
 "![去虚拟化弹头](_static/images/unlimbodetonate.gif) "
 "*@[八棱彩](https://space.bilibili.com/360577336) 在 **恐慌之矛的召唤** 中使用的去虚拟化弹头*"
 
-#: ../../New-or-Enhanced-Logics.md:2594
+#: ../../New-or-Enhanced-Logics.md:2598
 msgid "Unlimbo Detonate"
 msgstr "去虚拟化弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2597
+#: ../../New-or-Enhanced-Logics.md:2601
 msgid ""
 "`UnlimboDetonate` allows units that have fired weapons with "
 "`LimboLaunch=yes` to reappear."
 msgstr "`UnlimboDetonate` 允许发射了拥有 `LimboLaunch=yes` 的武器的单位在弹头引爆后重新刷出（退出 Limbo 状态）。"
 
-#: ../../New-or-Enhanced-Logics.md:2598
+#: ../../New-or-Enhanced-Logics.md:2602
 msgid ""
 "`UnlimboDetonate.ForceLocation` allows units to forcefully appear at the "
 "projectile explosion location, otherwise they will search for other "
 "available cells."
 msgstr "`UnlimboDetonate.ForceLocation` 允许单位强制出现在抛射体爆炸的位置，否则它们会检索其他可用的单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2599
+#: ../../New-or-Enhanced-Logics.md:2603
 msgid ""
 "`UnlimboDetonate.KeepTarget` allows units to retain their original attack"
 " target when they reappear."
 msgstr "`UnlimboDetonate.KeepTarget` 允许单位进出 Limbo 状态前后保留原先的目标。"
 
-#: ../../New-or-Enhanced-Logics.md:2600
+#: ../../New-or-Enhanced-Logics.md:2604
 msgid ""
 "`UnlimboDetonate.KeepSelected` allows units to retain their original "
 "selected state when they appear."
 msgstr "`UnlimboDetonate.KeepSelected` 允许单位进出 Limbo 状态前保留原先选中状态。"
 
-#: ../../New-or-Enhanced-Logics.md:2603
+#: ../../New-or-Enhanced-Logics.md:2607
 msgid ""
 "[SOMEWARHEAD]                          ; WarheadType\n"
 "UnlimboDetonate=false                  ; boolean\n"
@@ -9106,19 +9119,19 @@ msgstr ""
 "UnlimboDetonate.KeepTarget=false       ; boolean\n"
 "UnlimboDetonate.KeepSelected=false     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2612
+#: ../../New-or-Enhanced-Logics.md:2616
 msgid "`UnlimboDetonate` cannot be used in conjunction with `Parasite`."
 msgstr "`UnlimboDetonate` 不能与 `Parasite` 共用。"
 
-#: ../../New-or-Enhanced-Logics.md:2615
+#: ../../New-or-Enhanced-Logics.md:2619
 msgid "Weapons"
 msgstr "武器"
 
-#: ../../New-or-Enhanced-Logics.md:2617
+#: ../../New-or-Enhanced-Logics.md:2621
 msgid "AreaFire target customization"
 msgstr "自定义 `AreaFire` 目标"
 
-#: ../../New-or-Enhanced-Logics.md:2619
+#: ../../New-or-Enhanced-Logics.md:2623
 msgid ""
 "You can now specify how AreaFire weapon picks its target. By default it "
 "targets the base cell the firer is currently on, but this can now be "
@@ -9129,13 +9142,13 @@ msgstr ""
 "现在你可以指定 AreaFire 武器如何选择目标。默认情况下它会瞄准开火者当前所处的单元格，现在可以通过将 `AreaFire.Target` "
 "设为 `self` 或 `random` 分别改为瞄准发开火者自身或武器 `Range` 范围内的随机单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2620
+#: ../../New-or-Enhanced-Logics.md:2624
 msgid ""
 "`AreaFire.Target=self` respects normal targeting rules (Warhead `Verses` "
 "etc.) against the firer itself."
 msgstr "`AreaFire.Target=self` 遵守对开火者自身的正常目标筛选规则（弹头 `Verses` 等）。"
 
-#: ../../New-or-Enhanced-Logics.md:2621
+#: ../../New-or-Enhanced-Logics.md:2625
 msgid ""
 "`AreaFire.Target=random` ignores cells that are ineligible or contain "
 "ineligible objects based on listed values in weapon's `CanTarget` & "
@@ -9144,7 +9157,7 @@ msgstr ""
 "`AreaFire.Target=random` 会忽略由武器 `CanTarget` 和 `CanTargetHouses` "
 "值设为不可作为目标的单元格或存在不可作为目标的对象的单元格。"
 
-#: ../../New-or-Enhanced-Logics.md:2624
+#: ../../New-or-Enhanced-Logics.md:2628
 msgid ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "AreaFire.Target=base ; AreaFire Target Enumeration (base|self|random)\n"
@@ -9152,11 +9165,11 @@ msgstr ""
 "[SOMEWEAPON]         ; WeaponType\n"
 "AreaFire.Target=base ; AreaFire Target Enumeration (base|self|random)\n"
 
-#: ../../New-or-Enhanced-Logics.md:2629
+#: ../../New-or-Enhanced-Logics.md:2633
 msgid "Burst delay customizations"
 msgstr "自定义 BurstDelay"
 
-#: ../../New-or-Enhanced-Logics.md:2631
+#: ../../New-or-Enhanced-Logics.md:2635
 msgid ""
 "`Burst.Delays` allows specifying weapon-specific burst shot delays. Takes"
 " precedence over the old `BurstDelayX` logic available on VehicleTypes, "
@@ -9169,7 +9182,7 @@ msgstr ""
 "逻辑，且适用于步兵和建筑类型的武器（由于战机类型武器的发射系统完全不同因此暂不支持），并允许独立设置每一发 `Burst` 之间的间隔而不仅限于第"
 " 1 发到第 4 发。"
 
-#: ../../New-or-Enhanced-Logics.md:2632
+#: ../../New-or-Enhanced-Logics.md:2636
 msgid ""
 "If no delay is defined for a shot, it falls back to last delay value "
 "defined (f.ex `Burst=3` and `Burst.Delays=10` would use 10 as delay for "
@@ -9178,14 +9191,14 @@ msgstr ""
 "如果未未某一发设定间隔那么它会使用上一发所定义的间隔（例如 `Burst=3` 和 `Burst.Delays=10` 将使用 10 "
 "作为所有连发的间隔）。"
 
-#: ../../New-or-Enhanced-Logics.md:2633
+#: ../../New-or-Enhanced-Logics.md:2637
 msgid ""
 "Using `-1` as delay reverts back to old logic (`BurstDelay0-3` for "
 "VehicleTypes if available or random value between 3-5 otherwise) for that"
 " shot."
 msgstr "使用 `-1` 作为间隔会使该发使用旧逻辑（如果有则使用载具类型的 `BurstDelay0-3` 否则使用 3-5 之间的随机值）。"
 
-#: ../../New-or-Enhanced-Logics.md:2634
+#: ../../New-or-Enhanced-Logics.md:2638
 msgid ""
 "`Burst.FireWithinSequence` is only used if the weapon is fired by "
 "InfantryType or `Voxel=no` turretless VehicleType, and setting it to true"
@@ -9195,13 +9208,13 @@ msgstr ""
 "`Burst.FireWithinSequence` 仅在步兵或 `Voxel=no` 的无炮塔载具发射武器时使用，将其设为 true "
 "以允许步兵/载具在同一射击序列内射出多发 `Burst`。"
 
-#: ../../New-or-Enhanced-Logics.md:2635
+#: ../../New-or-Enhanced-Logics.md:2639
 msgid ""
 "First shot is always fired at sequence frame determined by firing frame "
 "controls on InfantryType image (`FireUp` et al)."
 msgstr "第一发始终在由步兵类型图像的射击帧（如 `FireUp` 等）确定的帧序列决定。"
 
-#: ../../New-or-Enhanced-Logics.md:2636
+#: ../../New-or-Enhanced-Logics.md:2640
 msgid ""
 "Following shots come at intervals determined by `Burst.Delays` (with "
 "minimum delay of 1 frame) or random delay between 3 to 5 frames if not "
@@ -9212,7 +9225,7 @@ msgstr ""
 "后续的连发发射间隔由 `Burst.Delays` 决定（最小间隔为 1 帧）或未定义情况下使用随机 3 到 5 "
 "帧。注意如果下一发的发射帧超出了射击序列长度则连发计数器将被重置且武器会重新开始装填。"
 
-#: ../../New-or-Enhanced-Logics.md:2637
+#: ../../New-or-Enhanced-Logics.md:2641
 msgid ""
 "Burst shot counter is not immediately reset if firing is ceased mid-"
 "sequence after at least one shot, but the frame at which each burst shot "
@@ -9222,7 +9235,7 @@ msgid ""
 "burst shot should be fired is hit)."
 msgstr "如果在至少一发后停止射击则连发计数器不会立即重置，但每个连发的发射帧不会受此影响（换而言之，如果之后重新开始射击而武器没有重新装填，那么射击序列会重新开始，但不会发射任何直到下一发应该被发射的帧）。"
 
-#: ../../New-or-Enhanced-Logics.md:2640
+#: ../../New-or-Enhanced-Logics.md:2644
 msgid ""
 "[SOMEWEAPON]                    ; WeaponType\n"
 "Burst.Delays=-1                 ; integer - burst delays (comma-"
@@ -9234,11 +9247,11 @@ msgstr ""
 "separated) for shots in order from first to last.\n"
 "Burst.FireWithinSequence=false  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2646
+#: ../../New-or-Enhanced-Logics.md:2650
 msgid "Burst without delay"
 msgstr "无间隔连发"
 
-#: ../../New-or-Enhanced-Logics.md:2648
+#: ../../New-or-Enhanced-Logics.md:2652
 msgid ""
 "In vanilla, vehicles and infantry will only fire once in one frame, even "
 "if their `ROF` or `BurstDelay` is set to 0. Now you can force units to "
@@ -9247,7 +9260,7 @@ msgstr ""
 "原版中即便武器的 `ROF` 或载具的 `BurstDelay` 设为 0 也最快每帧发射一次。现在可以通过将 `Burst.NoDelay` "
 "设为 true 强制单位在一帧内全部发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2651
+#: ../../New-or-Enhanced-Logics.md:2655
 msgid ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "Burst.NoDelay=false   ; boolean\n"
@@ -9255,32 +9268,32 @@ msgstr ""
 "[SOMEWEAPON]          ; WeaponType\n"
 "Burst.NoDelay=false   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2657
+#: ../../New-or-Enhanced-Logics.md:2661
 msgid "This is useless for buildings and aircraft."
 msgstr "此功能对建筑和战机无效。"
 
-#: ../../New-or-Enhanced-Logics.md:2658
+#: ../../New-or-Enhanced-Logics.md:2662
 msgid "This will ignore `Burst.Delays` setting."
 msgstr "这会无视 `Burst.Delays` 设置。"
 
-#: ../../New-or-Enhanced-Logics.md:2661
+#: ../../New-or-Enhanced-Logics.md:2665
 msgid "Delayed firing"
 msgstr "延迟开火"
 
-#: ../../New-or-Enhanced-Logics.md:2663
+#: ../../New-or-Enhanced-Logics.md:2667
 msgid ""
 "It is possible to have any weapon fire with a delay by setting "
 "`DelayedFire.Duration` on a WeaponType - it supports a single integer or "
 "two comma-separated ones for a random range to pick value from."
 msgstr "通过为武器设置 `DelayedFire.Duration` 可使其延迟开火 - 它支持单个整数或用逗号隔开的两个整数作为随机取值区间。"
 
-#: ../../New-or-Enhanced-Logics.md:2664
+#: ../../New-or-Enhanced-Logics.md:2668
 msgid ""
 "If `DelayedFire.SkipInTransport` is set to true and firer is in a "
 "transport, no delay is applied to firing."
 msgstr "若 `DelayedFire.SkipInTransport` 设为 true 且开火者在运输工具中则这种情况下跳过延迟。"
 
-#: ../../New-or-Enhanced-Logics.md:2665
+#: ../../New-or-Enhanced-Logics.md:2669
 msgid ""
 "`DelayedFire.Animation` can be used to define animation to create when "
 "the delay timer starts. `DelayedFire.OpenToppedAnimation` is used instead"
@@ -9289,7 +9302,7 @@ msgstr ""
 "`DelayedFire.Animation` 可用于定义延时计时器启动时创建的动画。可用 "
 "`DelayedFire.OpenToppedAnimation` 单独定义开火者在运输工具中开火时创建的。"
 
-#: ../../New-or-Enhanced-Logics.md:2666
+#: ../../New-or-Enhanced-Logics.md:2670
 msgid ""
 "If `DelayedFire.AnimIsAttached` is set to true, the animation is attached"
 " to the firing TechnoType. If `DelayedFire.RemoveAnimOnNoDelay` is also "
@@ -9300,26 +9313,26 @@ msgstr ""
 "`DelayedFire.RemoveAnimOnNoDelay` 也设为 "
 "true，则在持续时间结束或开火被中断时无论是否播放完毕都立即移除动画。"
 
-#: ../../New-or-Enhanced-Logics.md:2667
+#: ../../New-or-Enhanced-Logics.md:2671
 msgid ""
 "`DelayedFire.AnimOffset` can be used to override the weapon's firing "
 "coordinates / FLH for the animation's position."
 msgstr "`DelayedFire.AnimOffset` 可用于覆盖开火坐标来设置动画的位置。"
 
-#: ../../New-or-Enhanced-Logics.md:2668
+#: ../../New-or-Enhanced-Logics.md:2672
 msgid ""
 "`DelayedFire.AnimOnTurret` determines whether or not the animation's "
 "position is calculated relative to firer's body or turret (only if it has"
 " one)."
 msgstr "`DelayedFire.AnimOnTurret` 决定在单位有炮塔的情况下该动画的位置是相对于开火单位的本体还是炮塔。"
 
-#: ../../New-or-Enhanced-Logics.md:2669
+#: ../../New-or-Enhanced-Logics.md:2673
 msgid ""
 "If `DelayedFire.CenterAnimOnFirer` is set the animation is created at the"
 " firer's center rather than at the firing coordinates."
 msgstr "若设置了 `DelayedFire.CenterAnimOnFirer` 则动画会创建于开火单位的中心而非开火坐标处。"
 
-#: ../../New-or-Enhanced-Logics.md:2670
+#: ../../New-or-Enhanced-Logics.md:2674
 msgid ""
 "If the weapon was fired by InfantryType and "
 "`DelayedFire.PauseFiringSequence` is set to true, the infantry's firing "
@@ -9331,7 +9344,7 @@ msgstr ""
 "`artmd.ini` 中由 `FireUp/Prone` 或 `SecondaryFire/Prone` "
 "定义的开火帧时其开火序列动画将会暂停直至延时计时器结束。"
 
-#: ../../New-or-Enhanced-Logics.md:2671
+#: ../../New-or-Enhanced-Logics.md:2675
 msgid ""
 "If the weapon has `Burst` > 1 and `DelayedFire.OnlyOnInitialBurst` set to"
 " true, the delay occurs only before the initial burst shot. Note that if "
@@ -9343,7 +9356,7 @@ msgstr ""
 "则延迟仅在首次发射前生效。注意若使用了 Ares 则开火被中断或开火者失去目标时 `Burst` "
 "索引不会重置，这意味着它可以无需等待延迟时间即可开火。"
 
-#: ../../New-or-Enhanced-Logics.md:2674
+#: ../../New-or-Enhanced-Logics.md:2678
 msgid ""
 "[SOMEWEAPON]                           ; WeaponType\n"
 "DelayedFire.Duration=                  ; integer - single or comma-sep. "
@@ -9375,18 +9388,18 @@ msgstr ""
 "DelayedFire.PauseFiringSequence=false  ; boolean\n"
 "DelayedFire.OnlyOnInitialBurst=false   ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2690
+#: ../../New-or-Enhanced-Logics.md:2694
 msgid ""
 "AircraftTypes, due to their different attack patterns, will not wait for "
 "the delay to expire before attempting to fire and will instead continue "
 "without firing if the delay is too long."
 msgstr "战机类单位由于其独特的攻击模式并不会等待延迟结束后才尝试开火而是延迟过长时会不开火直接继续飞。"
 
-#: ../../New-or-Enhanced-Logics.md:2693
+#: ../../New-or-Enhanced-Logics.md:2697
 msgid "Extra warhead detonations"
 msgstr "额外弹头"
 
-#: ../../New-or-Enhanced-Logics.md:2695
+#: ../../New-or-Enhanced-Logics.md:2699
 msgid ""
 "It is now possible to have same weapon detonate multiple Warheads on "
 "impact by listing `ExtraWarheads`. The warheads are detonated at same "
@@ -9399,7 +9412,7 @@ msgstr ""
 "来让同一武器在命中时引爆多个弹头。这些弹头会在主弹头爆炸后按列出的顺序在同一位置引爆。这仅适用于由武器发射且引爆时仍保留其信息的抛射体（由于目前存在的技术限制，这不包括"
 " `AirburstWeapon`）。"
 
-#: ../../New-or-Enhanced-Logics.md:2696
+#: ../../New-or-Enhanced-Logics.md:2700
 msgid ""
 "`ExtraWarheads.DamageOverrides` can be used to override the weapon's "
 "`Damage` for the extra Warhead detonations. Value from position matching "
@@ -9409,7 +9422,7 @@ msgstr ""
 "`ExtraWarheads.DamageOverrides` 可用于额外弹头引爆时覆盖武器的 `Damage` 属性。如果找到 "
 "`ExtraWarheads` 中与之对应的值则使用，否则使用最后列出的值。如果列表为空则使用武器的 `Damage` 属性。"
 
-#: ../../New-or-Enhanced-Logics.md:2697
+#: ../../New-or-Enhanced-Logics.md:2701
 msgid ""
 "`ExtraWarheads.DetonationChances` can be used to customize the chance of "
 "each extra Warhead detonation occuring. Value from position matching the "
@@ -9420,7 +9433,7 @@ msgstr ""
 "`ExtraWarheads.DetonationChances` 可用于自定义每个额外弹头爆炸的概率。如果找到 `ExtraWarheads` "
 "中与之对应的值则使用，否则使用最后列出的值。如果列表为空则每个额外弹头都必然引爆。"
 
-#: ../../New-or-Enhanced-Logics.md:2698
+#: ../../New-or-Enhanced-Logics.md:2702
 msgid ""
 "`ExtraWarheads.FullDetonation` can be used to customize whether or not "
 "each individual Warhead is detonated fully (as part of a dummy weapon) or"
@@ -9432,13 +9445,13 @@ msgstr ""
 "可用于设置每个额外弹头是否在目标上完全引爆（作为虚拟武器的一部分）或者只能对所在区域造成杀伤并应用 Phobos 的弹头效果。如果找到 "
 "`ExtraWarheads` 中与之对应的值则使用，否则使用最后列出的值。如果列表为空则默认为 true。"
 
-#: ../../New-or-Enhanced-Logics.md:2699
+#: ../../New-or-Enhanced-Logics.md:2703
 msgid ""
 "Note that the listed Warheads must be listed in `[Warheads]` for them to "
 "work."
 msgstr "注意列出的弹头必须在 `[Warheads]` 中列出才能生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2702
+#: ../../New-or-Enhanced-Logics.md:2706
 msgid ""
 "[SOMEWEAPON]                      ; WeaponType\n"
 "ExtraWarheads=                    ; List of WarheadTypes\n"
@@ -9454,11 +9467,11 @@ msgstr ""
 "(percentage or absolute)\n"
 "ExtraWarheads.FullDetonation=     ; List of booleans\n"
 
-#: ../../New-or-Enhanced-Logics.md:2710
+#: ../../New-or-Enhanced-Logics.md:2714
 msgid "Feedback weapon"
 msgstr "反馈武器"
 
-#: ../../New-or-Enhanced-Logics.md:2712
+#: ../../New-or-Enhanced-Logics.md:2716
 msgid ""
 "![image](_static/images/feedbackweapon.gif) *`FeedbackWeapon` used to "
 "apply healing aura upon firing a weapon in [Project "
@@ -9468,13 +9481,13 @@ msgstr ""
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) "
 "中使用反馈武器在发射武器时对目标施加治疗光环*"
 
-#: ../../New-or-Enhanced-Logics.md:2715
+#: ../../New-or-Enhanced-Logics.md:2719
 msgid ""
 "You can now specify an auxiliary weapon to be fired on the firer itself "
 "when a weapon is fired."
 msgstr "现在你可以指定一个辅助武器在发射武器时对开火者自身发射。"
 
-#: ../../New-or-Enhanced-Logics.md:2716
+#: ../../New-or-Enhanced-Logics.md:2720
 msgid ""
 "`FireInTransport` setting of the feedback weapon is respected to "
 "determine if it can be fired when the original weapon is fired from "
@@ -9485,7 +9498,7 @@ msgstr ""
 "当原始武器于运输工具内的载员使用时反馈武器会根据自身的 `FireInTransport` "
 "决定能否发射。如果反馈武器被发射那么它将命中运输工具。注：`OpenToppedDamageMultiplier` 不适用于反馈武器。"
 
-#: ../../New-or-Enhanced-Logics.md:2719
+#: ../../New-or-Enhanced-Logics.md:2723
 msgid ""
 "[SOMEWEAPON]     ; WeaponType\n"
 "FeedbackWeapon=  ; WeaponType\n"
@@ -9493,17 +9506,17 @@ msgstr ""
 "[SOMEWEAPON]     ; WeaponType\n"
 "FeedbackWeapon=  ; WeaponType\n"
 
-#: ../../New-or-Enhanced-Logics.md:2724
+#: ../../New-or-Enhanced-Logics.md:2728
 msgid "Keep Range After Firing"
 msgstr "开火后保持距离"
 
-#: ../../New-or-Enhanced-Logics.md:2726
+#: ../../New-or-Enhanced-Logics.md:2730
 msgid ""
 "Technos can maintain a suitable distance after firing if `KeepRange` is "
 "not set to 0."
 msgstr "如果 `KeepRange` 没有设为 0 那么科技类型可以在开火后与目标保持适当的距离。"
 
-#: ../../New-or-Enhanced-Logics.md:2727
+#: ../../New-or-Enhanced-Logics.md:2731
 msgid ""
 "`KeepRange` controls how long the distance to maintain when the techno's "
 "ROF timer is ticking. What is actually read is its absolute value. If it "
@@ -9518,31 +9531,31 @@ msgstr ""
 "`MinimumRange`。对于负值则科技类型会尽可能保持在该距离附近，就像它有一个开火后的特殊 "
 "`Range`。此外如果有效射程区间太小单位将被视为无法开火。最好有一个 1.0 长度的有效射程，对步兵而言为 2.0。"
 
-#: ../../New-or-Enhanced-Logics.md:2728
+#: ../../New-or-Enhanced-Logics.md:2732
 msgid ""
 "`KeepRange.AllowAI` controls whether this function is effective for "
 "computer."
 msgstr "`KeepRange.AllowAI` 控制此功能是否对 AI 玩家生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2729
+#: ../../New-or-Enhanced-Logics.md:2733
 msgid ""
 "`KeepRange.AllowPlayer` controls whether this function is effective for "
 "human."
 msgstr "`KeepRange.AllowPlayer` 控制此功能是否对人类玩家生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2730
+#: ../../New-or-Enhanced-Logics.md:2734
 msgid ""
 "The function won't take effect if the techno's rearm time left is shorter"
 " than `KeepRange.EarlyStopFrame`."
 msgstr "如果单位开火剩余 CD 短于 `KeepRange.EarlyStopFrame` 的时间则该功能不会生效。"
 
-#: ../../New-or-Enhanced-Logics.md:2733
+#: ../../New-or-Enhanced-Logics.md:2737
 msgid ""
 "That is to say, the total duration of executing KeepRange equals the "
 "value of weapon `ROF` minus the value of `KeepRange.EarlyStopFrame`."
 msgstr "也就是说执行 KeepRange 效果的总时长 = 武器 `ROF` 的值 - `KeepRange.EarlyStopFrame` 的值。"
 
-#: ../../New-or-Enhanced-Logics.md:2737
+#: ../../New-or-Enhanced-Logics.md:2741
 msgid ""
 "[SOMEWEAPON]                  ; WeaponType\n"
 "KeepRange=0                   ; floating point value\n"
@@ -9556,23 +9569,23 @@ msgstr ""
 "KeepRange.AllowPlayer=false   ; boolean\n"
 "KeepRange.EarlyStopFrame=0    ; integer\n"
 
-#: ../../New-or-Enhanced-Logics.md:2745
+#: ../../New-or-Enhanced-Logics.md:2749
 msgid "Make units try turning to target when firing with `OmniFire=yes`"
 msgstr "`OmniFire=yes` 下转向"
 
-#: ../../New-or-Enhanced-Logics.md:2747
+#: ../../New-or-Enhanced-Logics.md:2751
 msgid ""
 "The unit will try to turn the body to target even firing with "
 "`OmniFire=yes`."
 msgstr "即便使用 `OmniFire=yes` 的武器开火单位也会尝试将车体转向目标。"
 
-#: ../../New-or-Enhanced-Logics.md:2748
+#: ../../New-or-Enhanced-Logics.md:2752
 msgid ""
 "Jumpjets are recommended to have the same value of body `ROT` and "
 "`JumpjetTurnRate`."
 msgstr "建议 Jumpjet 的 `ROT` 和 `JumpjetTurnRate` 相同。"
 
-#: ../../New-or-Enhanced-Logics.md:2751
+#: ../../New-or-Enhanced-Logics.md:2755
 msgid ""
 "[SOMEWEAPON]              ; WeaponType, with OmniFire=yes\n"
 "OmniFire.TurnToTarget=no  ; boolean\n"
@@ -9580,11 +9593,11 @@ msgstr ""
 "[SOMEWEAPON]              ; WeaponType, with OmniFire=yes\n"
 "OmniFire.TurnToTarget=no  ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2756
+#: ../../New-or-Enhanced-Logics.md:2760
 msgid "Radiation enhancements"
 msgstr "辐射增强"
 
-#: ../../New-or-Enhanced-Logics.md:2758
+#: ../../New-or-Enhanced-Logics.md:2762
 msgid ""
 "In addition to allowing custom radiation types, several enhancements are "
 "also available to the default radiation type defined in `[Radiation]`, "
@@ -9594,11 +9607,11 @@ msgstr ""
 "除了允许自定义辐射类型外还有对于默认辐射类型 `[Radiation]` 的增强，例如可以设置所有者与开火者或对建筑造成伤害。详见[自定义辐射类型"
 "](#custom-radiation-types)。"
 
-#: ../../New-or-Enhanced-Logics.md:2760
+#: ../../New-or-Enhanced-Logics.md:2764
 msgid "Strafing aircraft weapon customization"
 msgstr "自定义战机扫射"
 
-#: ../../New-or-Enhanced-Logics.md:2762
+#: ../../New-or-Enhanced-Logics.md:2766
 msgid ""
 "![image](_static/images/strafing-01.gif) *Strafing aircraft weapon "
 "customization in [Project Phantom](https://www.moddb.com/mods/project-"
@@ -9607,11 +9620,11 @@ msgstr ""
 "![image](_static/images/strafing-01.gif) "
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) 中的自定义战机扫射武器*"
 
-#: ../../New-or-Enhanced-Logics.md:2765
+#: ../../New-or-Enhanced-Logics.md:2769
 msgid "Some of the behavior of strafing aircraft weapons can now be customized."
 msgstr "现在可以自定义战机扫射武器的一些行为。"
 
-#: ../../New-or-Enhanced-Logics.md:2766
+#: ../../New-or-Enhanced-Logics.md:2770
 msgid ""
 "`Strafing` controls if the aircraft can strafe when firing at the target."
 " Default to `true` if the projectile's `ROT` < 2 and `Inviso=false` "
@@ -9620,7 +9633,7 @@ msgstr ""
 "`Strafing` 控制战机在目标射击时是否可以扫射。如果抛射体 `ROT` < 2 且 `Inviso=false` 并且没有 "
 "`Trajectory` 则默认为 `true` 其他情况为 `false`。"
 
-#: ../../New-or-Enhanced-Logics.md:2767
+#: ../../New-or-Enhanced-Logics.md:2771
 msgid ""
 "`Strafing.Shots` controls the number of times the weapon is fired during "
 "a single strafe run, defaults to 5 if not set. `Ammo` is only deducted at"
@@ -9629,7 +9642,7 @@ msgstr ""
 "`Strafing.Shots` 控制在单次扫射过程中武器发射的次数，如果未设置则默认为 5。`Ammo` "
 "只会在扫射结束后扣除一次，无论实际多少次。"
 
-#: ../../New-or-Enhanced-Logics.md:2768
+#: ../../New-or-Enhanced-Logics.md:2772
 msgid ""
 "`Strafing.SimulateBurst` controls whether or not the shots fired during "
 "strafing simulate behavior of `Burst`, allowing for alternating firing "
@@ -9638,14 +9651,14 @@ msgstr ""
 "`Strafing.SimulateBurst` 控制在扫射过程中发射的武器是否模拟 `Burst` 的行为，即允许交替开火坐标。仅当武器 "
 "`Burst` 设置为 1 或未定义时才有效。"
 
-#: ../../New-or-Enhanced-Logics.md:2769
+#: ../../New-or-Enhanced-Logics.md:2773
 msgid ""
 "`Strafing.UseAmmoPerShot`, if set to `true` overrides the usual behaviour"
 " of only deducting ammo after a strafing run and instead doing it after "
 "each individual shot."
 msgstr "`Strafing.UseAmmoPerShot` 如果设为 `true` 将在每次开火后都扣除弹药而不是通常的仅在扫射结束后才扣除弹药。"
 
-#: ../../New-or-Enhanced-Logics.md:2770
+#: ../../New-or-Enhanced-Logics.md:2774
 msgid ""
 "`Strafing.TargetCell` controls whether the aircraft will change the "
 "target of this round to the ground after firing the first shot, to ensure"
@@ -9655,7 +9668,7 @@ msgstr ""
 "`Strafing.TargetCell` 控制战机是否会在第一发后将目标切换为地板以确保与 `Strafing.Shots` "
 "设定的次数一致。也就是扫射不再会由于目标被摧毁而中断。"
 
-#: ../../New-or-Enhanced-Logics.md:2771
+#: ../../New-or-Enhanced-Logics.md:2775
 msgid ""
 "`Strafing.EndDelay` can be used to override the delay after firing last "
 "shot in strafing run before aircraft resumes another strafing run or "
@@ -9670,7 +9683,7 @@ msgstr ""
 "Speed`。注意对于弹药量足够进行多次扫射的战机而言过短的间隔可能导致并不理想的行为例如四处游走或朝向怪异的方向，具体取决于 "
 "`[WeaponType] -> ROF` 和 `[AircraftType] -> Speed` 等其他因素。"
 
-#: ../../New-or-Enhanced-Logics.md:2772
+#: ../../New-or-Enhanced-Logics.md:2776
 msgid ""
 "There is a special case for aircraft spawned by `Type=SpyPlane` "
 "superweapons on `SpyPlane Approach` or `SpyPlane Overfly` mission where "
@@ -9681,7 +9694,7 @@ msgstr ""
 "对于 `Type=SpyPlane` 超级武器生成的战机在 `SpyPlane Approach` 或 `SpyPlane Overfly` "
 "任务中的情况 `Strafing.Shots` 只有在其主武器上手动设置才会生效并决定地图揭示效果的最大次数而无视其他因素。"
 
-#: ../../New-or-Enhanced-Logics.md:2775
+#: ../../New-or-Enhanced-Logics.md:2779
 msgid ""
 "[SOMEWEAPON]                   ; WeaponType\n"
 "Strafing=                      ; boolean\n"
@@ -9699,11 +9712,11 @@ msgstr ""
 "Strafing.TargetCell=false      ; boolean\n"
 "Strafing.EndDelay=             ; integer, game frames\n"
 
-#: ../../New-or-Enhanced-Logics.md:2785
+#: ../../New-or-Enhanced-Logics.md:2789
 msgid "Visual effect scatter"
 msgstr "视觉效果散布"
 
-#: ../../New-or-Enhanced-Logics.md:2787
+#: ../../New-or-Enhanced-Logics.md:2791
 msgid ""
 "You can now add a random offset to visual effect's (`IsLaser=true`, "
 "`IsElectricBolt=true` or `IsRadBeam=true`) target location if set "
@@ -9712,7 +9725,7 @@ msgstr ""
 "现在你可以在 `VisualScatter` 设为 true "
 "时为视觉效果（`IsLaser=true`、`IsElectricBolt=true` 或 `IsRadBeam=true`）添加一个随机偏移。"
 
-#: ../../New-or-Enhanced-Logics.md:2790
+#: ../../New-or-Enhanced-Logics.md:2794
 msgid ""
 "[AudioVisual]\n"
 "VisualScatter.Min=0.03  ; floating point value, distance in cells\n"
@@ -9728,7 +9741,7 @@ msgstr ""
 "[SOMEWEAPON]            ; WeaponType\n"
 "VisualScatter=false     ; boolean\n"
 
-#: ../../New-or-Enhanced-Logics.md:2800
+#: ../../New-or-Enhanced-Logics.md:2804
 msgid ""
 "This function is only used as an additional scattering visual display, "
 "which is different from `BallisticScatter.(Min/Max)` and can be used "
@@ -9738,11 +9751,11 @@ msgstr ""
 "此功能仅叠加到**视觉效果**原本的散布上，也就是说它独立于 `BallisticScatter.(Min/Max)` "
 "且可共同使用，不会影响抛射体实际爆点的散布。"
 
-#: ../../New-or-Enhanced-Logics.md:2803
+#: ../../New-or-Enhanced-Logics.md:2807
 msgid "Weapon targeting filter"
 msgstr "武器瞄准筛选"
 
-#: ../../New-or-Enhanced-Logics.md:2805
+#: ../../New-or-Enhanced-Logics.md:2809
 msgid ""
 "![image](_static/images/weaponfilter.gif) *`Weapon target filter - "
 "different weapon used against enemies & allies as well as units & "
@@ -9753,14 +9766,14 @@ msgstr ""
 "*[幽灵计划](https://www.moddb.com/mods/project-phantom) 中的武器瞄准筛选 - "
 "就像分别对单位和建筑使用那样对敌军和友军使用不同武器*"
 
-#: ../../New-or-Enhanced-Logics.md:2808
+#: ../../New-or-Enhanced-Logics.md:2812
 msgid ""
 "You can now specify which targets or houses a weapon can fire at. This "
 "also affects weapon selection, other than certain special cases where the"
 " selection is fixed."
 msgstr "现在你可以指定武器可以开火的目标或所属方。这还会影响武器选择，除了某些特殊情况下的固定选择。"
 
-#: ../../New-or-Enhanced-Logics.md:2809
+#: ../../New-or-Enhanced-Logics.md:2813
 msgid ""
 "`CanTarget.MaxHealth` and `CanTarget.MinHealth` set health percentage "
 "thresholds for allowed targets (TechnoTypes only) that the target's "
@@ -9770,7 +9783,7 @@ msgstr ""
 "`CanTarget.MaxHealth` 和 `CanTarget.MinHealth` "
 "用于设置可被攻击的（仅单位）目标所需的血量阈值，分别要求目标血量必须高于和／或低于／等于的限制。若目标血量为 0 则跳过检查。"
 
-#: ../../New-or-Enhanced-Logics.md:2812
+#: ../../New-or-Enhanced-Logics.md:2816
 msgid ""
 "[SOMEWEAPON]             ; WeaponType\n"
 "CanTarget=all            ; List of Affected Target Enumeration "
@@ -9788,7 +9801,7 @@ msgstr ""
 "CanTarget.MaxHealth=1.0  ; floating point value, percents or absolute\n"
 "CanTarget.MinHealth=0.0  ; floating point value, percents or absolute\n"
 
-#: ../../New-or-Enhanced-Logics.md:2821
+#: ../../New-or-Enhanced-Logics.md:2825
 msgid ""
 "`CanTarget` explicitly requires either `all` or `empty` to be listed for "
 "the weapon to be able to fire at cells containing no TechnoTypes."


### PR DESCRIPTION
原先一堆仅全局定义的语句被分散在不同的大类下面，以至于非常难找
还有一些修复后来被默认禁用，需要手动开启，但依然在修复列表里
于是我决定把这些内容重新排列，创建了一个新增的全局功能类别